### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -7,6 +7,9 @@ on:
     # Review gh actions docs if you want to further define triggers, paths, etc
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
 
+permissions:
+  contents: read
+
 defaults:
   run:
     working-directory: docs


### PR DESCRIPTION
Potential fix for [https://github.com/OpenUp-LabTakizawa/robopo/security/code-scanning/2](https://github.com/OpenUp-LabTakizawa/robopo/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly set the permissions to `contents: read`, which is sufficient for the workflow's tasks, such as checking out the code and installing dependencies. This change ensures that the workflow does not have unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Sourcery によるサマリー

CI:
- `test-deploy.yml` 内の不要な書き込みアクセス権を削除するために、ルートレベルの permissions ブロックに `contents: read` を追加しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Add a root-level permissions block with contents: read in test-deploy.yml to remove unnecessary write access

</details>