### PR TITLE
chore: change `next.config.mjs` to `next.config.ts`

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {
-  webpack(config, options) {
+import type { NextConfig } from "next"
+
+const nextConfig: NextConfig = {
+  webpack(config) {
     config.module.rules.push({
       test: /\.(mp3)$/,
       type: "asset/resource",


### PR DESCRIPTION
## Sourceryによるサマリー

Next.jsの設定ファイルをJavaScript (next.config.mjs)からTypeScript (next.config.ts)に変換し、NextConfigの型を適切に設定します。

雑務:
- next.config.mjsをnext.config.tsにリネームし、Next.jsからNextConfig型をインポート
- NextConfigオブジェクトにTypeScriptの注釈を追加し、webpack設定の署名を調整

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Convert Next.js configuration file from JavaScript (next.config.mjs) to TypeScript (next.config.ts) with proper typing for NextConfig.

Chores:
- Rename next.config.mjs to next.config.ts and import NextConfig type from Next.js
- Add TypeScript annotation for the NextConfig object and adjust webpack config signature

</details>