### PR TITLE
fix: session always true at production version

### DIFF
--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -39,7 +39,7 @@ export const Header = async () => {
       </h1>
       {/* サインインorサインアウトボタン & HOMEボタン (PC表示) */}
       <div className="hidden lg:inline-block ml-auto">
-        {session ? <SignOut /> : <Link href="/signIn" className="btn btn-primary p-2 text-xl">Sign in</Link>}
+        {session?.user ? <SignOut /> : <Link href="/signIn" className="btn btn-primary p-2 text-xl">Sign in</Link>}
         <Link href="/" className="btn btn-primary p-2 text-xl ml-5">
           Home
         </Link>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,7 +14,7 @@ export default async function Home() {
   const competitionCourseList: { competitionCourseList: SelectCompetitionCourse[] } = await getCompetitionCourseAssignList()
 
   return (
-    session ?
+    session?.user ?
       <ThreeTabs
         tab1Title="採点"
         tab1={<ChallengeTab key="challenge" competitionList={competitionList} courseList={courseList} competitionCourseList={competitionCourseList} />}

--- a/auth.ts
+++ b/auth.ts
@@ -55,8 +55,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
             return session
         },
         authorized: async ({ auth }) => {
-            // Logged in users are authenticated, otherwise redirect to login page
-            return !!auth
+            return !!auth?.user
         },
     },
     session: {

--- a/auth.ts
+++ b/auth.ts
@@ -65,6 +65,4 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     pages: {
         signIn: "/signIn",
     },
-    trustHost: process.env.NETLIFY === "true" //netlifyで動かす場合
-    || process.env.TRUST_HOST === "true", // localhostその他で動かす場合
 })


### PR DESCRIPTION
## Sourceryによるサマリー

セッションの真偽値チェックを修正し、認証済みユーザーを正しく検出するようにしました。

バグ修正:
- 認証ロジックを修正し、`auth`の代わりに`auth.user`をチェックするようにしました。
- `Header`コンポーネントを更新し、`session.user`が存在する場合のみ`SignOut`をレンダリングするようにしました。
- `Home`ページの条件を調整し、認証済みビューをレンダリングする前に`session.user`を検証するようにしました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix session truthiness checks to properly detect authenticated users

Bug Fixes:
- Change authorization logic to check for auth.user instead of auth
- Update Header component to render SignOut only when session.user is present
- Adjust Home page conditional to verify session.user before rendering authenticated views

</details>