### PR TITLE
docs: replace the all kazutan1230 with openuplab-takizawa

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 kazutan1230
+Copyright (c) 2025 OpenUp-LabTakizawa
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/docs/01-intro.md
+++ b/docs/docs/01-intro.md
@@ -44,7 +44,7 @@ OpenUp ラボ滝沢構成員
 
 (Organization の Github にする予定)
 
-[https://github.com/kazutan1230/robopo](https://github.com/kazutan1230/robopo)
+[https://github.com/openup-labtakizawa/robopo](https://github.com/openup-labtakizawa/robopo)
 
 ご参考願う。
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -9,14 +9,14 @@ const config: Config = {
   favicon: "img/favicon.ico",
 
   // Set the production url of your site here
-  url: "https://kazutan1230.github.io",
+  url: "https://openup-labtakizawa.github.io",
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: "/robopo/",
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
-  organizationName: "kazutan1230", // Usually your GitHub org/user name.
+  organizationName: "openup-labtakizawa", // Usually your GitHub org/user name.
   projectName: "robopo", // Usually your repo name.
 
   onBrokenLinks: "throw",
@@ -53,7 +53,7 @@ const config: Config = {
           sidebarPath: "./sidebars.ts",
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
-          editUrl: "https://github.com/kazutan1230/robopo/tree/docusaurus",
+          editUrl: "https://github.com/openup-labtakizawa/robopo/tree/docusaurus",
         },
         theme: {
           customCss: "./src/css/custom.css",
@@ -80,7 +80,7 @@ const config: Config = {
           label: "目次",
         },
         {
-          href: "https://github.com/kazutan1230/robopo/tree/docusaurus",
+          href: "https://github.com/openup-labtakizawa/robopo/tree/docusaurus",
           label: "GitHub",
           position: "right",
         },
@@ -103,7 +103,7 @@ const config: Config = {
           items: [
             {
               label: "GitHub",
-              href: "https://github.com/kazutan1230/robopo/tree/docusaurus",
+              href: "https://github.com/openup-labtakizawa/robopo/tree/docusaurus",
             },
           ],
         },

--- a/docs/i18n/ja/docusaurus-theme-classic/footer.json
+++ b/docs/i18n/ja/docusaurus-theme-classic/footer.json
@@ -13,7 +13,7 @@
   },
   "link.item.label.GitHub": {
     "message": "GitHub",
-    "description": "The label of footer link with label=GitHub linking to https://github.com/kazutan1230/robopo/tree/docusaurus"
+    "description": "The label of footer link with label=GitHub linking to https://github.com/openup-labtakizawa/robopo/tree/docusaurus"
   },
   "copyright": {
     "message": "Copyright © 2025 OpenUp Lab. Takizawa. Built with Docusaurus.",

--- a/docs/src/components/variables.tsx
+++ b/docs/src/components/variables.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import Link from "@docusaurus/Link"
 
 // ROBOPO のあるGithubリポジトリのURL
-const robopoGithubUrl = "https://github.com/kazutan1230/robopo/"
+const robopoGithubUrl = "https://github.com/openup-labtakizawa/robopo/"
 
 interface GithubLinkProps {
   filePath: string

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -35,7 +35,7 @@ function HomepageHeader() {
         <div className={styles.buttons}>
           <Link
             className="button button--secondary button--lg"
-            to="https://github.com/kazutan1230/robopo/tree/docusaurus">
+            to="https://github.com/openup-labtakizawa/robopo/tree/docusaurus">
             <img role="img" src="img/github-mark.png" alt="ROBOPO Githubへ" width="20" height="20" />
             ROBOPO Githubへ
           </Link>


### PR DESCRIPTION
## Sourcery によるサマリー

ドキュメンテーション:
- Docusaurus の設定、ドキュメント、およびコンポーネントのリンクにおいて、"kazutan1230" のすべての出現箇所を "openup-labtakizawa" に置換しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Replace all occurrences of “kazutan1230” with “openup-labtakizawa” in Docusaurus config, docs, and component links

</details>