### PR TITLE
chore: update deploy workflows for merge main branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,12 +1,14 @@
 name: Deploy to GitHub Pages
+
 permissions:
   contents: read # to download the repository
   pull-requests: write # to comment on the pull request
 
 on:
   push:
-    branches:
-      - docusaurus
+    branches: main
+    paths:
+      - "docs/**"
     # Review gh actions docs if you want to further define triggers, paths, etc
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
 

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -1,12 +1,14 @@
 name: Test deployment
+
 permissions:
   contents: read # to download the repository
   pull-requests: write # to comment on the pull request
 
 on:
   pull_request:
-    branches:
-      - docusaurus
+    branches: main
+    paths:
+      - "docs/**"
     # Review gh actions docs if you want to further define triggers, paths, etc
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
 


### PR DESCRIPTION
## Sourceryによるサマリー

GitHub Actionsのデプロイワークフローを更新し、mainブランチで実行され、ドキュメントファイルが変更された場合にのみ実行されるようにします。

CI:
- デプロイおよびテストデプロイワークフローの両方で、ブランチフィルターを「docusaurus」から「main」に変更
- `docs/**` のパスフィルターを追加し、ドキュメントの変更時にのみデプロイがトリガーされるようにします。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update GitHub Actions deployment workflows to run on the main branch and only when documentation files change

CI:
- Change branch filter from ‘docusaurus’ to ‘main’ in both deploy and test-deploy workflows
- Add a path filter for docs/** to only trigger deployments on documentation changes

</details>