### PR TITLE
chore: move permission on deploy.yml

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-.vercelignore merge=ours

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,5 @@
 name: Deploy to GitHub Pages
 
-permissions:
-  contents: read # to download the repository
-  pull-requests: write # to comment on the pull request
-
 on:
   push:
     branches: main
@@ -20,6 +16,10 @@ jobs:
   build:
     name: Build Docusaurus
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # to download the repository
+      pull-requests: write # to comment on the pull request
+
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Sourcery によるサマリー

デプロイワークフローの権限をビルドジョブの範囲に限定し、不要になった .gitattributes ファイルを削除します。

CI:
- deploy.yml の権限ブロックをワークフローのルートからビルドジョブレベルに移動

雑務:
- 不要になった .gitattributes ファイルを削除

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Scope deploy workflow permissions under the build job and remove the obsolete .gitattributes file

CI:
- Move permissions block in deploy.yml from the workflow root to the build job level

Chores:
- Delete the now-unnecessary .gitattributes file

</details>