### PR TITLE
fix: exclude docs for `npm run build`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,5 @@
     "target": "ES2022"
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["docs", "node_modules"]
 }


### PR DESCRIPTION
## Sourceryによるサマリー

バグ修正:
- `tsconfig.json` の `exclude` 配列に `docs` を追加し、ドキュメントフォルダをビルドプロセスから除外しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Add `docs` to the `exclude` array in `tsconfig.json` to omit the documentation folder from the build process.

</details>