### PR TITLE
docs: fix typo on TypeScript and GitHub

### DIFF
--- a/docs/docs/01-intro.md
+++ b/docs/docs/01-intro.md
@@ -30,7 +30,7 @@ OpenUp ラボ滝沢構成員
 
   Web 開発についての知識。
 
-  あるとよい技術的知識 →Github, Node.js, Typescript, AWS
+  あるとよい技術的知識 →GitHub, Node.js, TypeScript, AWS
 
 ## アプリケーション本体・ソースコードについて
 
@@ -40,9 +40,9 @@ OpenUp ラボ滝沢構成員
 
 [https://robopo.vercel.app/](https://robopo.vercel.app/)
 
-また、code 自体も以下 Github から取得することが可能である。
+また、code 自体も以下 GitHub から取得することが可能である。
 
-(Organization の Github にする予定)
+(Organization の GitHub にする予定)
 
 [https://github.com/openup-labtakizawa/robopo](https://github.com/openup-labtakizawa/robopo)
 

--- a/docs/docs/02_overview/02-system-structure.mdx
+++ b/docs/docs/02_overview/02-system-structure.mdx
@@ -12,7 +12,7 @@ import systemStructure from "!!raw-loader!/static/drawioData/systemStructure.dra
   <figcaption className="text--center">システム構成</figcaption>
 </figure>
 
-2024 年 11 月こどもテックキャラバン時には上記のように Github 上にコードを上げて、Vercel でのホスティング。Neon というサービスの DB を利用した。
+2024 年 11 月こどもテックキャラバン時には上記のように GitHub 上にコードを上げて、Vercel でのホスティング。Neon というサービスの DB を利用した。
 この形にこだわる必要はないと考えている。AWS に移行できるはず。[^1]
 
 [^1]: この形になったのは費用面で無料だったからである。Vercel の DB ではないのはアカウントに 1 つしか作れなくて他の開発で使っていたため。

--- a/docs/src/components/variables.tsx
+++ b/docs/src/components/variables.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import Link from "@docusaurus/Link"
 
-// ROBOPO のあるGithubリポジトリのURL
+// ROBOPO のあるGitHubリポジトリのURL
 const robopoGithubUrl = "https://github.com/openup-labtakizawa/robopo/"
 
 interface GithubLinkProps {

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -36,8 +36,8 @@ function HomepageHeader() {
           <Link
             className="button button--secondary button--lg"
             to="https://github.com/openup-labtakizawa/robopo/tree/docusaurus">
-            <img role="img" src="img/github-mark.png" alt="ROBOPO Githubへ" width="20" height="20" />
-            ROBOPO Githubへ
+            <img role="img" src="img/github-mark.png" alt="ROBOPO GitHubへ" width="20" height="20" />
+            ROBOPO GitHubへ
           </Link>
         </div>
       </div>


### PR DESCRIPTION
## Sourceryによるサマリー

ドキュメント内のタイプミスを修正しました。複数のファイルにわたって、'GitHub'と'TypeScript'の大文字表記を標準化しました。

ドキュメント：
- リンク、コメント、およびテキスト内の'GitHub'の大文字表記を修正
- テックスタックリスト内の'TypeScript'の大文字表記を修正

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix typos in documentation by standardizing the capitalization of ‘GitHub’ and ‘TypeScript’ across multiple files

Documentation:
- Correct capitalization of ‘GitHub’ in links, comments, and text
- Correct capitalization of ‘TypeScript’ in the tech stack list

</details>