### PR TITLE
feat: add navigation guard and enable state management for challenge …

### DIFF
--- a/app/challenge/[competitionId]/[courseId]/[playerId]/view.tsx
+++ b/app/challenge/[competitionId]/[courseId]/[playerId]/view.tsx
@@ -1,9 +1,11 @@
 "use client"
+
+import { useState } from "react"
+import { useNavigationGuard } from "next-navigation-guard"
 import { type SelectCourse, type SelectPlayer } from "@/app/lib/db/schema"
 import Challenge from "@/app/challenge/challenge"
 import { RESERVED_COURSE_IDS } from "@/app/components/course/utils"
 import { SensorCourse } from "@/app/components/challenge/sensorCourse"
-import { useNavigationGuard } from "next-navigation-guard"
 
 type ViewProps = {
   courseData: SelectCourse
@@ -15,8 +17,9 @@ type ViewProps = {
 export const View = ({ courseData, playerData, competitionId, courseId }: ViewProps) => {
   const playerId = playerData.id
   const umpireId = 1 // 一旦1
+  const [isEnabled, setIsenabled] = useState(true)
   const navGuard = useNavigationGuard({
-    enabled: true,
+    enabled: isEnabled,
     confirm: () => window.confirm("このページを離れると編集中のデータは失われます。よろしいですか？"),
   })
 
@@ -32,12 +35,19 @@ export const View = ({ courseData, playerData, competitionId, courseId }: ViewPr
           courseId={courseId}
           playerId={playerId}
           umpireId={umpireId}
+          setIsenabled={setIsenabled}
         />
       )}
 
       {/* センサーコース */}
       {Number(courseId) === RESERVED_COURSE_IDS.SENSOR && playerId !== null && (
-        <SensorCourse compeId={competitionId} courseId={courseId} playerId={playerId} umpireId={umpireId} />
+        <SensorCourse
+          compeId={competitionId}
+          courseId={courseId}
+          playerId={playerId}
+          umpireId={umpireId}
+          setIsenabled={setIsenabled}
+        />
       )}
     </div>
   )

--- a/app/challenge/[competitionId]/[courseId]/[playerId]/view.tsx
+++ b/app/challenge/[competitionId]/[courseId]/[playerId]/view.tsx
@@ -17,7 +17,7 @@ type ViewProps = {
 export const View = ({ courseData, playerData, competitionId, courseId }: ViewProps) => {
   const playerId = playerData.id
   const umpireId = 1 // 一旦1
-  const [isEnabled, setIsenabled] = useState(true)
+  const [isEnabled, setIsEnabled] = useState(true)
   const navGuard = useNavigationGuard({
     enabled: isEnabled,
     confirm: () => window.confirm("このページを離れると編集中のデータは失われます。よろしいですか？"),
@@ -35,7 +35,7 @@ export const View = ({ courseData, playerData, competitionId, courseId }: ViewPr
           courseId={courseId}
           playerId={playerId}
           umpireId={umpireId}
-          setIsenabled={setIsenabled}
+          setIsEnabled={setIsEnabled}
         />
       )}
 
@@ -46,7 +46,7 @@ export const View = ({ courseData, playerData, competitionId, courseId }: ViewPr
           courseId={courseId}
           playerId={playerId}
           umpireId={umpireId}
-          setIsenabled={setIsenabled}
+          setIsEnabled={setIsEnabled}
         />
       )}
     </div>

--- a/app/challenge/challenge.tsx
+++ b/app/challenge/challenge.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react"
+import { useRouter } from "next/navigation"
 import {
   MissionString,
   PointState,
@@ -29,9 +30,11 @@ type ChallengeProps = {
   courseId: number
   playerId: number
   umpireId: number
+  setIsenabled: React.Dispatch<React.SetStateAction<boolean>>
 }
 
-const Challenge = ({ field, mission, point, compeId, courseId, playerId, umpireId }: ChallengeProps) => {
+const Challenge = ({ field, mission, point, compeId, courseId, playerId, umpireId, setIsenabled }: ChallengeProps) => {
+  const router = useRouter()
   if (
     field !== null &&
     field !== undefined &&
@@ -317,7 +320,9 @@ const Challenge = ({ field, mission, point, compeId, courseId, playerId, umpireI
               umpireId,
               setMessage,
               setIsSuccess,
-              setLoading
+              setLoading,
+              router,
+              setIsenabled
             )
           }
           handleRetry={handleRetry}
@@ -348,7 +353,9 @@ const Challenge = ({ field, mission, point, compeId, courseId, playerId, umpireI
               umpireId,
               setMessage,
               setIsSuccess,
-              setLoading
+              setLoading,
+              router,
+              setIsenabled
             )
           }
           handleRetry={handleRetry}

--- a/app/challenge/challenge.tsx
+++ b/app/challenge/challenge.tsx
@@ -30,10 +30,10 @@ type ChallengeProps = {
   courseId: number
   playerId: number
   umpireId: number
-  setIsenabled: React.Dispatch<React.SetStateAction<boolean>>
+  setIsEnabled: React.Dispatch<React.SetStateAction<boolean>>
 }
 
-const Challenge = ({ field, mission, point, compeId, courseId, playerId, umpireId, setIsenabled }: ChallengeProps) => {
+const Challenge = ({ field, mission, point, compeId, courseId, playerId, umpireId, setIsEnabled }: ChallengeProps) => {
   const router = useRouter()
   if (
     field !== null &&
@@ -322,7 +322,7 @@ const Challenge = ({ field, mission, point, compeId, courseId, playerId, umpireI
               setIsSuccess,
               setLoading,
               router,
-              setIsenabled
+              setIsEnabled
             )
           }
           handleRetry={handleRetry}
@@ -355,7 +355,7 @@ const Challenge = ({ field, mission, point, compeId, courseId, playerId, umpireI
               setIsSuccess,
               setLoading,
               router,
-              setIsenabled
+              setIsEnabled
             )
           }
           handleRetry={handleRetry}

--- a/app/components/challenge/sensorCourse.tsx
+++ b/app/components/challenge/sensorCourse.tsx
@@ -8,10 +8,10 @@ type SensorCourseProps = {
   courseId: number
   playerId: number
   umpireId: number
-  setIsenabled: React.Dispatch<React.SetStateAction<boolean>>
+  setIsEnabled: React.Dispatch<React.SetStateAction<boolean>>
 }
 
-export const SensorCourse = ({ compeId, courseId, playerId, umpireId, setIsenabled }: SensorCourseProps) => {
+export const SensorCourse = ({ compeId, courseId, playerId, umpireId, setIsEnabled }: SensorCourseProps) => {
   const [result1, setResult1] = useState<number>(0) // 進んだmission
   const [tunnelPoint, setTunnelPoint] = useState<number>(0)
   const [wallPoint, setWallPoint] = useState<number>(0)
@@ -164,7 +164,7 @@ export const SensorCourse = ({ compeId, courseId, playerId, umpireId, setIsenabl
               setIsSuccess,
               setLoading,
               router,
-              setIsenabled
+              setIsEnabled
             )
           }
           handleRetry={handleRetry}

--- a/app/components/challenge/sensorCourse.tsx
+++ b/app/components/challenge/sensorCourse.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react"
+import { useRouter } from "next/navigation"
 import { resultSubmit } from "@/app/components/challenge/utils"
 import { ChallengeModal } from "@/app/challenge/challengeModal"
 
@@ -7,9 +8,10 @@ type SensorCourseProps = {
   courseId: number
   playerId: number
   umpireId: number
+  setIsenabled: React.Dispatch<React.SetStateAction<boolean>>
 }
 
-export const SensorCourse = ({ compeId, courseId, playerId, umpireId }: SensorCourseProps) => {
+export const SensorCourse = ({ compeId, courseId, playerId, umpireId, setIsenabled }: SensorCourseProps) => {
   const [result1, setResult1] = useState<number>(0) // 進んだmission
   const [tunnelPoint, setTunnelPoint] = useState<number>(0)
   const [wallPoint, setWallPoint] = useState<number>(0)
@@ -19,6 +21,7 @@ export const SensorCourse = ({ compeId, courseId, playerId, umpireId }: SensorCo
   const [modalOpen, setModalOpen] = useState<number>(0)
   const [pointCount, setPointCount] = useState<number>(0)
   const [isRetry, setIsRetry] = useState<boolean>(false)
+  const router = useRouter()
 
   // 壁停止のポイント配列を20, 10, 5, 3, 0, -5で作成
   const wallPointArray = [20, 10, 5, 3, 0, -5]
@@ -159,7 +162,9 @@ export const SensorCourse = ({ compeId, courseId, playerId, umpireId }: SensorCo
               umpireId,
               setMessage,
               setIsSuccess,
-              setLoading
+              setLoading,
+              router,
+              setIsenabled
             )
           }
           handleRetry={handleRetry}

--- a/app/components/challenge/utils.tsx
+++ b/app/components/challenge/utils.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from "next/navigation"
 import { PointState } from "@/app/components/course/utils"
 
 // 進んだmissionの数によって獲得したポイントを計算する
@@ -24,9 +25,12 @@ export const resultSubmit = async (
   umpireId: number,
   setMessage: React.Dispatch<React.SetStateAction<string>>,
   setIsSuccess: React.Dispatch<React.SetStateAction<boolean>>,
-  setLoading: React.Dispatch<React.SetStateAction<boolean>>
+  setLoading: React.Dispatch<React.SetStateAction<boolean>>,
+  router: ReturnType<typeof useRouter>,
+  setIsenabled: React.Dispatch<React.SetStateAction<boolean>>
 ) => {
   setLoading(true)
+  setIsenabled(false)
 
   const requestBody = {
     result1: result1,
@@ -49,6 +53,7 @@ export const resultSubmit = async (
     if (response.ok) {
       setMessage("チャレンジの送信に成功しました")
       setIsSuccess(true)
+      router.push("/")
     } else {
       setMessage("チャレンジの送信に失敗しました")
     }
@@ -56,6 +61,7 @@ export const resultSubmit = async (
     console.log("error: ", error)
     setMessage("送信中にエラーが発生しました")
   } finally {
+    setIsenabled(true)
     setLoading(false)
   }
 }

--- a/app/components/challenge/utils.tsx
+++ b/app/components/challenge/utils.tsx
@@ -27,10 +27,10 @@ export const resultSubmit = async (
   setIsSuccess: React.Dispatch<React.SetStateAction<boolean>>,
   setLoading: React.Dispatch<React.SetStateAction<boolean>>,
   router: ReturnType<typeof useRouter>,
-  setIsenabled: React.Dispatch<React.SetStateAction<boolean>>
+  setIsEnabled: React.Dispatch<React.SetStateAction<boolean>>
 ) => {
   setLoading(true)
-  setIsenabled(false)
+  setIsEnabled(false)
 
   const requestBody = {
     result1: result1,
@@ -61,7 +61,7 @@ export const resultSubmit = async (
     console.log("error: ", error)
     setMessage("送信中にエラーが発生しました")
   } finally {
-    setIsenabled(true)
+    setIsEnabled(true)
     setLoading(false)
   }
 }

--- a/app/lib/db/queries/insertTestUmpire.sql
+++ b/app/lib/db/queries/insertTestUmpire.sql
@@ -1,0 +1,4 @@
+-- app/lib/db/queries/insertTestUmpire.sql
+-- testUmpireをID 1 に挿入する
+
+INSERT INTO umpire (id, name) VALUES (1, 'TestUmpire')


### PR DESCRIPTION
…components

-結果送信後、トップページに自動的に遷移するようにした。
-umpireId=1のcolumnをtableに入れるDB初期設定用SQLを追加。

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

- [ ] Documentation (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- 
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

## Sourcery によるサマリー

チャレンジコンポーネントに有効/無効状態を持つナビゲーションガードを追加し、結果送信後にホームページへ自動リダイレクト、およびテスト用アンパイアの初期データベースシードスクリプトを含めます。

新機能:
- チャレンジ結果送信後、ホームページへ自動リダイレクト。

機能拡張:
- チャレンジページとセンサーコースページにナビゲーションガードを追加し、離脱前に警告を表示。
- 送信中にナビゲーションガードの切り替えを有効化し、ナビゲーションを防止。

雑務:
- テスト用アンパイア（ID 1）でデータベースをシードするSQLスクリプトを追加。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a navigation guard with enable/disable state to challenge components, auto-redirect to the homepage after submitting results, and include an initial database seed script for a test umpire.

New Features:
- Auto-redirect to homepage after challenge result submission.

Enhancements:
- Add navigation guard to challenge and sensor course pages to warn before leaving.
- Enable toggling of the navigation guard during submission to prevent navigation.

Chores:
- Add SQL script to seed the database with a test umpire (ID 1).

</details>