### PR TITLE
chore: do not run deploy action in fork repo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,7 @@ jobs:
   build:
     name: Build Docusaurus
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'openup-labtakizawa'
     permissions:
       contents: read # to download the repository
       pull-requests: write # to comment on the pull request


### PR DESCRIPTION
## Sourcery によるサマリー

CI:
- リポジトリのオーナーをチェックすることで、forkされたリポジトリに対するデプロイワークフローをスキップする条件を追加しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Add condition to skip deploy workflow for forked repositories by checking the repository owner

</details>