### PR TITLE
feat: add environment variable for public base URL

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,9 @@
 import type { NextConfig } from "next"
 
 const nextConfig: NextConfig = {
+  env: {
+    NEXT_PUBLIC_BASE_URL: process.env.URL,
+  },
   webpack(config) {
     config.module.rules.push({
       test: /\.(mp3)$/,


### PR DESCRIPTION
-NEXT_PUBLIC_BASE_URLにNetlifyのprocess.env.URLを設定

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

- [ ] Documentation (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- 
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

## Sourceryによるサマリー

新機能:
- Netlifyの `process.env.URL` を `next.config.ts` 内で `NEXT_PUBLIC_BASE_URL` として公開します。

<details>
<summary>Original summary in English</summary>

## Sourceryによるサマリー

新機能:
- Netlifyのprocess.env.URLをパブリックなベースURLとしてNEXT_PUBLIC_BASE_URLで公開

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Expose Netlify's process.env.URL as NEXT_PUBLIC_BASE_URL for public base URL

</details>

</details>