### PR TITLE
fix: improve rendering of player points in summary table

### DIFF
--- a/app/summary/[competitionId]/summaryTable.tsx
+++ b/app/summary/[competitionId]/summaryTable.tsx
@@ -195,6 +195,7 @@ export const SummaryTable = ({ id, courseList, ipponBashiPoint }: Props) => {
             ) : courseSummary.length > 0 ? (
               courseSummary?.map((player) => (
                 <tr key={player.playerId}>
+                  {/* 名前 */}
                   <th className="border border-gray-400 p-2">
                     <Link
                       href={`/summary/${competitionId}/${courseId}/${player.playerId}`}
@@ -202,13 +203,17 @@ export const SummaryTable = ({ id, courseList, ipponBashiPoint }: Props) => {
                       {player.playerName ? player.playerName : "-"}
                     </Link>
                   </th>
+                  {/* ふりがな */}
                   <td className="border border-gray-400 p-2 sm:whitespace-nowrap">
                     {player.playerFurigana ? player.playerFurigana : "-"}
                   </td>
+                  {/* ゼッケン */}
                   <td className="border border-gray-400 p-2">{player.playerZekken ? player.playerZekken : "-"}</td>
+                  {/* ベーシックコース完走時刻 */}
                   <td className="border border-gray-400 p-2">
                     {isCompletedCourse(pointData, player.tCourseMaxResult) ? player.firstTCourseTime : "-"}
                   </td>
+                  {/* 完走は何回で達成? */}
                   <td className="border border-gray-400 p-2">
                     {isCompletedCourse(pointData, player.tCourseMaxResult) && player.firstTCourseCount
                       ? player.firstTCourseCount
@@ -216,8 +221,9 @@ export const SummaryTable = ({ id, courseList, ipponBashiPoint }: Props) => {
                   </td>
                   {/* センサーコース以外 */}
                   {courseId !== RESERVED_COURSE_IDS.SENSOR && (
+                    // ベーシックコースの最高得点
                     <td className="border border-gray-400 p-2">
-                      {player.tCourseMaxResult ? calcPoint(pointData, player.tCourseMaxResult) : "-"}
+                      {player.tCourseMaxResult || player.tCourseMaxResult === 0 ? calcPoint(pointData, player.tCourseMaxResult) : "-"}
                     </td>
                   )}
                   {/* センサーコースはmaxResultにそのまま最高得点が入ってる */}
@@ -226,16 +232,23 @@ export const SummaryTable = ({ id, courseList, ipponBashiPoint }: Props) => {
                       {player.sensorMaxResult ? player.sensorMaxResult : "-"}
                     </td>
                   )}
+                  {/* センサーコースの最高得点 */}
                   <td className="border border-gray-400 p-2">
                     {player.sensorMaxResult ? player.sensorMaxResult : "-"}
                   </td>
-                  <td className="border border-gray-400 p-2">{player.sumIpponPoint}</td>
+                  {/* 一本橋の合計得点 */}
+                  <td className="border border-gray-400 p-2">{player.sumIpponPoint ? player.sumIpponPoint : "-"}</td>
+                  {/* 一本橋の最高得点 */}
                   <td className="border border-gray-400 p-2">
                     {player.ipponMaxResult || player.ipponMaxResult === 0 ? calcPoint(ipponBashiPoint, player.ipponMaxResult) : "-"}
                   </td>
+                  {/* 全てのチャレンジの総得点 */}
                   <td className="border border-gray-400 p-2">{player.totalPoint ? player.totalPoint : "-"}</td>
+                  {/* 総得点の順位 */}
                   <td className="border border-gray-400 p-2">{player.pointRank}</td>
+                  {/* チャレンジ回数 */}
                   <td className="border border-gray-400 p-2">{player.challengeCount}</td>
+                  {/* 回数の順位 */}
                   <td className="border border-gray-400 p-2">{player.challengeRank}</td>
                 </tr>
               ))

--- a/app/summary/[competitionId]/summaryTable.tsx
+++ b/app/summary/[competitionId]/summaryTable.tsx
@@ -81,7 +81,7 @@ export const SummaryTable = ({ id, courseList, ipponBashiPoint }: Props) => {
           case "firstTCourseTime":
             return parseDateValue(value, item["tCourseMaxResult"])
           case "playerFurigana":
-            return typeof value === "string" ? value : ""
+            return typeof value === "string" ? value.toString() : ""
           case "playerZekken":
             return parseZekken(value)
           case "firstTCourseCount":
@@ -97,7 +97,10 @@ export const SummaryTable = ({ id, courseList, ipponBashiPoint }: Props) => {
       const aVal = getVal(a)
       const bVal = getVal(b)
 
-      if (aVal < bVal) {
+      if (key === "playerFurigana" && typeof aVal === "string" && typeof bVal === "string") {
+        return order === "asc" ? aVal.localeCompare(bVal, "ja")
+          : bVal.localeCompare(aVal, "ja")
+      } else if (aVal < bVal) {
         return order === "asc" ? -1 : 1
       } else if (aVal > bVal) {
         return order === "asc" ? 1 : -1

--- a/app/summary/[competitionId]/summaryTable.tsx
+++ b/app/summary/[competitionId]/summaryTable.tsx
@@ -52,44 +52,46 @@ export const SummaryTable = ({ id, courseList, ipponBashiPoint }: Props) => {
     const order = sortKey === key && sortOrder === "asc" ? "desc" : "asc"
     setSortKey(key)
     setSortOrder(order)
+    const parseDateValue = (value: any, tCourseMaxResult: any): number => {
+      if (
+        !value ||
+        value === "-" ||
+        !isCompletedCourse(pointData, tCourseMaxResult)
+      ) {
+        return order === "asc" ? Infinity : -Infinity
+      }
+      const t = Date.parse(value as string)
+      return isNaN(t) ? (order === "asc" ? Infinity : -Infinity) : t
+    }
+
+    const parseZekken = (value: any): number | string => {
+      const num = Number(value)
+      return !isNaN(num) ? num : typeof value === "string" ? value : ""
+    }
+
+    const parseNumberFallback = (value: any): number => {
+      return typeof value === "number" ? value : value === null ? 0 : Number(value)
+    }
+
     const sortedData = [...courseSummary].sort((a, b) => {
       const getVal = (item: CourseSummary) => {
         const value = item[key]
 
-        // 日時keyのときはDate.parseで比較
-        if (key === "firstTCourseTime") {
-          // a[key] / b[key]は「YYYY/MM/DD hh:mm:ss」等の文字列
-          if (
-            !value ||
-            value === "-" ||
-            !isCompletedCourse(pointData, item["tCourseMaxResult"])
-          ) {
-            return order === "asc" ? Infinity : -Infinity
-          }
-          const t = Date.parse(value as string)
-          return isNaN(t) ? (order === "asc" ? Infinity : -Infinity) : t
+        switch (key) {
+          case "firstTCourseTime":
+            return parseDateValue(value, item["tCourseMaxResult"])
+          case "playerFurigana":
+            return typeof value === "string" ? value : ""
+          case "playerZekken":
+            return parseZekken(value)
+          case "firstTCourseCount":
+            if (!isCompletedCourse(pointData, item["tCourseMaxResult"])) {
+              return order === "asc" ? Infinity : -Infinity
+            }
+            return parseNumberFallback(value)
+          default:
+            return parseNumberFallback(value)
         }
-
-        if (key === "playerFurigana") {
-          return typeof value === "string" ? value : ""
-        }
-
-        if (key === "playerZekken") {
-          const num = Number(value)
-          return !isNaN(num) ? num : typeof value === "string" ? value : ""
-        }
-
-        if (key === "firstTCourseCount") {
-          if (!isCompletedCourse(pointData, item["tCourseMaxResult"])) {
-            return order === "asc" ? Infinity : -Infinity
-          }
-        }
-
-        return typeof value === "number"
-          ? value
-          : value === null
-            ? 0
-            : Number(value)
       }
 
       const aVal = getVal(a)

--- a/app/summary/[competitionId]/summaryTable.tsx
+++ b/app/summary/[competitionId]/summaryTable.tsx
@@ -53,42 +53,54 @@ export const SummaryTable = ({ id, courseList, ipponBashiPoint }: Props) => {
     setSortKey(key)
     setSortOrder(order)
     const sortedData = [...courseSummary].sort((a, b) => {
-      // 日時keyのときはDate.parseで比較
-      if (key === "firstTCourseTime") {
-        // a[key] / b[key]は「YYYY/MM/DD hh:mm:ss」等の文字列
-        const getTimeVal = (v: CourseSummary | null) => {
-          if (!v || v["firstTCourseTime"] === "-" || !isCompletedCourse(pointData, v["tCourseMaxResult"])) {
+      const getVal = (item: CourseSummary) => {
+        const value = item[key]
+
+        // 日時keyのときはDate.parseで比較
+        if (key === "firstTCourseTime") {
+          // a[key] / b[key]は「YYYY/MM/DD hh:mm:ss」等の文字列
+          if (
+            !value ||
+            value === "-" ||
+            !isCompletedCourse(pointData, item["tCourseMaxResult"])
+          ) {
             return order === "asc" ? Infinity : -Infinity
           }
-          const t = Date.parse(v["firstTCourseTime"] as string)
+          const t = Date.parse(value as string)
           return isNaN(t) ? (order === "asc" ? Infinity : -Infinity) : t
         }
-        const aTime = getTimeVal(a)
-        const bTime = getTimeVal(b)
-        return order === "asc" ? aTime - bTime : bTime - aTime
+
+        if (key === "playerFurigana") {
+          return typeof value === "string" ? value : ""
+        }
+
+        if (key === "playerZekken") {
+          const num = Number(value)
+          return !isNaN(num) ? num : typeof value === "string" ? value : ""
+        }
+
+        if (key === "firstTCourseCount") {
+          if (!isCompletedCourse(pointData, item["tCourseMaxResult"])) {
+            return order === "asc" ? Infinity : -Infinity
+          }
+        }
+
+        return typeof value === "number"
+          ? value
+          : value === null
+            ? 0
+            : Number(value)
       }
 
-      const aValue: number | string =
-        key === "playerFurigana" || key === "playerZekken"
-          ? a[key] === null
-            ? "" // 何も入ってない時に何入れるかは考える余地あり。
-            : a[key]
-          : a[key] === null
-            ? 0
-            : +a[key]
-      const bValue: number | string =
-        key === "playerFurigana" || key === "playerZekken"
-          ? b[key] === null
-            ? "" // 何も入ってない時に何入れるかは考える余地あり。
-            : b[key]
-          : b[key] === null
-            ? 0
-            : +b[key]
+      const aVal = getVal(a)
+      const bVal = getVal(b)
 
-      if (order === "asc") {
-        return aValue > bValue ? 1 : -1
+      if (aVal < bVal) {
+        return order === "asc" ? -1 : 1
+      } else if (aVal > bVal) {
+        return order === "asc" ? 1 : -1
       } else {
-        return aValue < bValue ? 1 : -1
+        return 0
       }
     })
     setCourseSummary(sortedData)
@@ -212,9 +224,9 @@ export const SummaryTable = ({ id, courseList, ipponBashiPoint }: Props) => {
                   <td className="border border-gray-400 p-2">
                     {player.sensorMaxResult ? player.sensorMaxResult : "-"}
                   </td>
-                  <td className="border border-gray-400 p-2">{player.sumIpponPoint ? player.sumIpponPoint : "-"}</td>
+                  <td className="border border-gray-400 p-2">{player.sumIpponPoint}</td>
                   <td className="border border-gray-400 p-2">
-                    {player.ipponMaxResult ? calcPoint(ipponBashiPoint, player.ipponMaxResult) : "-"}
+                    {player.ipponMaxResult || player.ipponMaxResult === 0 ? calcPoint(ipponBashiPoint, player.ipponMaxResult) : "-"}
                   </td>
                   <td className="border border-gray-400 p-2">{player.totalPoint ? player.totalPoint : "-"}</td>
                   <td className="border border-gray-400 p-2">{player.pointRank}</td>


### PR DESCRIPTION
一本橋の最高得点が0でもきちんと表示されるように修正

fix: improve sorting logic for course summary table

fix: refine sorting logic for playerZekken in summary table

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

- [ ] Documentation (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- 
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

## Sourceryによるサマリー

競技概要テーブルのソートと表示ロジックを改善

バグ修正:
- `sumIpponPoint` と `ipponMaxResult` の値がゼロの場合に、非表示にならずに正しくレンダリングされるように修正

機能拡張:
- 日付、`playerFurigana`、`playerZekken`、コース数キーに対するカスタム値抽出を用いて、ソートロジックを統一および改善
- すべてのソート可能な列で一貫した昇順/降順比較を実装

<details>
<summary>Original summary in English</summary>

## Sourcery によるサマリー

カスタム値の抽出によるソートロジックの標準化と、ゼロ値ポイントのレンダリング修正により、サマリーテーブルを改善

バグ修正:
- `sumIpponPoint` がゼロ値を非表示にするのではなく表示するように修正
- `ipponMaxResult` が欠落として表示されるのではなく、ゼロ値を表示するように修正

機能拡張:
- 日付、`playerFurigana`、`playerZekken`、コース数、および数値フォールバックのための専用パーサーを使用して、列のソートを統一およびリファクタリングし、一貫した昇順/降順の順序付けを実現

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve summary table by standardizing sorting logic with custom value extraction and fixing rendering of zero-value points

Bug Fixes:
- Ensure sumIpponPoint displays zero values instead of hiding them
- Ensure ipponMaxResult displays zero values instead of showing as missing

Enhancements:
- Unify and refactor column sorting with dedicated parsers for dates, playerFurigana, playerZekken, course counts, and numeric fallbacks with consistent asc/desc ordering

</details>

</details>