### PR TITLE
fix: add overrides for webpack-dev-server version in package.json

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -46,5 +46,8 @@
   },
   "engines": {
     "node": ">=18.0"
+  },
+  "overrides": {
+    "webpack-dev-server": "^5.2.1"
   }
 }


### PR DESCRIPTION
-Dependabot的にalertが出て、
webpack-dev-server
をパッチバージョンにトリアージする。
docusaurusにかまけている暇は無いので、動作確認はしてない。

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

- [ ] Documentation (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- 
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

## Sourcery によるサマリー

バグ修正:
- webpack-dev-server を ^5.2.1 にオーバーライドして、セキュリティアラートを解決しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Override webpack-dev-server to ^5.2.1 to resolve a security alert

</details>