### PR TITLE
fix: hidden score board input

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -32,22 +32,8 @@ export default async function Home() {
         tab3Icon={<TrophyIcon className="h-3 w-3 md:h-8 md:w-8" />}
       />
       :
-      <div role="tablist" className="tabs tabs-lifted m-5">
-        <input
-          type="radio"
-          name="tabs"
-          id="challenge-tab"
-          role="tab"
-          className="tab whitespace-nowrap"
-          defaultChecked={true}
-        />
-        <div role="tabpanel" className="tab-content bg-base-100 border border-base-300 rounded-box p-6">
-          <ChallengeTab key="challenge" competitionList={competitionList} courseList={courseList} competitionCourseList={competitionCourseList} />
-        </div>
-        <label htmlFor="challenge-tab" className="flex tab items-center gap-2">
-          <ClipboardDocumentCheckIcon className="h-6 w-6" />
-          採点
-        </label>
+      <div className="bg-base-100 border border-base-300 rounded-box p-6">
+        <ChallengeTab key="challenge" competitionList={competitionList} courseList={courseList} competitionCourseList={competitionCourseList} />
       </div>
   )
 }


### PR DESCRIPTION
## Sourcery によるサマリー

未使用のタブ入力を削除し、チャレンジタブコンポーネントをタブコントロールなしで直接レンダリングすることで、ホームページを簡素化します。

機能拡張:
- チャレンジタブのラジオ入力、tablist コンテナ、ラベルを削除
- ChallengeTab をタブパネル内ではなく、スタンドアロンのスタイル付きコンテナ内にレンダリング

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify the home page by removing the unused tabs input and directly rendering the ChallengeTab component without the surrounding tab controls.

Enhancements:
- Remove the radio input, tablist container, and label for the challenge tab
- Render ChallengeTab inside a standalone styled container instead of within a tab panel

</details>