### PR TITLE
build: version up dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,8 @@
         "@heroicons/react": "^2.2.0",
         "@neondatabase/serverless": "^1.0.1",
         "@tailwindcss/postcss": "^4.1.8",
-        "@types/node": "^22.15.30",
-        "@types/react": "^19.1.6",
+        "@types/node": "^22.15.31",
+        "@types/react": "^19.1.7",
         "@types/react-dom": "^19.1.6",
         "bcryptjs": "^3.0.2",
         "daisyui": "^5.0.43",
@@ -29,7 +29,7 @@
         "postcss": "^8.5.4",
         "tailwindcss": "^4.1.8",
         "typescript": "^5.8.3",
-        "zod": "^3.25.56"
+        "zod": "^3.25.58"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1676,9 +1676,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.15.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.30.tgz",
-      "integrity": "sha512-6Q7lr06bEHdlfplU6YRbgG1SFBdlsfNC4/lX+SkhiTs0cpJkOElmWls8PxDFv4yY/xKb8Y6SO0OmSX4wgqTZbA==",
+      "version": "22.15.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.31.tgz",
+      "integrity": "sha512-jnVe5ULKl6tijxUhvQeNbQG/84fHfg+yMak02cT8QVhBx/F05rAVxCGBYYTh2EKz22D6JF5ktXuNwdx7b9iEGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1698,9 +1698,9 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.1.6",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.6.tgz",
-      "integrity": "sha512-JeG0rEWak0N6Itr6QUx+X60uQmN+5t3j9r/OVDtWzFXKaj6kD1BwJzOksD0FF6iWxZlbE1kB0q9vtnU2ekqa1Q==",
+      "version": "19.1.7",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.7.tgz",
+      "integrity": "sha512-BnsPLV43ddr05N71gaGzyZ5hzkCmGwhMvYc8zmvI8Ci1bRkkDSzDDVfAXfN2tk748OwI7ediiPX6PfT9p0QGVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2946,9 +2946,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.56",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.56.tgz",
-      "integrity": "sha512-rd6eEF3BTNvQnR2e2wwolfTmUTnp70aUTqr0oaGbHifzC3BKJsoV+Gat8vxUMR1hwOKBs6El+qWehrHbCpW6SQ==",
+      "version": "3.25.58",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.58.tgz",
+      "integrity": "sha512-DVLmMQzSZwNYzQoMaM3MQWnxr2eq+AtM9Hx3w1/Yl0pH8sLTSjN4jGP7w6f7uand6Hw44tsnSu1hz1AOA6qI2Q==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "@heroicons/react": "^2.2.0",
     "@neondatabase/serverless": "^1.0.1",
     "@tailwindcss/postcss": "^4.1.8",
-    "@types/node": "^22.15.30",
-    "@types/react": "^19.1.6",
+    "@types/node": "^22.15.31",
+    "@types/react": "^19.1.7",
     "@types/react-dom": "^19.1.6",
     "bcryptjs": "^3.0.2",
     "daisyui": "^5.0.43",
@@ -30,7 +30,7 @@
     "postcss": "^8.5.4",
     "tailwindcss": "^4.1.8",
     "typescript": "^5.8.3",
-    "zod": "^3.25.56"
+    "zod": "^3.25.58"
   },
   "overrides": {
     "@esbuild-kit/core-utils": {


### PR DESCRIPTION
## Sourceryによるサマリー

開発依存関係のパッチバージョンを最新リリースに更新

ビルド：
- @types/node を 22.15.31 に更新
- @types/react を 19.1.7 に更新
- zod を 3.25.58 に更新

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bump patch versions of development dependencies to their latest releases

Build:
- Update @types/node to 22.15.31
- Update @types/react to 19.1.7
- Update zod to 3.25.58

</details>