### PR TITLE
chore(part11): format and lint components/common files

### DIFF
--- a/app/components/common/commonList.tsx
+++ b/app/components/common/commonList.tsx
@@ -1,29 +1,50 @@
-import type { SelectPlayer, SelectUmpire, SelectCompetition, SelectAssignList, SelectPlayerWithCompetition, SelectUmpireWithCompetition, SelectCourseWithCompetition } from "@/app/lib/db/schema"
+import type {
+  SelectAssignList,
+  SelectCompetition,
+  SelectCourseWithCompetition,
+  SelectPlayer,
+  SelectPlayerWithCompetition,
+  SelectUmpire,
+  SelectUmpireWithCompetition,
+} from "@/app/lib/db/schema"
+import type React from "react"
 
-type commonListProps = {
+type CommonListProps = {
   type: "player" | "umpire" | "course" | "competition" | "assign"
-  commonDataList: SelectPlayer[] | SelectUmpire[] | SelectCompetition[] | SelectAssignList[] | SelectPlayerWithCompetition[] | SelectUmpireWithCompetition[]
+  commonDataList:
+    | SelectPlayer[]
+    | SelectUmpire[]
+    | SelectCompetition[]
+    | SelectAssignList[]
+    | SelectPlayerWithCompetition[]
+    | SelectUmpireWithCompetition[]
 }
 
-type radioListProps = {
-  props: commonListProps
+type RadioListProps = {
+  props: CommonListProps
   commonId: number | null
   setCommonId: React.Dispatch<React.SetStateAction<number | null>>
 }
 
-type checkboxListProps = {
-  props: commonListProps
+type CheckboxListProps = {
+  props: CommonListProps
   commonId: number[] | null
   setCommonId: React.Dispatch<React.SetStateAction<number[] | null>>
 }
 
-const TableComponent = ({
+function TableComponent({
   type,
   common,
 }: {
-  type: commonListProps["type"]
-  common: SelectPlayer | SelectUmpire | SelectCompetition | SelectAssignList | SelectPlayerWithCompetition | SelectUmpireWithCompetition
-}) => {
+  type: CommonListProps["type"]
+  common:
+    | SelectPlayer
+    | SelectUmpire
+    | SelectCompetition
+    | SelectAssignList
+    | SelectPlayerWithCompetition
+    | SelectUmpireWithCompetition
+}) {
   return (
     <>
       {type === "player" && (
@@ -32,7 +53,13 @@ const TableComponent = ({
           <td>{(common as SelectPlayerWithCompetition).zekken}</td>
           <td>{(common as SelectPlayerWithCompetition).furigana}</td>
           <td>{(common as SelectPlayerWithCompetition).name}</td>
-          <td>{(common as SelectPlayerWithCompetition).competitionName?.map((name, index) => (<div key={index}>{name}</div>))}</td>
+          <td>
+            {(common as SelectPlayerWithCompetition).competitionName?.map(
+              (name) => (
+                <div key={name}>{name}</div>
+              ),
+            )}
+          </td>
           {/* <td>{(common as SelectPlayerWithCompetition).qr}</td> */}
         </>
       )}
@@ -40,22 +67,44 @@ const TableComponent = ({
         <>
           <td>{(common as SelectUmpireWithCompetition).id}</td>
           <td>{(common as SelectUmpireWithCompetition).name}</td>
-          <td>{(common as SelectUmpireWithCompetition).competitionName?.map((name, index) => (<div key={index}>{name}</div>))}</td>
+          <td>
+            {(common as SelectUmpireWithCompetition).competitionName?.map(
+              (name) => (
+                <div key={name}>{name}</div>
+              ),
+            )}
+          </td>
         </>
       )}
       {type === "course" && (
         <>
           <td>{(common as SelectCourseWithCompetition).id}</td>
           <td>{(common as SelectCourseWithCompetition).name}</td>
-          <td suppressHydrationWarning={true}>{(common as SelectCourseWithCompetition).createdAt?.toLocaleString("ja-JP")}</td>
-          <td>{(common as SelectCourseWithCompetition).competitionName?.map((name, index) => (<div key={index}>{name}</div>))}</td>
+          <td suppressHydrationWarning={true}>
+            {(common as SelectCourseWithCompetition).createdAt?.toLocaleString(
+              "ja-JP",
+            )}
+          </td>
+          <td>
+            {(common as SelectCourseWithCompetition).competitionName?.map(
+              (name) => (
+                <div key={name}>{name}</div>
+              ),
+            )}
+          </td>
         </>
       )}
       {type === "competition" && (
         <>
           <td>{(common as SelectCompetition).id}</td>
           <td>{(common as SelectCompetition).name}</td>
-          <td>{(common as SelectCompetition).step === 0 ? "開催前" : (common as SelectCompetition).step === 1 ? "開催中" : "終了済"}</td>
+          <td>
+            {(common as SelectCompetition).step === 0
+              ? "開催前"
+              : (common as SelectCompetition).step === 1
+                ? "開催中"
+                : "終了済"}
+          </td>
         </>
       )}
       {type === "assign" && (
@@ -69,7 +118,7 @@ const TableComponent = ({
   )
 }
 
-const itemNames = (type: commonListProps["type"]): string[] => {
+function itemNames(type: CommonListProps["type"]): string[] {
   const itemNames: string[] = []
   if (type === "player") {
     itemNames.push("ゼッケン番号", "ふりがな", "名前", "参加大会")
@@ -85,8 +134,12 @@ const itemNames = (type: commonListProps["type"]): string[] => {
   return itemNames
 }
 
-export const CommonRadioList = ({ props: { type, commonDataList }, commonId, setCommonId }: radioListProps) => {
-  const handleRadioSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
+export function CommonRadioList({
+  props: { type, commonDataList },
+  commonId,
+  setCommonId,
+}: RadioListProps) {
+  function handleRadioSelect(event: React.ChangeEvent<HTMLInputElement>) {
     setCommonId(Number(event.target.value))
   }
 
@@ -94,7 +147,16 @@ export const CommonRadioList = ({ props: { type, commonDataList }, commonId, set
     <>
       {type !== "competition" && (
         <h2 className="text-center text-xl font-semibold">
-          {type === "player" ? "選手" : type === "umpire" ? "採点者" : type === "course" ? "コース" : type === "assign" ? "割当" : null}一覧
+          {type === "player"
+            ? "選手"
+            : type === "umpire"
+              ? "採点者"
+              : type === "course"
+                ? "コース"
+                : type === "assign"
+                  ? "割当"
+                  : null}
+          一覧
         </h2>
       )}
       <div className="w-full">
@@ -108,14 +170,29 @@ export const CommonRadioList = ({ props: { type, commonDataList }, commonId, set
                   </label>
                 </th>
                 {itemNames(type).map((name) => (
-                  <th key={name} hidden={type === "player" && name === "参加大会"}>{name}</th>
+                  <th
+                    key={name}
+                    hidden={type === "player" && name === "参加大会"}
+                  >
+                    {name}
+                  </th>
                 ))}
               </tr>
             </thead>
             <tbody>
               {commonDataList.length > 0 ? (
                 commonDataList.map((common) => (
-                  <tr key={common.id} className="hover cursor-pointer" onClick={() => setCommonId(common.id)} hidden={common.id < 0}>
+                  <tr
+                    key={common.id}
+                    className="hover cursor-pointer"
+                    onClick={() => setCommonId(common.id)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === "Space") {
+                        setCommonId(common.id)
+                      }
+                    }}
+                    hidden={common.id < 0}
+                  >
                     <th>
                       <label>
                         <input
@@ -124,7 +201,7 @@ export const CommonRadioList = ({ props: { type, commonDataList }, commonId, set
                           value={common.id}
                           checked={commonId === common.id}
                           onChange={handleRadioSelect}
-                          className="h-4 w-4"
+                          className="size-4"
                         />
                       </label>
                     </th>
@@ -155,8 +232,12 @@ export const CommonRadioList = ({ props: { type, commonDataList }, commonId, set
   )
 }
 
-export const CommonCheckboxList = ({ props: { type, commonDataList }, commonId, setCommonId }: checkboxListProps) => {
-  const handleCheckboxChange = (id: number) => {
+export function CommonCheckboxList({
+  props: { type, commonDataList },
+  commonId,
+  setCommonId,
+}: CheckboxListProps) {
+  function handleCheckboxChange(id: number) {
     if (!commonId) {
       setCommonId([id])
     } else if (commonId.includes(id)) {
@@ -170,7 +251,14 @@ export const CommonCheckboxList = ({ props: { type, commonDataList }, commonId, 
     <>
       {type !== "competition" && (
         <h2 className="text-center text-xl font-semibold">
-          {type === "player" ? "選手" : type === "umpire" ? "採点者" : type === "course" ? "コース" : null}一覧
+          {type === "player"
+            ? "選手"
+            : type === "umpire"
+              ? "採点者"
+              : type === "course"
+                ? "コース"
+                : null}
+          一覧
         </h2>
       )}
       <div className="w-full">
@@ -191,14 +279,20 @@ export const CommonCheckboxList = ({ props: { type, commonDataList }, commonId, 
             <tbody>
               {commonDataList.length > 0 ? (
                 commonDataList.map((common) => (
-                  <tr key={common.id} className="hover cursor-pointer" onClick={() => handleCheckboxChange(common.id)} hidden={common.id < 0}>
+                  <tr
+                    key={common.id}
+                    className="hover cursor-pointer"
+                    onClick={() => handleCheckboxChange(common.id)}
+                    onKeyDown={() => handleCheckboxChange(common.id)}
+                    hidden={common.id < 0}
+                  >
                     <th>
                       <label>
                         <input
                           type="checkbox"
                           name="selectedCommon"
                           value={common.id}
-                          checked={commonId?.includes(common.id) || false}
+                          checked={commonId?.includes(common.id)}
                           onChange={() => handleCheckboxChange(common.id)}
                           className="h-4 w-4"
                         />

--- a/app/components/common/commonModal.tsx
+++ b/app/components/common/commonModal.tsx
@@ -1,42 +1,58 @@
 "use client"
-import { useState } from "react"
-import { useRouter } from "next/navigation"
-import { SelectCompetition } from "@/app/lib/db/schema"
+
 import { BackLabelWithIcon } from "@/app/lib/const"
+import type { SelectCompetition } from "@/app/lib/db/schema"
+import { useRouter } from "next/navigation"
+import { useState } from "react"
 
-type inputType = "player" | "umpire" | "course"
+type InputType = "player" | "umpire" | "course"
 
-function getCommonString(type: inputType): string {
+function getCommonString(type: InputType): string {
   return type === "player" ? "選手" : type === "umpire" ? "採点者" : "コース"
 }
 
-export const ModalBackdrop = () => {
+export function ModalBackdrop() {
   const router = useRouter()
   return (
-    <form method="dialog" className="modal-backdrop" onClick={() => router.back()}>
-      <button className="cursor-default">close</button>
+    <form
+      method="dialog"
+      className="modal-backdrop"
+      onClick={() => router.back()}
+      onKeyDown={(e) => {
+        if (e.key === "Escape") {
+          router.back()
+        }
+      }}
+    >
+      <button type="button" className="cursor-default">
+        close
+      </button>
     </form>
   )
 }
 
-export const ModalBackButton = () => {
+export function ModalBackButton() {
   const router = useRouter()
   return (
-    <button className="flex btn btn-accent m-3" onClick={() => router.back()}>
+    <button
+      type="button"
+      className="flex btn btn-accent m-3"
+      onClick={() => router.back()}
+    >
       <BackLabelWithIcon />
     </button>
   )
 }
 
-export const DeleteModal = ({ type, ids }: { type: inputType; ids: number[] }) => {
+export function DeleteModal({ type, ids }: { type: InputType; ids: number[] }) {
   const [loading, setLoading] = useState(false)
   const [successMessage, setSuccessMessage] = useState<string | null>(null)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const commonString: string = getCommonString(type)
-  const handleDelete = async () => {
+  async function handleDelete() {
     try {
       setLoading(true)
-      const url = "/api/" + type
+      const url = `/api/${type}`
       const response = await fetch(url, {
         method: "DELETE",
         headers: {
@@ -47,12 +63,10 @@ export const DeleteModal = ({ type, ids }: { type: inputType; ids: number[] }) =
 
       if (response.ok) {
         // 削除成功時の処理
-        setSuccessMessage(commonString + "を正常に削除しました")
+        setSuccessMessage(`${commonString}を正常に削除しました`)
       } else {
-        setErrorMessage(commonString + "を削除できませんでした")
+        setErrorMessage(`${commonString}を削除できませんでした`)
       }
-    } catch (error) {
-      console.log("error: ", error)
     } finally {
       setLoading(false)
     }
@@ -61,19 +75,30 @@ export const DeleteModal = ({ type, ids }: { type: inputType; ids: number[] }) =
   return (
     <dialog id="challenge-modal" className="modal modal-open">
       <div className="modal-box">
-        {successMessage ? successMessage : <p>選択した{commonString}を削除しますか?</p>}
+        {successMessage ? (
+          successMessage
+        ) : (
+          <p>選択した{commonString}を削除しますか?</p>
+        )}
         {errorMessage ? errorMessage : <br />}
         {!successMessage && (
-          <button className="btn btn-accent m-3" onClick={handleDelete} disabled={loading}>
+          <button
+            type="button"
+            className="btn btn-accent m-3"
+            onClick={handleDelete}
+            disabled={loading}
+          >
             はい
           </button>
         )}
         <button
+          type="button"
           className="btn btn-accent m-3"
           onClick={() => {
-            window.location.href = "/" + type
+            window.location.href = `/${type}`
           }}
-          disabled={loading}>
+          disabled={loading}
+        >
           <BackLabelWithIcon />
         </button>
       </div>
@@ -82,16 +107,20 @@ export const DeleteModal = ({ type, ids }: { type: inputType; ids: number[] }) =
   )
 }
 
-export const AssignModal = (params: { type: inputType, ids: number[], competitionList: { competitions: SelectCompetition[] } }) => {
+export function AssignModal(params: {
+  type: InputType
+  ids: number[]
+  competitionList: { competitions: SelectCompetition[] }
+}) {
   const [loading, setLoading] = useState(false)
   const { type, ids, competitionList } = params
   const [competitionId, setCompetitionId] = useState<number | null>(null)
   const commonString: string = getCommonString(type)
 
-  const handleAssign = async () => {
+  async function handleAssign() {
     try {
       setLoading(true)
-      const url = "/api/assign/" + type
+      const url = `/api/assign/${type}`
       const response = await fetch(url, {
         method: "POST",
         headers: {
@@ -101,25 +130,20 @@ export const AssignModal = (params: { type: inputType, ids: number[], competitio
       })
 
       if (response.ok) {
-        const data = await response.json()
-        alert(commonString + "の割当てに成功しました。")
-        window.location.href = "/" + type
+        alert(`${commonString}の割当てに成功しました。`)
+        window.location.href = `/${type}`
       } else {
-        const errorData = await response.json()
-        console.error("Error assigning:", errorData)
-        alert(commonString + "の割当てに失敗しました。")
+        alert(`${commonString}の割当てに失敗しました。`)
       }
-    } catch (error) {
-      console.log("error: ", error)
     } finally {
       setLoading(false)
     }
   }
 
-  const handleUnassign = async () => {
+  async function handleUnassign() {
     try {
       setLoading(true)
-      const url = "/api/assign/" + type
+      const url = `/api/assign/${type}`
       const response = await fetch(url, {
         method: "DELETE",
         headers: {
@@ -129,18 +153,11 @@ export const AssignModal = (params: { type: inputType, ids: number[], competitio
       })
 
       if (response.ok) {
-        const data = await response.json()
-        console.log("Player unassigned successfully:", data)
-        alert(commonString + "の割当てを解除しました。")
-        window.location.href = "/" + type
+        alert(`${commonString}の割当てを解除しました。`)
+        window.location.href = `/${type}`
       } else {
-        const errorData = await response.json()
-        console.error("Error unassigning player:", errorData)
-        alert(commonString + "の割当て解除に失敗しました。")
+        alert(`${commonString}の割当て解除に失敗しました。`)
       }
-    }
-    catch (error) {
-      console.log("error: ", error)
     } finally {
       setLoading(false)
     }
@@ -153,8 +170,9 @@ export const AssignModal = (params: { type: inputType, ids: number[], competitio
           <select
             className="select select-bordered m-3"
             onChange={(event) => setCompetitionId(Number(event.target.value))}
-            value={competitionId || 0}>
-            <option value={0} disabled>
+            value={competitionId || 0}
+          >
+            <option value={0} disabled={true}>
               大会を選んでください
             </option>
             {competitionList?.competitions?.map((competition) => (
@@ -163,20 +181,39 @@ export const AssignModal = (params: { type: inputType, ids: number[], competitio
               </option>
             ))}
           </select>
-
         </div>
-        <button className="btn btn-accent m-3" onClick={handleAssign} disabled={loading}>
-          {loading ? <span className="loading loading-spinner"></span> : "大会を割り当てる"}
-        </button>
-        <button className="btn btn-accent m-3" onClick={handleUnassign} disabled={loading}>
-          {loading ? <span className="loading loading-spinner"></span> : "大会割り当て解除"}
+        <button
+          type="button"
+          className="btn btn-accent m-3"
+          onClick={handleAssign}
+          disabled={loading}
+        >
+          {loading ? (
+            <span className="loading loading-spinner" />
+          ) : (
+            "大会を割り当てる"
+          )}
         </button>
         <button
+          type="button"
+          className="btn btn-accent m-3"
+          onClick={handleUnassign}
+          disabled={loading}
+        >
+          {loading ? (
+            <span className="loading loading-spinner" />
+          ) : (
+            "大会割り当て解除"
+          )}
+        </button>
+        <button
+          type="button"
           className="btn btn-accent m-3"
           onClick={() => {
-            window.location.href = "/" + type
+            window.location.href = `/${type}`
           }}
-          disabled={loading}>
+          disabled={loading}
+        >
           <BackLabelWithIcon />
         </button>
       </div>

--- a/app/components/common/commonRegister.tsx
+++ b/app/components/common/commonRegister.tsx
@@ -1,16 +1,33 @@
 "use client"
+
+import {
+  getCompetitionList,
+  getPlayerList,
+  getUmpireList,
+} from "@/app/components/server/db"
+import type {
+  SelectCompetition,
+  SelectPlayer,
+  SelectUmpire,
+} from "@/app/lib/db/schema"
 import { useCallback, useState } from "react"
-import type { SelectPlayer, SelectUmpire, SelectCompetition } from "@/app/lib/db/schema"
-import { getPlayerList, getUmpireList, getCompetitionList } from "@/app/components/server/db"
+import type React from "react"
 
 type CommonRegisterProps = {
   type: "player" | "umpire" | "course" | "competition"
   setSuccessMessage: React.Dispatch<React.SetStateAction<string | null>>
   setErrorMessage: React.Dispatch<React.SetStateAction<string | null>>
-  setCommonDataList: React.Dispatch<React.SetStateAction<SelectPlayer[] | SelectUmpire[] | SelectCompetition[]>>
+  setCommonDataList: React.Dispatch<
+    React.SetStateAction<SelectPlayer[] | SelectUmpire[] | SelectCompetition[]>
+  >
 }
 
-const CommonRegister = ({ type, setSuccessMessage, setErrorMessage, setCommonDataList }: CommonRegisterProps) => {
+export function CommonRegister({
+  type,
+  setSuccessMessage,
+  setErrorMessage,
+  setCommonDataList,
+}: CommonRegisterProps) {
   const [loading, setLoading] = useState(false)
   const [name, setName] = useState("")
   const [furigana, setFurigana] = useState("")
@@ -18,30 +35,47 @@ const CommonRegister = ({ type, setSuccessMessage, setErrorMessage, setCommonDat
   const [qr, setQr] = useState("")
 
   const formItems = [
-    (type === "competition"
+    type === "competition"
       ? { label: "name", dispName: "大会名", value: name, setValue: setName }
-      : { label: "name", dispName: "名前", value: name, setValue: setName }
-    ),
+      : { label: "name", dispName: "名前", value: name, setValue: setName },
     ...(type === "player"
       ? [
-        { label: "furigana", dispName: "ふりがな", value: furigana, setValue: setFurigana },
-        { label: "zekken", dispName: "ゼッケン番号", value: zekken, setValue: setZekken },
-        { label: "qr", dispName: "QRコード", value: qr, setValue: setQr },
-      ]
+          {
+            label: "furigana",
+            dispName: "ふりがな",
+            value: furigana,
+            setValue: setFurigana,
+          },
+          {
+            label: "zekken",
+            dispName: "ゼッケン番号",
+            value: zekken,
+            setValue: setZekken,
+          },
+          { label: "qr", dispName: "QRコード", value: qr, setValue: setQr },
+        ]
       : []),
   ]
 
-  const handleSubmit = async (event: React.FormEvent) => {
+  async function handleSubmit(event: React.FormEvent) {
     event.preventDefault()
     setLoading(true)
     setErrorMessage(null)
     setSuccessMessage(null)
 
-    const commonData = { name, ...(type === "player" ? { furigana, zekken, qr } : {}) }
+    const commonData = {
+      name,
+      ...(type === "player" ? { furigana, zekken, qr } : {}),
+    }
 
     try {
       // APIにPOSTリクエストを送信
-      const url = type === "player" ? "/api/player" : type === "umpire" ? "/api/umpire" : "/api/competition"
+      const url =
+        type === "player"
+          ? "/api/player"
+          : type === "umpire"
+            ? "/api/umpire"
+            : "/api/competition"
       const response = await fetch(url, {
         method: "POST",
         headers: {
@@ -53,31 +87,35 @@ const CommonRegister = ({ type, setSuccessMessage, setErrorMessage, setCommonDat
       const result = await response.json()
 
       if (response.ok) {
+        setName("")
         // 登録成功時の処理
         if (type === "player") {
           setSuccessMessage("プレイヤーが正常に登録されました")
-          setName("")
           setFurigana("")
           setZekken("")
           setQr("")
-          const newCommonDataList: { players: SelectPlayer[] } = await getPlayerList()
+          const newCommonDataList: { players: SelectPlayer[] } =
+            await getPlayerList()
           setCommonDataList(newCommonDataList.players)
         } else if (type === "umpire") {
           setSuccessMessage("採点者が正常に登録されました")
-          setName("")
-          const newCommonDataList: { umpires: SelectUmpire[] } = await getUmpireList()
-          type === "umpire" && setCommonDataList(newCommonDataList.umpires as SelectUmpire[])
+          const newCommonDataList: { umpires: SelectUmpire[] } =
+            await getUmpireList()
+          setCommonDataList(newCommonDataList.umpires as SelectUmpire[])
         } else {
           setSuccessMessage("大会が正常に登録されました")
-          setName("")
-          const newCommonDataList: { competitions: SelectCompetition[] } = await getCompetitionList()
-          type === "competition" && setCommonDataList(newCommonDataList.competitions as SelectCompetition[])
+          const newCommonDataList: { competitions: SelectCompetition[] } =
+            await getCompetitionList()
+          type === "competition" &&
+            setCommonDataList(
+              newCommonDataList.competitions as SelectCompetition[],
+            )
         }
       } else {
         // エラーメッセージを表示
         setErrorMessage(result.message || "登録中にエラーが発生しました")
       }
-    } catch (error) {
+    } catch {
       // ネットワークエラーやその他のエラーの処理
       setErrorMessage("エラーが発生しました。もう一度お試しください。")
     } finally {
@@ -99,7 +137,10 @@ const CommonRegister = ({ type, setSuccessMessage, setErrorMessage, setCommonDat
       setValue: React.Dispatch<React.SetStateAction<string>>
     }) => (
       <div>
-        <label htmlFor={label} className="block text-sm font-medium text-gray-700">
+        <label
+          htmlFor={label}
+          className="block text-sm font-medium text-gray-700"
+        >
           {dispName}
         </label>
         <input
@@ -107,21 +148,25 @@ const CommonRegister = ({ type, setSuccessMessage, setErrorMessage, setCommonDat
           id={label}
           value={value}
           onChange={(e) => setValue(e.target.value)}
-          required
+          required={true}
           className="mt-1 p-2 border border-gray-300 rounded-md"
         />
       </div>
     ),
-    []
+    [],
   )
 
   return (
     <div className=" flex justify-center">
       <form onSubmit={handleSubmit} className="space-y-4">
-        <button type="submit" disabled={loading} className="btn btn-primary mx-auto m-3">
+        <button
+          type="submit"
+          disabled={loading}
+          className="btn btn-primary mx-auto m-3"
+        >
           {loading ? "登録中..." : "↓新規登録"}
         </button>
-        {formItems.map((item, index) => (
+        {formItems.map((item) => (
           <FormItem
             key={item.label}
             label={item.label}
@@ -134,5 +179,3 @@ const CommonRegister = ({ type, setSuccessMessage, setErrorMessage, setCommonDat
     </div>
   )
 }
-
-export default CommonRegister

--- a/app/components/common/view.tsx
+++ b/app/components/common/view.tsx
@@ -1,9 +1,17 @@
 "use client"
-import { useState, useEffect } from "react"
-import type { SelectPlayer, SelectUmpire, SelectPlayerWithCompetition, SelectUmpireWithCompetition, SelectCourseWithCompetition } from "@/app/lib/db/schema"
+
 import { CommonCheckboxList } from "@/app/components/common/commonList"
-import CommonRegister from "@/app/components/common/commonRegister"
+import { CommonRegister } from "@/app/components/common/commonRegister"
+import type {
+  SelectCourseWithCompetition,
+  SelectPlayer,
+  SelectPlayerWithCompetition,
+  SelectUmpire,
+  SelectUmpireWithCompetition,
+} from "@/app/lib/db/schema"
 import Link from "next/link"
+import { useEffect, useState } from "react"
+import type React from "react"
 
 type PlayerProps = {
   type: "player"
@@ -22,16 +30,23 @@ type CourseProps = {
 
 type ViewProps = PlayerProps | UmpireProps | CourseProps
 
-export const View = ({ type, initialCommonDataList }: ViewProps) => {
+export function View({ type, initialCommonDataList }: ViewProps) {
   const [successMessage, setSuccessMessage] = useState<string | null>(null)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
-  const commonString = type === "player" ? "選手" : type === "umpire" ? "採点者" : "コース"
-  const [commonDataList, setCommonDataList] = useState<SelectPlayerWithCompetition[] | SelectUmpireWithCompetition[] | SelectCourseWithCompetition[] | SelectPlayer[] | SelectUmpire[]>(
-    initialCommonDataList
-  )
+  const commonString =
+    type === "player" ? "選手" : type === "umpire" ? "採点者" : "コース"
+  const [commonDataList, setCommonDataList] = useState<
+    | SelectPlayerWithCompetition[]
+    | SelectUmpireWithCompetition[]
+    | SelectCourseWithCompetition[]
+    | SelectPlayer[]
+    | SelectUmpire[]
+  >(initialCommonDataList)
   // 配列をクエリ文字列に変換する関数
   const createQueryParams = (ids: number[] | null) => {
-    if (!ids || ids.length === 0) return ""
+    if (!ids || ids.length === 0) {
+      return ""
+    }
     return ids.map((id) => `${id}`).join("/")
   }
 
@@ -40,61 +55,74 @@ export const View = ({ type, initialCommonDataList }: ViewProps) => {
   }, [commonDataList])
 
   // 選択したitemに実施する行動の選択肢
-  const ItemManager = ({ commonId }: { commonId: number[] | null }) => {
+  function ItemManager({ commonId }: { commonId: number[] | null }) {
     return (
       <>
-        {successMessage && <div className="text-green-500 font-semibold">{successMessage}</div>}
-        {errorMessage && <div className="text-red-500 font-semibold">{errorMessage}</div>}
+        {successMessage && (
+          <div className="text-green-500 font-semibold">{successMessage}</div>
+        )}
+        {errorMessage && (
+          <div className="text-red-500 font-semibold">{errorMessage}</div>
+        )}
         <div className="flex w-fit">
           <p className="flex m-3">選択した{commonString}を</p>
-          {type === "course" &&
+          {type === "course" && (
             <Link
               href={`/course/edit/${createQueryParams(commonId)}`}
-              className={
-                "flex btn mx-auto m-3 " +
-                (commonId?.length !== 1 ? "pointer-events-none btn-disabled" : "btn-primary")
-              }
+              className={`flex btn mx-auto m-3 ${
+                commonId?.length !== 1
+                  ? "pointer-events-none btn-disabled"
+                  : "btn-primary"
+              }`}
               aria-disabled={commonId?.length !== 1}
               tabIndex={commonId?.length !== 1 ? -1 : undefined}
               onClick={() => {
                 setSuccessMessage(null)
-              }}>
+              }}
+            >
               編集
-            </Link>}
+            </Link>
+          )}
           <Link
             href={
               type === "player"
                 ? `/player/assign/${createQueryParams(commonId)}`
-                : type === "umpire" ? `/umpire/assign/${createQueryParams(commonId)}`
+                : type === "umpire"
+                  ? `/umpire/assign/${createQueryParams(commonId)}`
                   : `/course/assign/${createQueryParams(commonId)}`
             }
-            className={
-              "flex btn mx-auto m-3 ml-5 " +
-              (commonId === null || commonId?.length === 0 ? "pointer-events-none btn-disabled" : "btn-primary")
-            }
+            className={`flex btn mx-auto m-3 ml-5 ${
+              commonId === null || commonId?.length === 0
+                ? "pointer-events-none btn-disabled"
+                : "btn-primary"
+            }`}
             aria-disabled={commonId === null || commonId?.length === 0}
-            tabIndex={commonId === null || commonId?.length === 0 ? -1 : undefined}
-            onClick={() => {
-              setSuccessMessage(null)
-            }}>
+            tabIndex={
+              commonId === null || commonId?.length === 0 ? -1 : undefined
+            }
+            onClick={() => setSuccessMessage(null)}
+          >
             大会割当
           </Link>
           <Link
             href={
               type === "player"
                 ? `/player/delete/${createQueryParams(commonId)}`
-                : type === "umpire" ? `/umpire/delete/${createQueryParams(commonId)}`
+                : type === "umpire"
+                  ? `/umpire/delete/${createQueryParams(commonId)}`
                   : `/course/delete/${createQueryParams(commonId)}`
             }
-            className={
-              "flex btn mx-auto m-3 ml-5 " +
-              (commonId === null || commonId?.length === 0 ? "pointer-events-none btn-disabled" : "btn-warning")
-            }
+            className={`flex btn mx-auto m-3 ml-5 ${
+              commonId === null || commonId?.length === 0
+                ? "pointer-events-none btn-disabled"
+                : "btn-warning"
+            }`}
             aria-disabled={commonId === null || commonId?.length === 0}
-            tabIndex={commonId === null || commonId?.length === 0 ? -1 : undefined}
-            onClick={() => {
-              setSuccessMessage(null)
-            }}>
+            tabIndex={
+              commonId === null || commonId?.length === 0 ? -1 : undefined
+            }
+            onClick={() => setSuccessMessage(null)}
+          >
             削除
           </Link>
         </div>
@@ -103,7 +131,7 @@ export const View = ({ type, initialCommonDataList }: ViewProps) => {
   }
 
   // 新規登録UIを持つView
-  const ViewWithRegister = () => {
+  function ViewWithRegister() {
     const [commonId, setCommonId] = useState<number[] | null>(null)
     return (
       <div className="lg:flex lg:flex-row">
@@ -121,7 +149,9 @@ export const View = ({ type, initialCommonDataList }: ViewProps) => {
             setSuccessMessage={setSuccessMessage}
             setErrorMessage={setErrorMessage}
             setCommonDataList={
-              setCommonDataList as React.Dispatch<React.SetStateAction<SelectPlayer[] | SelectUmpire[]>>
+              setCommonDataList as React.Dispatch<
+                React.SetStateAction<SelectPlayer[] | SelectUmpire[]>
+              >
             }
           />
         </div>
@@ -130,7 +160,7 @@ export const View = ({ type, initialCommonDataList }: ViewProps) => {
   }
 
   // 新規登録UIを持たないView
-  const ViewNoRegister = () => {
+  function ViewNoRegister() {
     const [commonId, setCommonId] = useState<number[] | null>(null)
     return (
       <>
@@ -144,7 +174,9 @@ export const View = ({ type, initialCommonDataList }: ViewProps) => {
     )
   }
 
-  return (
-    type === "player" || type === "umpire" ? <ViewWithRegister /> : <ViewNoRegister />
+  return type === "player" || type === "umpire" ? (
+    <ViewWithRegister />
+  ) : (
+    <ViewNoRegister />
   )
 }

--- a/app/config/tabs.tsx
+++ b/app/config/tabs.tsx
@@ -3,7 +3,7 @@ import { useState } from "react"
 import Link from "next/link"
 import { CommonRadioList } from "@/app/components/common/commonList"
 import type { SelectCompetition, SelectPlayer, SelectUmpire, SelectCourse } from "@/app/lib/db/schema"
-import CommonRegister from "@/app/components/common/commonRegister"
+import { CommonRegister } from "@/app/components/common/commonRegister"
 import { BackLabelWithIcon } from "@/app/lib/const"
 
 type CompetitionListTabProps = {


### PR DESCRIPTION
## Sourceryによるサマリー

共通コンポーネントにコードフォーマットとlintの更新を適用し、命名規則、型アノテーション、JSXスタイルを標準化すると同時に、キーボード操作によるアクセシビリティの向上を導入します。

機能拡張:
- propsと型をPascalCaseにリネームし、匿名コンポーネントを名前付き関数宣言に変換
- 明示的なボタンタイプとキーボードイベントハンドラを追加し、モーダルとリスト項目のアクセシビリティを向上
- API URLと文字列連結全体で、テンプレートリテラルと一貫性のある分割代入を使用
- lintルールに従って、インポート順序、スペーシング、JSX/TSX構文を統一的にフォーマット

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Apply code formatting and linting updates to common components, standardizing naming conventions, type annotations, and JSX style while introducing keyboard accessibility enhancements

Enhancements:
- Rename props and types to PascalCase and convert anonymous components to named function declarations
- Add explicit button types and keyboard event handlers for improved accessibility in modals and list items
- Use template literals and consistent destructuring across API URLs and string concatenations
- Uniformly format import ordering, spacing, and JSX/TSX syntax according to linting rules

</details>