### PR TITLE
chore(part13): format @auth files

### DIFF
--- a/app/@auth/signIn/layout.tsx
+++ b/app/@auth/signIn/layout.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from "react"
 import "@/app/globals.css"
-import { PageLoading } from "@/app/components/parts/pageLoading"
 import type React from "react"
+import { PageLoading } from "@/app/components/parts/pageLoading"
 
 export default function Layout({
   children,

--- a/app/@auth/signIn/page.tsx
+++ b/app/@auth/signIn/page.tsx
@@ -1,19 +1,19 @@
 "use client"
 
+import { useSearchParams } from "next/navigation"
+import { useActionState, useEffect } from "react"
 import {
   ModalBackButton,
   ModalBackdrop,
 } from "@/app/components/common/commonModal"
 import { signInAction } from "@/app/components/server/auth"
 import { SIGN_IN_CONST } from "@/app/lib/const"
-import { useSearchParams } from "next/navigation"
-import { useActionState, useEffect } from "react"
 
 export default function SignIn() {
   const params = useSearchParams()
   const rawCallbackUrl = params.get("callbackUrl") || "/"
   // クロスサイトスクリプティング&フィッシング攻撃対策
-  const getSafeCallbackUrl = (cb: string) => {
+  function getSafeCallbackUrl(cb: string) {
     try {
       const url = new URL(cb, window.location.origin)
       if (


### PR DESCRIPTION
## Sourceryによるサマリー

@authサインインページとレイアウトのフォーマットとimportの順序を標準化

機能拡張:
- page.tsxとlayout.tsxでimportの順序を整理し、一貫性を持たせました。
- `getSafeCallbackUrl`をアロー関数から関数宣言に変換しました。
- 不要な空白行を削除し、layout内の`PageLoading`のimportを復元しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize formatting and import ordering in the @auth sign-in pages and layout

Enhancements:
- Reorder and group imports consistently in page.tsx and layout.tsx
- Convert getSafeCallbackUrl from arrow function to function declaration
- Remove redundant blank lines and restore PageLoading import in the layout

</details>