### PR TITLE
build: version up dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "next-auth": "^5.0.0-beta.28",
         "next-navigation-guard": "^0.1.2",
         "next-rspack": "canary",
-        "pg": "^8.16.1",
+        "pg": "^8.16.2",
         "postcss": "^8.5.6",
         "tailwindcss": "^4.1.10",
         "typescript": "^5.8.3",
@@ -2827,15 +2827,15 @@
       }
     },
     "node_modules/pg": {
-      "version": "8.16.1",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.1.tgz",
-      "integrity": "sha512-5n6e7MgF5ABRsssOsX9xC95p+NUuhgDQDBSsrKSZJjYVqZHGyrmJuknym2IbVhGtzV9siBdzH9SEIQAuWF+sdg==",
+      "version": "8.16.2",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.2.tgz",
+      "integrity": "sha512-OtLWF0mKLmpxelOt9BqVq83QV6bTfsS0XLegIeAKqKjurRnRKie1Dc1iL89MugmSLhftxw6NNCyZhm1yQFLMEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
-        "pg-protocol": "^1.10.1",
+        "pg-protocol": "^1.10.2",
         "pg-types": "2.2.0",
         "pgpass": "1.0.5"
       },
@@ -2890,9 +2890,9 @@
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.1.tgz",
-      "integrity": "sha512-9YS3ZonDj0Lxny//aF0ITPdfrEPgKWCJvONsSXAaIUhgpzlzl5JgaZNlbTFxvYNfm2terGEnHeOSUlF6qRGBzw==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.2.tgz",
+      "integrity": "sha512-Ci7jy8PbaWxfsck2dwZdERcDG2A0MG8JoQILs+uZNjABFuBuItAZCWUNz8sXRDMoui24rJw7WlXqgpMdBSN/vQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "next-auth": "^5.0.0-beta.28",
     "next-navigation-guard": "^0.1.2",
     "next-rspack": "canary",
-    "pg": "^8.16.1",
+    "pg": "^8.16.2",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.10",
     "typescript": "^5.8.3",


### PR DESCRIPTION
## Sourceryによるサマリー

ビルド：
- package.jsonとpackage-lock.jsonにおいて、pgのバージョンを^8.16.1から^8.16.2に上げました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Bump pg from ^8.16.1 to ^8.16.2 in package.json and package-lock.json.

</details>