### PR TITLE
refactor: clean up type definitions and improve state initialization …

### DIFF
--- a/app/components/common/commonList.tsx
+++ b/app/components/common/commonList.tsx
@@ -11,11 +11,11 @@ import type {
 type CommonListProps = {
   type: "player" | "umpire" | "course" | "competition"
   commonDataList:
-    | SelectPlayer[]
-    | SelectUmpire[]
-    | SelectCompetition[]
-    | SelectPlayerWithCompetition[]
-    | SelectUmpireWithCompetition[]
+  | SelectPlayer[]
+  | SelectUmpire[]
+  | SelectCompetition[]
+  | SelectPlayerWithCompetition[]
+  | SelectUmpireWithCompetition[]
 }
 
 function TableComponent({
@@ -24,11 +24,11 @@ function TableComponent({
 }: {
   type: CommonListProps["type"]
   common:
-    | SelectPlayer
-    | SelectUmpire
-    | SelectCompetition
-    | SelectPlayerWithCompetition
-    | SelectUmpireWithCompetition
+  | SelectPlayer
+  | SelectUmpire
+  | SelectCompetition
+  | SelectPlayerWithCompetition
+  | SelectUmpireWithCompetition
 }) {
   return (
     <>
@@ -214,8 +214,8 @@ export function CommonCheckboxList({
   setCommonId,
 }: {
   props: CommonListProps
-  commonId: number[] | null
-  setCommonId: React.Dispatch<React.SetStateAction<number[] | null>>
+  commonId: number[]
+  setCommonId: React.Dispatch<React.SetStateAction<number[]>>
 }) {
   function handleCheckboxChange(id: number) {
     if (!commonId) {

--- a/app/components/common/view.tsx
+++ b/app/components/common/view.tsx
@@ -70,11 +70,10 @@ export function View({
           {type === "course" && (
             <Link
               href={`/course/edit/${createQueryParams(commonId)}`}
-              className={`flex btn mx-auto m-3 ${
-                commonId?.length !== 1
+              className={`flex btn mx-auto m-3 ${commonId?.length !== 1
                   ? "pointer-events-none btn-disabled"
                   : "btn-primary"
-              }`}
+                }`}
               aria-disabled={commonId?.length !== 1}
               tabIndex={commonId?.length !== 1 ? -1 : undefined}
               onClick={() => {
@@ -92,11 +91,10 @@ export function View({
                   ? `/umpire/assign/${createQueryParams(commonId)}`
                   : `/course/assign/${createQueryParams(commonId)}`
             }
-            className={`flex btn mx-auto m-3 ml-5 ${
-              commonId === null || commonId?.length === 0
+            className={`flex btn mx-auto m-3 ml-5 ${commonId === null || commonId?.length === 0
                 ? "pointer-events-none btn-disabled"
                 : "btn-primary"
-            }`}
+              }`}
             aria-disabled={commonId === null || commonId?.length === 0}
             tabIndex={
               commonId === null || commonId?.length === 0 ? -1 : undefined
@@ -113,11 +111,10 @@ export function View({
                   ? `/umpire/delete/${createQueryParams(commonId)}`
                   : `/course/delete/${createQueryParams(commonId)}`
             }
-            className={`flex btn mx-auto m-3 ml-5 ${
-              commonId === null || commonId?.length === 0
+            className={`flex btn mx-auto m-3 ml-5 ${commonId === null || commonId?.length === 0
                 ? "pointer-events-none btn-disabled"
                 : "btn-warning"
-            }`}
+              }`}
             aria-disabled={commonId === null || commonId?.length === 0}
             tabIndex={
               commonId === null || commonId?.length === 0 ? -1 : undefined
@@ -133,7 +130,7 @@ export function View({
 
   // 新規登録UIを持つView
   function ViewWithRegister() {
-    const [commonId, setCommonId] = useState<number[] | null>(null)
+    const [commonId, setCommonId] = useState<number[]>([])
     return (
       <div className="lg:flex lg:flex-row">
         <div className="flex-col lg:w-2/3">
@@ -162,7 +159,7 @@ export function View({
 
   // 新規登録UIを持たないView
   function ViewNoRegister() {
-    const [commonId, setCommonId] = useState<number[] | null>(null)
+    const [commonId, setCommonId] = useState<number[]>([])
     return (
       <>
         <CommonCheckboxList


### PR DESCRIPTION
…in common components

-commonIdの初期値を[]空配列にする。
以下コンソールエラーのデバッグ
A component is changing an uncontrolled input to be controlled. This is likely caused by the value changing from undefined to a defined value, which should not happen. Decide between using a controlled or uncontrolled input element for the lifetime of the component.

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

- [ ] Documentation (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- 
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

## Sourceryによるサマリー

共通コンポーネントをリファクタリングし、空の配列として初期化された非nullの `commonId` ステートを使用するようにし、関連する型定義をクリーンアップして、制御されていない入力に関する警告を排除します。

バグ修正：
- `commonId` ステートを空の配列として初期化し、制御されていない入力から制御された入力への警告を防ぎます。

機能拡張：
- `CommonListProps` および `TableComponent` の `commonDataList` および `common` プロパティの union 型のフォーマットを標準化します。
- nullable な `commonId` の型定義を削除し、ボタンの disabled ロジックと className の条件を、新しい非nullの `number[]` ステートで動作するように更新します。

<details>
<summary>Original summary in English</summary>

## Sourceryによるサマリー

共通コンポーネントをリファクタリングし、`commonId`を非nullの空配列として初期化、関連する型定義を整理し、非制御入力から制御入力への警告を削除します。

バグ修正:
- `commonId`の状態を`null`ではなく空配列として初期化し、非制御入力から制御入力への警告を防ぎます。

機能拡張:
- `CommonListProps`と`TableComponent`で、共用体の型フォーマットを標準化します。
- nullableな`commonId`型を削除し、disabled状態とclassNameロジックを更新して、非nullの`number[]`状態で動作するようにします。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor common components to initialize `commonId` as a non-null empty array, clean up related type definitions, and remove uncontrolled-to-controlled input warnings.

Bug Fixes:
- Initialize `commonId` state to an empty array instead of `null` to prevent uncontrolled-to-controlled input warnings.

Enhancements:
- Standardize union type formatting in `CommonListProps` and `TableComponent`.
- Remove nullable `commonId` types and update disabled-state and className logic to work with a non-null `number[]` state.

</details>

</details>