### PR TITLE
build: version up dependencies

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -8,7 +8,6 @@
   },
   "linter": {
     "rules": {
-      "nursery": "error",
       "style": {
         "noUselessElse": "error",
         "useBlockStatements": "error"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,13 @@
       "name": "robopo",
       "version": "0.1.0",
       "dependencies": {
-        "@auth/drizzle-adapter": "^1.9.1",
+        "@auth/drizzle-adapter": "^1.10.0",
         "next": "^15.3.4",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.0.0",
+        "@biomejs/biome": "^2.0.4",
         "@heroicons/react": "^2.2.0",
         "@tailwindcss/postcss": "^4.1.10",
         "@types/node": "^24.0.3",
@@ -24,7 +24,7 @@
         "daisyui": "^5.0.43",
         "drizzle-kit": "^0.31.1",
         "drizzle-orm": "^0.44.2",
-        "next-auth": "^5.0.0-beta.28",
+        "next-auth": "^5.0.0-beta.29",
         "next-navigation-guard": "^0.1.2",
         "next-rspack": "canary",
         "pg": "^8.16.2",
@@ -62,9 +62,9 @@
       }
     },
     "node_modules/@auth/core": {
-      "version": "0.39.1",
-      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.39.1.tgz",
-      "integrity": "sha512-McD8slui0oOA1pjR5sPjLPl5Zm//nLP/8T3kr8hxIsvNLvsiudYvPHhDFPjh1KcZ2nFxCkZmP6bRxaaPd/AnLA==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.40.0.tgz",
+      "integrity": "sha512-n53uJE0RH5SqZ7N1xZoMKekbHfQgjd0sAEyUbE+IYJnmuQkbvuZnXItCU7d+i7Fj8VGOgqvNO7Mw4YfBTlZeQw==",
       "license": "ISC",
       "dependencies": {
         "@panva/hkdf": "^1.2.1",
@@ -91,18 +91,18 @@
       }
     },
     "node_modules/@auth/drizzle-adapter": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@auth/drizzle-adapter/-/drizzle-adapter-1.9.1.tgz",
-      "integrity": "sha512-WQ4vtDxpo3jAPfSLJbrjFx++/lMO1HJbV7ZwzCUBEkhqYMTrqQBJhLb+vcusDu95wiekVOUCPe1y6QSNbMeeYA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@auth/drizzle-adapter/-/drizzle-adapter-1.10.0.tgz",
+      "integrity": "sha512-3MKsdAINTfvV4QKev8PFMNG93HJEUHh9sggDXnmUmriFogRf8qLvgqnPsTlfUyWcLwTzzrrYjeu8CGM+4IxHwQ==",
       "license": "ISC",
       "dependencies": {
-        "@auth/core": "0.39.1"
+        "@auth/core": "0.40.0"
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.0.0.tgz",
-      "integrity": "sha512-BlUoXEOI/UQTDEj/pVfnkMo8SrZw3oOWBDrXYFT43V7HTkIUDkBRY53IC5Jx1QkZbaB+0ai1wJIfYwp9+qaJTQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.0.4.tgz",
+      "integrity": "sha512-DNA++xe+E7UugTvI/HhzSFl6OwrVgU8SIV0Mb2fPtWPk2/oTr4eOSA5xy1JECrvgJeYxurmUBOS49qxv/OUkrQ==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -116,20 +116,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.0.0",
-        "@biomejs/cli-darwin-x64": "2.0.0",
-        "@biomejs/cli-linux-arm64": "2.0.0",
-        "@biomejs/cli-linux-arm64-musl": "2.0.0",
-        "@biomejs/cli-linux-x64": "2.0.0",
-        "@biomejs/cli-linux-x64-musl": "2.0.0",
-        "@biomejs/cli-win32-arm64": "2.0.0",
-        "@biomejs/cli-win32-x64": "2.0.0"
+        "@biomejs/cli-darwin-arm64": "2.0.4",
+        "@biomejs/cli-darwin-x64": "2.0.4",
+        "@biomejs/cli-linux-arm64": "2.0.4",
+        "@biomejs/cli-linux-arm64-musl": "2.0.4",
+        "@biomejs/cli-linux-x64": "2.0.4",
+        "@biomejs/cli-linux-x64-musl": "2.0.4",
+        "@biomejs/cli-win32-arm64": "2.0.4",
+        "@biomejs/cli-win32-x64": "2.0.4"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.0.0.tgz",
-      "integrity": "sha512-QvqWYtFFhhxdf8jMAdJzXW+Frc7X8XsnHQLY+TBM1fnT1TfeV/v9vsFI5L2J7GH6qN1+QEEJ19jHibCY2Ypplw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.0.4.tgz",
+      "integrity": "sha512-r5McIUMMiedwJ2rltuXhj0+w0W7IJLpkOS+OGCVZQQOOcrGY9gUSUmOo7O6Z7P0vlv5YYZkPbi+qR9MDDWRBSw==",
       "cpu": [
         "arm64"
       ],
@@ -144,9 +144,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.0.0.tgz",
-      "integrity": "sha512-5JFhls1EfmuIH4QGFPlNpxJQFC6ic3X1ltcoLN+eSRRIPr6H/lUS1ttuD0Fj7rPgPhZqopK/jfH8UVj/1hIsQw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.0.4.tgz",
+      "integrity": "sha512-aV5Zc/3E3aXFbrjK1IgCMEQc+6PCkBL+NS+vtjoNM2VPFeM5OL5Q82BI4YZyPnebj+k42BPIoYtz0jJ95PGRRg==",
       "cpu": [
         "x64"
       ],
@@ -161,9 +161,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.0.0.tgz",
-      "integrity": "sha512-BAH4QVi06TzAbVchXdJPsL0Z/P87jOfes15rI+p3EX9/EGTfIjaQ9lBVlHunxcmoptaA5y1Hdb9UYojIhmnjIw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.0.4.tgz",
+      "integrity": "sha512-nlJhf7DyuajMj+S7Ygum59cbrHvI/nSRvedfJcEIx4X7SsiZjpRUiC5XtEn77kg7NIKq/KqG5roQIHkmjuFHCw==",
       "cpu": [
         "arm64"
       ],
@@ -178,9 +178,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.0.0.tgz",
-      "integrity": "sha512-Bxsz8ki8+b3PytMnS5SgrGV+mbAWwIxI3ydChb/d1rURlJTMdxTTq5LTebUnlsUWAX6OvJuFeiVq9Gjn1YbCyA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.0.4.tgz",
+      "integrity": "sha512-cNukq2PthoOa7quqaKoEFz4Zd1pDPJGfTR5jVyk9Z9iFHEm6TI7+7eeIs3aYcEuuJPNFR9xhJ4Uj3E2iUWkV3A==",
       "cpu": [
         "arm64"
       ],
@@ -195,9 +195,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.0.0.tgz",
-      "integrity": "sha512-09PcOGYTtkopWRm6mZ/B6Mr6UHdkniUgIG/jLBv+2J8Z61ezRE+xQmpi3yNgUrFIAU4lPA9atg7mhvE/5Bo7Wg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.0.4.tgz",
+      "integrity": "sha512-jlzrNZ+OzN9wvp2RL3cl5Y4NiV7xSU+QV5A8bWXke1on3jKy7QbXajybSjVQ6aFw1gdrqkO/W8xV5HODhIMT4g==",
       "cpu": [
         "x64"
       ],
@@ -212,9 +212,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.0.0.tgz",
-      "integrity": "sha512-tiQ0ABxMJb9I6GlfNp0ulrTiQSFacJRJO8245FFwE3ty3bfsfxlU/miblzDIi+qNrgGsLq5wIZcVYGp4c+HXZA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.0.4.tgz",
+      "integrity": "sha512-oWQALSbp8xF0t/wiHU2zdkZOpIHyaI9QxQv0Ytty9GAKsCGP6pczp8qyKD/P49iGJdDozHp5KiuQPxs33APhyA==",
       "cpu": [
         "x64"
       ],
@@ -229,9 +229,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.0.0.tgz",
-      "integrity": "sha512-vrTtuGu91xNTEQ5ZcMJBZuDlqr32DWU1r14UfePIGndF//s2WUAmer4FmgoPgruo76rprk37e8S2A2c0psXdxw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.0.4.tgz",
+      "integrity": "sha512-/PbNhMJo9ONja7hOxLlifM/qgeHpRD9bF2flTz5KIrXnQqpuegaRuwP/HYdJ9TFkTKFjHkPLoE4onOz3HIT5CQ==",
       "cpu": [
         "arm64"
       ],
@@ -246,9 +246,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.0.0.tgz",
-      "integrity": "sha512-2USVQ0hklNsph/KIR72ZdeptyXNnQ3JdzPn3NbjI4Sna34CnxeiYAaZcZzXPDl5PYNFBivV4xmvT3Z3rTmyDBg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.0.4.tgz",
+      "integrity": "sha512-dIM4SgO4/Rmsb4X7fwKtciQ682SZDSC1lm42uSM9gt8zNqBIeTaqsMc6eO1DpxYWMlAb/n2SML9+HUHmCib7NA==",
       "cpu": [
         "x64"
       ],
@@ -2740,13 +2740,13 @@
       }
     },
     "node_modules/next-auth": {
-      "version": "5.0.0-beta.28",
-      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.28.tgz",
-      "integrity": "sha512-2RDR1h3DJb4nizcd5UBBwC2gtyP7j/jTvVLvEtDaFSKUWNfou3Gek2uTNHSga/Q4I/GF+OJobA4mFbRaWJgIDQ==",
+      "version": "5.0.0-beta.29",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.29.tgz",
+      "integrity": "sha512-Ukpnuk3NMc/LiOl32njZPySk7pABEzbjhMUFd5/n10I0ZNC7NCuVv8IY2JgbDek2t/PUOifQEoUiOOTLy4os5A==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@auth/core": "0.39.1"
+        "@auth/core": "0.40.0"
       },
       "peerDependencies": {
         "@simplewebauthn/browser": "^9.0.1",
@@ -2818,9 +2818,9 @@
       }
     },
     "node_modules/oauth4webapi": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.5.2.tgz",
-      "integrity": "sha512-VYz5BaP3izIrUc1GAVzIoz4JnljiW0YAUFObMBwsqDnfHxz2sjLu3W7/8vE8Ms9IbMewN9+1kcvhY3tMscAeGQ==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.5.3.tgz",
+      "integrity": "sha512-2bnHosmBLAQpXNBLOvaJMyMkr4Yya5ohE5Q9jqyxiN+aa7GFCzvDN1RRRMrp0NkfqRR2MTaQNkcSUCCjILD9oQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"

--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
     "lint": "biome check --write"
   },
   "dependencies": {
-    "@auth/drizzle-adapter": "^1.9.1",
+    "@auth/drizzle-adapter": "^1.10.0",
     "next": "^15.3.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.0.0",
+    "@biomejs/biome": "^2.0.4",
     "@heroicons/react": "^2.2.0",
     "@tailwindcss/postcss": "^4.1.10",
     "@types/node": "^24.0.3",
@@ -25,7 +25,7 @@
     "daisyui": "^5.0.43",
     "drizzle-kit": "^0.31.1",
     "drizzle-orm": "^0.44.2",
-    "next-auth": "^5.0.0-beta.28",
+    "next-auth": "^5.0.0-beta.29",
     "next-navigation-guard": "^0.1.2",
     "next-rspack": "canary",
     "pg": "^8.16.2",


### PR DESCRIPTION
## Sourceryによるサマリー

いくつかのパッケージ依存関係を最新バージョンに更新

雑務:
- @auth/drizzle-adapter を ^1.10.0 に更新
- @biomejs/biome を ^2.0.4 に更新
- next-auth を ^5.0.0-beta.29 に更新

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update several package dependencies to their latest versions

Chores:
- Bump @auth/drizzle-adapter to ^1.10.0
- Bump @biomejs/biome to ^2.0.4
- Bump next-auth to ^5.0.0-beta.29

</details>