### PR TITLE
refactor: improve type definitions and reorganize imports in auth module

### DIFF
--- a/app/lib/auth.ts
+++ b/app/lib/auth.ts
@@ -1,7 +1,5 @@
 import type { User } from "next-auth"
-// biome-ignore lint/nursery/noUnresolvedImports: zodは依存関係として含まれているため、解決可能
 import { z } from "zod"
-// biome-ignore lint/nursery/noUnresolvedImports: @/app/lib/constはプロジェクト内のモジュールであり、解決可能
 import { BASE_URL } from "@/app/lib/const"
 
 const credentialsSchema: z.ZodSchema<{ username: string; password: string }> =

--- a/app/lib/auth.ts
+++ b/app/lib/auth.ts
@@ -1,13 +1,19 @@
-import { BASE_URL } from "@/app/lib/const"
 import type { User } from "next-auth"
+// biome-ignore lint/nursery/noUnresolvedImports: zodは依存関係として含まれているため、解決可能
 import { z } from "zod"
+// biome-ignore lint/nursery/noUnresolvedImports: @/app/lib/constはプロジェクト内のモジュールであり、解決可能
+import { BASE_URL } from "@/app/lib/const"
 
-const credentialsSchema = z.object({
-  username: z.string().nonempty(),
-  password: z.string().nonempty(),
-})
+const credentialsSchema: z.ZodSchema<{ username: string; password: string }> =
+  z.object({
+    username: z.string().nonempty(),
+    password: z.string().nonempty(),
+  })
 
-export function parsedCredentials(input: unknown) {
+export function parsedCredentials(input: unknown): {
+  username: string
+  password: string
+} {
   const result = credentialsSchema.safeParse(input)
   if (!result.success) {
     throw new Error("Invalid credentials")
@@ -15,7 +21,11 @@ export function parsedCredentials(input: unknown) {
   return result.data
 }
 
-export async function fetchUser(username: string, password: string) {
+export async function fetchUser(
+  username: string,
+  password: string,
+): Promise<User | null> {
+  console.log("{BASE_URL}", BASE_URL)
   const response = await fetch(`${BASE_URL}/api/user/`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
-Dokployでサインインの際、[auth][error] CredentialsSignin
が出ているので、URLがきちんと設定できているか確認する。

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

- [ ] Documentation (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- 
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

## Sourceryによるサマリー

認証モジュールを改良し、型定義を強化、インポートを再編成し、BASE_URLのデバッグログを追加しました。

改善点：
- credentialsとユーザー取得のために、明示的なZodスキーマと関数の戻り値の型注釈を追加
- auth.ts内のインポートを、サードパーティとプロジェクトモジュールで並べ替え、lintの無視コメントを追加
- デバッグ目的で、fetchUserにBASE_URLのconsoleログを追加

<details>
<summary>Original summary in English</summary>

## Sourceryによるサマリー

authモジュールをリファクタリングし、Zodスキーマによる型安全性の強化、関数の戻り値の型注釈の追加、lint ignoreによるimportの再編成、およびBASE_URLのデバッグログの追加を行いました。

機能拡張:
- 明示的なZodスキーマ型とparsedCredentialsの型付き戻り値により、認証情報の検証を強化
- fetchUserに明示的な戻り値の型注釈を追加し、Promise<User | null>を保証
- importの順序を変更し、未解決の依存関係に対するbiome-ignore lintコメントを追加
- デバッグ用にfetchUserにBASE_URLのconsole.logを挿入

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the auth module by bolstering type safety with Zod schemas, annotating function return types, reorganizing imports with lint ignores, and adding a debug log for BASE_URL

Enhancements:
- Strengthen credentials validation with explicit Zod schema types and typed return for parsedCredentials
- Add explicit return type annotation for fetchUser to ensure Promise<User | null>
- Reorder imports and add biome-ignore lint comments for unresolved dependencies
- Insert console.log of BASE_URL in fetchUser for debugging

</details>

</details>