### PR TITLE
build: downgrade auth.js dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "robopo",
       "version": "0.1.0",
       "dependencies": {
-        "@auth/drizzle-adapter": "^1.10.0",
+        "@auth/drizzle-adapter": "^1.9.1",
         "next": "^15.3.4",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
@@ -24,7 +24,7 @@
         "daisyui": "^5.0.43",
         "drizzle-kit": "^0.31.1",
         "drizzle-orm": "^0.44.2",
-        "next-auth": "^5.0.0-beta.29",
+        "next-auth": "^5.0.0-beta.28",
         "next-navigation-guard": "^0.1.2",
         "next-rspack": "canary",
         "pg": "^8.16.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "biome check --write"
   },
   "dependencies": {
-    "@auth/drizzle-adapter": "^1.10.0",
+    "@auth/drizzle-adapter": "^1.9.1",
     "next": "^15.3.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
@@ -25,7 +25,7 @@
     "daisyui": "^5.0.43",
     "drizzle-kit": "^0.31.1",
     "drizzle-orm": "^0.44.2",
-    "next-auth": "^5.0.0-beta.29",
+    "next-auth": "^5.0.0-beta.28",
     "next-navigation-guard": "^0.1.2",
     "next-rspack": "canary",
     "pg": "^8.16.2",


### PR DESCRIPTION
## Sourceryによるサマリー

認証関連の2つの依存関係を以前の安定バージョンにダウングレードします。

ビルド：
- @auth/drizzle-adapterを^1.10.0から^1.9.1にダウングレード
- next-authを^5.0.0-beta.29から^5.0.0-beta.28にダウングレード

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Downgrade two authentication-related dependencies to earlier stable versions

Build:
- Downgrade @auth/drizzle-adapter from ^1.10.0 to ^1.9.1
- Downgrade next-auth from ^5.0.0-beta.29 to ^5.0.0-beta.28

</details>