### PR TITLE
build: version up auth.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "robopo",
       "version": "0.1.0",
       "dependencies": {
-        "@auth/drizzle-adapter": "^1.9.1",
+        "@auth/drizzle-adapter": "^1.10.0",
         "next": "^15.3.4",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
@@ -24,7 +24,7 @@
         "daisyui": "^5.0.43",
         "drizzle-kit": "^0.31.1",
         "drizzle-orm": "^0.44.2",
-        "next-auth": "^5.0.0-beta.28",
+        "next-auth": "^5.0.0-beta.29",
         "next-navigation-guard": "^0.1.2",
         "next-rspack": "canary",
         "pg": "^8.16.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "biome check --write"
   },
   "dependencies": {
-    "@auth/drizzle-adapter": "^1.9.1",
+    "@auth/drizzle-adapter": "^1.10.0",
     "next": "^15.3.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
@@ -25,7 +25,7 @@
     "daisyui": "^5.0.43",
     "drizzle-kit": "^0.31.1",
     "drizzle-orm": "^0.44.2",
-    "next-auth": "^5.0.0-beta.28",
+    "next-auth": "^5.0.0-beta.29",
     "next-navigation-guard": "^0.1.2",
     "next-rspack": "canary",
     "pg": "^8.16.2",


### PR DESCRIPTION
## Sourcery によるサマリー

認証関連の依存関係を最新バージョンに更新

ビルド：
- @auth/drizzle-adapter を ^1.10.0 に更新
- next-auth を ^5.0.0-beta.29 に更新

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bump authentication dependencies to their latest versions

Build:
- Update @auth/drizzle-adapter to ^1.10.0
- Update next-auth to ^5.0.0-beta.29

</details>