### PR TITLE
chore: add `noUnusedImports` rule to Biome

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -8,6 +8,9 @@
   },
   "linter": {
     "rules": {
+      "correctness": {
+        "noUnusedImports": "error"
+      },
       "nursery": {
         "useSortedClasses": "error"
       },


### PR DESCRIPTION
## Sourcery によるサマリー

雑務:
- `noUnusedImports` ルールを `biome.json` の lint 設定に追加

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Add noUnusedImports rule to biome.json lint configuration

</details>