### PR TITLE
build: version up dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@heroicons/react": "^2.2.0",
         "@tailwindcss/postcss": "^4.1.11",
         "@types/bcrypt": "^5.0.2",
-        "@types/node": "^24.0.7",
+        "@types/node": "^24.0.8",
         "@types/pg": "^8.15.4",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
@@ -1964,9 +1964,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.0.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.7.tgz",
-      "integrity": "sha512-YIEUUr4yf8q8oQoXPpSlnvKNVKDQlPMWrmOcgzoduo7kvA2UF0/BwJ/eMKFTiTtkNL17I0M6Xe2tvwFU7be6iw==",
+      "version": "24.0.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.8.tgz",
+      "integrity": "sha512-WytNrFSgWO/esSH9NbpWUfTMGQwCGIKfCmNlmFDNiI5gGhgMmEA+V1AEvKLeBNvvtBnailJtkrEa2OIISwrVAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@heroicons/react": "^2.2.0",
     "@tailwindcss/postcss": "^4.1.11",
     "@types/bcrypt": "^5.0.2",
-    "@types/node": "^24.0.7",
+    "@types/node": "^24.0.8",
     "@types/pg": "^8.15.4",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
@@ -39,9 +39,6 @@
   "overrides": {
     "@esbuild-kit/core-utils": {
       "esbuild": "0.25.5"
-    },
-    "next-navigation-guard": {
-      "react": "^19.0.0"
     }
   }
 }


### PR DESCRIPTION
## Sourceryによるサマリー

依存関係の更新とパッケージのオーバーライドの整理

ビルド:
- @types/node を 24.0.7 から 24.0.8 に更新

雑務:
- next-navigation-guard の React バージョンに対する不要なオーバーライドを削除

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update dependencies and clean up package overrides

Build:
- Bump @types/node from 24.0.7 to 24.0.8

Chores:
- Remove obsolete override for next-navigation-guard's React version

</details>