### PR TITLE
docs: split README.md for i18n

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,40 @@
+[English](README.md) | 日本語 | [简体中文](README.zh-CN.md)
+
+# Next.js プロジェクト (日本語)
+
+これは [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) で作成された [Next.js](https://nextjs.org/) プロジェクトです。
+
+## 🚀 はじめに
+
+まず、以下のコマンドで開発サーバーを起動します:
+
+```bash
+npm run dev
+# または
+yarn dev
+# または
+pnpm dev
+# または
+bun dev
+```
+
+ブラウザで [http://localhost:3000](http://localhost:3000) を開くと、結果が表示されます。
+
+ページの編集を始めるには、`app/page.tsx` を修正してください。ファイルを編集すると、ページは自動的に更新されます。
+
+このプロジェクトでは、カスタムGoogleフォントである「Inter」を自動的に最適化して読み込むために [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) を使用しています。
+
+## 📚 さらに詳しく
+
+Next.jsについてさらに学ぶには、以下のリソースをご覧ください:
+
+-   [Next.js ドキュメント](https://nextjs.org/docs) - Next.jsの機能とAPIについて解説しています。
+-   [Learn Next.js](https://nextjs.org/learn) - インタラクティブなNext.jsのチュートリアルです。
+
+[Next.jsのGitHubリポジトリ](https://github.com/vercel/next.js/)もぜひご覧ください。フィードバックやコントリビューションをお待ちしています！
+
+## Vercelへのデプロイ
+
+Next.jsアプリをデプロイする最も簡単な方法は、Next.jsの制作者であるVercelが提供する[Vercelプラットフォーム](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme)を利用することです。
+
+詳細については、[Next.jsのデプロイに関するドキュメント](https://nextjs.org/docs/deployment)をご確認ください。

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+English | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
+
 This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
 
 ## Getting Started
@@ -34,85 +36,3 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
-
----
-
-# Next.js プロジェクト (日本語)
-
-これは [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) で作成された [Next.js](https://nextjs.org/) プロジェクトです。
-
-## 🚀 はじめに
-
-まず、以下のコマンドで開発サーバーを起動します:
-
-```bash
-npm run dev
-# または
-yarn dev
-# または
-pnpm dev
-# または
-bun dev
-```
-
-ブラウザで [http://localhost:3000](http://localhost:3000) を開くと、結果が表示されます。
-
-ページの編集を始めるには、`app/page.tsx` を修正してください。ファイルを編集すると、ページは自動的に更新されます。
-
-このプロジェクトでは、カスタムGoogleフォントである「Inter」を自動的に最適化して読み込むために [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) を使用しています。
-
-## 📚 さらに詳しく
-
-Next.jsについてさらに学ぶには、以下のリソースをご覧ください:
-
--   [Next.js ドキュメント](https://nextjs.org/docs) - Next.jsの機能とAPIについて解説しています。
--   [Learn Next.js](https://nextjs.org/learn) - インタラクティブなNext.jsのチュートリアルです。
-
-[Next.jsのGitHubリポジトリ](https://github.com/vercel/next.js/)もぜひご覧ください。フィードバックやコントリビューションをお待ちしています！
-
-## Vercelへのデプロイ
-
-Next.jsアプリをデプロイする最も簡単な方法は、Next.jsの制作者であるVercelが提供する[Vercelプラットフォーム](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme)を利用することです。
-
-詳細については、[Next.jsのデプロイに関するドキュメント](https://nextjs.org/docs/deployment)をご確認ください。
-
----
-
-# Next.js 项目 (简体中文)
-
-这是一个使用 [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) 初始化的 [Next.js](https://nextjs.org/) 项目。
-
-## 🚀 开始
-
-首先，运行开发服务器：
-
-```bash
-npm run dev
-# 或
-yarn dev
-# 或
-pnpm dev
-# 或
-bun dev
-```
-
-在浏览器中打开 [http://localhost:3000](http://localhost:3000) 查看结果。
-
-您可以通过修改 `app/page.tsx` 来开始编辑页面。当您编辑文件时，页面会自动更新。
-
-该项目使用 [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) 来自动优化和加载 Inter，一个自定义的 Google 字体。
-
-## 📚 了解更多
-
-要了解有关 Next.js 的更多信息，请查看以下资源：
-
-- [Next.js 文档](https://nextjs.org/docs) - 了解 Next.js 的功能和 API。
-- [学习 Next.js](https://nextjs.org/learn) - 一个交互式的 Next.js 教程。
-
-您可以查看 [Next.js 的 GitHub 存储库](https://github.com/vercel/next.js/) - 欢迎您的反馈和贡献！
-
-## 在 Vercel 上部署
-
-部署 Next.js 应用程序最简单的方法是使用 Next.js 的创建者提供的 [Vercel 平台](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme)。
-
-有关更多详细信息，请查看我们的 [Next.js 部署文档](https://nextjs.org/docs/deployment)。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,40 @@
+[English](README.md) | [日本語](README.ja.md) | 简体中文
+
+# Next.js 项目 (简体中文)
+
+这是一个使用 [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) 初始化的 [Next.js](https://nextjs.org/) 项目。
+
+## 🚀 开始
+
+首先，运行开发服务器：
+
+```bash
+npm run dev
+# 或
+yarn dev
+# 或
+pnpm dev
+# 或
+bun dev
+```
+
+在浏览器中打开 [http://localhost:3000](http://localhost:3000) 查看结果。
+
+您可以通过修改 `app/page.tsx` 来开始编辑页面。当您编辑文件时，页面会自动更新。
+
+该项目使用 [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) 来自动优化和加载 Inter，一个自定义的 Google 字体。
+
+## 📚 了解更多
+
+要了解有关 Next.js 的更多信息，请查看以下资源：
+
+- [Next.js 文档](https://nextjs.org/docs) - 了解 Next.js 的功能和 API。
+- [学习 Next.js](https://nextjs.org/learn) - 一个交互式的 Next.js 教程。
+
+您可以查看 [Next.js 的 GitHub 存储库](https://github.com/vercel/next.js/) - 欢迎您的反馈和贡献！
+
+## 在 Vercel 上部署
+
+部署 Next.js 应用程序最简单的方法是使用 Next.js 的创建者提供的 [Vercel 平台](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme)。
+
+有关更多详细信息，请查看我们的 [Next.js 部署文档](https://nextjs.org/docs/deployment)。


### PR DESCRIPTION
## Sourcery によるサマリー

モノリシックな README を、英語、日本語、簡体字中国語の個別のファイルに分割し、言語選択リンクを追加しました。

ドキュメント：
- 日本語と簡体字中国語の翻訳用に README.ja.md と README.zh-CN.md を追加
- メインの README.md を更新して、インライン翻訳を削除し、ローカライズされたバージョンへのリンクを含める

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Split the monolithic README into separate English, Japanese, and Simplified Chinese files and added language selection links.

Documentation:
- Add README.ja.md and README.zh-CN.md for Japanese and Simplified Chinese translations
- Update main README.md to remove inline translations and include links to localized versions

</details>