### PR TITLE
refactor: update nextMissionPair handling and improve Field component…

### DIFF
--- a/app/challenge/challenge.tsx
+++ b/app/challenge/challenge.tsx
@@ -177,7 +177,7 @@ function IpponBashiSection({
           botPosition={botPosition}
           botDirection={botDirection}
           nextMissionPair={
-            isGoal ? missionPair[nowMission - 1] : missionPair[nowMission]
+            isGoal ? [null, null] : missionPair[nowMission]
           }
           onPanelClick={handleNext}
         />
@@ -447,8 +447,8 @@ export function Challenge({
     field: fieldState,
     botPosition,
     botDirection,
-    nextMissionPair: isGoal && nowMission > 0
-      ? missionPair[nowMission - 1]
+    nextMissionPair: isGoal
+      ? [null, null]
       : missionPair[nowMission],
     onPanelClick: handleNext,
     nowMission,

--- a/app/components/challenge/ipponBashi.tsx
+++ b/app/components/challenge/ipponBashi.tsx
@@ -1,7 +1,5 @@
 import type React from "react"
-import { NextArrow } from "@/app/components/course/nextArrow"
-import { Panel } from "@/app/components/course/panel"
-import { Robot } from "@/app/components/course/robot"
+import { Field } from "@/app/components/course/field"
 import {
   type FieldState,
   getPanelHeight,
@@ -22,7 +20,7 @@ export function IpponBashiUI({
   nextMissionPair: MissionValue[]
   onPanelClick: (row: number, col: number) => void
 }): React.JSX.Element {
-  const type: string = "ipponBashi"
+  const type: "ipponBashi" = "ipponBashi"
   // 一本橋の大きさ 幅1パネル 長さ5パネル 1パネル毎の大きさ60×60
   const width: number = 1
   const length: number = IPPON_BASHI_SIZE
@@ -41,34 +39,14 @@ export function IpponBashiUI({
   }
 
   return (
-    <div
-      className={`relative grid grid-cols-${width} grid-rows-${length} mx-auto`}
-      style={ipponBashiStyle}
-    >
-      {field.map((row, rowIndex) =>
-        row.map((panel, colIndex) => (
-          <Panel
-            key={`${rowIndex}-${colIndex}`}
-            value={panel}
-            type={type}
-            onClick={() => onPanelClick(rowIndex, colIndex)}
-          />
-        )),
-      )}
-      <Robot
-        row={botPosition.row}
-        col={botPosition.col}
-        direction={botDirection}
-        type={type}
-      />
-      <NextArrow
-        row={botPosition.row}
-        col={botPosition.col}
-        direction={botDirection}
-        nextMissionPair={nextMissionPair}
-        duration={1.5}
-        type={type}
-      />
-    </div>
+    <Field
+      field={field}
+      type={type}
+      botPosition={botPosition}
+      botDirection={botDirection}
+      nextMissionPair={nextMissionPair}
+      onPanelClick={onPanelClick}
+      customStyle={ipponBashiStyle}
+    />
   )
 }

--- a/app/components/course/field.tsx
+++ b/app/components/course/field.tsx
@@ -1,3 +1,4 @@
+import type React from "react"
 import { NextArrow } from "@/app/components/course/nextArrow"
 import { Panel } from "@/app/components/course/panel"
 import { Robot } from "@/app/components/course/robot"
@@ -10,53 +11,54 @@ import {
   type MissionValue,
 } from "@/app/components/course/utils"
 
-type EditProps = {
-  type: "edit"
+type FieldProps = {
   field: FieldState
+  type: "edit" | "challenge" | "ipponBashi"
+  botPosition?: { row: number; col: number }
+  botDirection?: MissionValue
+  nextMissionPair?: MissionValue[]
   onPanelClick: (row: number, col: number) => void
-}
-
-type ChalProps = {
-  type: "challenge"
-  field: FieldState
-  botPosition: { row: number; col: number }
-  botDirection: MissionValue
-  nextMissionPair: MissionValue[]
-  onPanelClick: (row: number, col: number) => void
+  customStyle?: React.CSSProperties
 }
 
 // Fieldを表すコンポーネント
-export function Field(props: EditProps | ChalProps) {
+export function Field({
+  field,
+  type,
+  botPosition,
+  botDirection,
+  nextMissionPair,
+  onPanelClick,
+  customStyle,
+}: FieldProps): React.JSX.Element {
+  const styles = customStyle ?? {
+    gridTemplateColumns: `repeat(${MAX_FIELD_WIDTH}, ${getPanelWidth()}px)`,
+    gridTemplateRows: `repeat(${MAX_FIELD_HEIGHT}, ${getPanelHeight()}px)`,
+  }
   return (
-    <div
-      className={`relative grid grid-cols-${MAX_FIELD_WIDTH} grid-rows-${MAX_FIELD_HEIGHT} mx-auto`}
-      style={{
-        gridTemplateColumns: `repeat(${MAX_FIELD_WIDTH}, ${getPanelWidth()}px)`,
-        gridTemplateRows: `repeat(${MAX_FIELD_HEIGHT}, ${getPanelHeight()}px)`,
-      }}
-    >
-      {props.field.map((row, rowIndex) =>
+    <div className={`relative mx-auto grid`} style={styles}>
+      {field.map((row, rowIndex) =>
         row.map((panel, colIndex) => (
           <Panel
             key={`panel-${rowIndex}-${colIndex}-${String(panel)}`}
             value={panel}
-            onClick={() => props.onPanelClick(rowIndex, colIndex)}
+            onClick={() => onPanelClick(rowIndex, colIndex)}
           />
         )),
       )}
       {/* challengeの時はbotを表示 */}
-      {props.type === "challenge" && (
+      {(type === "challenge" || type === "ipponBashi") && botPosition && botDirection && (
         <>
           <Robot
-            row={props.botPosition.row}
-            col={props.botPosition.col}
-            direction={props.botDirection}
+            row={botPosition.row}
+            col={botPosition.col}
+            direction={botDirection}
           />
           <NextArrow
-            row={props.botPosition.row}
-            col={props.botPosition.col}
-            direction={props.botDirection}
-            nextMissionPair={props.nextMissionPair}
+            row={botPosition.row}
+            col={botPosition.col}
+            direction={botDirection}
+            nextMissionPair={nextMissionPair}
             duration={1.5}
           />
         </>

--- a/app/components/course/nextArrow.tsx
+++ b/app/components/course/nextArrow.tsx
@@ -16,10 +16,14 @@ export function NextArrow({
   row: number
   col: number
   direction: MissionValue
-  nextMissionPair: MissionValue[]
+  nextMissionPair: MissionValue[] | undefined
   duration?: number // 点滅速度（秒）
   type?: string
 }) {
+  if (!nextMissionPair || nextMissionPair[0] === null || nextMissionPair[1] === null || nextMissionPair[0] === undefined || nextMissionPair[1] === undefined) {
+    // 次のミッションがない場合は何も表示しない
+    return null
+  }
   if (nextMissionPair[0] === "mf" || nextMissionPair[0] === "mb") {
     const [nextRow, nextCol] = getNextPosition(
       row,
@@ -27,6 +31,7 @@ export function NextArrow({
       direction,
       nextMissionPair[0],
       nextMissionPair[1],
+
     )
     return (
       <NextMoveArrow


### PR DESCRIPTION
… structure

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

- [ ] Documentation (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- 
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

## Sourceryによるサマリー

モード間でフィールドのレンダリングとボットのミッション矢印の処理をリファクタリングし、統一します。

バグ修正:
- `nextMissionPair` が欠落しているか、目標に達している場合に `NextArrow` がレンダリングされないようにします。

機能拡張:
- `Field` コンポーネントを統一し、編集、チャレンジ、および一本橋モードを、オプションのボットのpropsとカスタムスタイルで処理できるようにします。
- `IpponBashiUI` の実装を `Field` コンポーネントの再利用に置き換えます。
- ゴール時に `nextMissionPair` を `[null,null]` にデフォルト設定し、矢印を抑制します。

<details>
<summary>Original summary in English</summary>

## Sourceryによるサマリー

Fieldコンポーネントをリファクタリングし、複数のモードとカスタムスタイルをサポート、IpponBashi UIをFieldに統合、次のミッションがない場合にNextArrowのレンダリングをスキップするガードを追加、ゴール達成後に空のミッションペアを渡すようにChallengeを更新。

機能拡張:
- Fieldコンポーネントのpropsとレンダリングを、edit、challenge、ipponBashiモードで統一し、オプションのスタイル設定を可能にしました。
- IpponBashiUIの実装を、ipponBashi固有のスタイルを使用したFieldの呼び出しに置き換えました。
- nextMissionPairが存在しない場合にレンダリングを回避するため、NextArrowにnull/undefinedチェックを追加しました。
- ゴール達成時に、以前のミッションの代わりに[null,null]をnextMissionPairとして渡すようにChallengeコンポーネントを調整しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the Field component to support multiple modes and custom styling, consolidate the IpponBashi UI into Field, add guards in NextArrow to skip rendering when there’s no next mission, and update Challenge to pass an empty mission pair after goal completion.

Enhancements:
- Unify Field component props and rendering for edit, challenge, and ipponBashi modes with optional styling.
- Replace IpponBashiUI implementation with a Field invocation using ipponBashi-specific styles.
- Add null/undefined checks to NextArrow to avoid rendering when nextMissionPair is absent.
- Adjust Challenge component to pass [null,null] as nextMissionPair upon goal completion instead of the previous mission.

</details>

</details>