### PR TITLE
docs: update README.md paths

### DIFF
--- a/@robopo/web/README.ja.md
+++ b/@robopo/web/README.ja.md
@@ -1,4 +1,4 @@
-[English](README.md) | 日本語 | [简体中文](README.zh-CN.md)
+[English](/@robopo/web/README.md) | 日本語 | [简体中文](/@robopo/web/README.zh-CN.md)
 
 # Next.js プロジェクト (日本語)
 

--- a/@robopo/web/README.md
+++ b/@robopo/web/README.md
@@ -1,4 +1,4 @@
-English | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
+English | [日本語](/@robopo/web/README.ja.md) | [简体中文](/@robopo/web/README.zh-CN.md)
 
 This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
 

--- a/@robopo/web/README.zh-CN.md
+++ b/@robopo/web/README.zh-CN.md
@@ -1,4 +1,4 @@
-[English](README.md) | [日本語](README.ja.md) | 简体中文
+[English](/@robopo/web/README.md) | [日本語](/@robopo/web/README.ja.md) | 简体中文
 
 # Next.js 项目 (简体中文)
 


### PR DESCRIPTION
## Sourcery によるサマリー

ドキュメンテーション:
- 英語、日本語、中国語の README 全体で、相対的な README リンクを絶対パス `/ @robopo/web/` に置換します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Replace relative README links with absolute /@robopo/web/ paths across English, Japanese, and Chinese READMEs

</details>