### PR TITLE
build: version up dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
         "./@robopo/web"
       ],
       "devDependencies": {
-        "@biomejs/biome": "^2.1.0",
-        "@types/node": "^24.0.10"
+        "@biomejs/biome": "^2.1.1",
+        "@types/node": "^24.0.12"
       }
     },
     "@robopo/web": {
@@ -114,9 +114,9 @@
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.1.0.tgz",
-      "integrity": "sha512-K2UDr1dCiaOWegp4yQLMC4Evgl85ze1O7r+WxPeO7cNl0XrIcTshvdQGMDB23c/2afXz6RsOKYfWLErNbBbjmA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.1.1.tgz",
+      "integrity": "sha512-HFGYkxG714KzG+8tvtXCJ1t1qXQMzgWzfvQaUjxN6UeKv+KvMEuliInnbZLJm6DXFXwqVi6446EGI0sGBLIYng==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -130,20 +130,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.1.0",
-        "@biomejs/cli-darwin-x64": "2.1.0",
-        "@biomejs/cli-linux-arm64": "2.1.0",
-        "@biomejs/cli-linux-arm64-musl": "2.1.0",
-        "@biomejs/cli-linux-x64": "2.1.0",
-        "@biomejs/cli-linux-x64-musl": "2.1.0",
-        "@biomejs/cli-win32-arm64": "2.1.0",
-        "@biomejs/cli-win32-x64": "2.1.0"
+        "@biomejs/cli-darwin-arm64": "2.1.1",
+        "@biomejs/cli-darwin-x64": "2.1.1",
+        "@biomejs/cli-linux-arm64": "2.1.1",
+        "@biomejs/cli-linux-arm64-musl": "2.1.1",
+        "@biomejs/cli-linux-x64": "2.1.1",
+        "@biomejs/cli-linux-x64-musl": "2.1.1",
+        "@biomejs/cli-win32-arm64": "2.1.1",
+        "@biomejs/cli-win32-x64": "2.1.1"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.1.0.tgz",
-      "integrity": "sha512-RDXEUGSCvUx3PKWRt95WRtwH+l01slm7r2zaotDwWERn/RITMcdet21rI5q5cYhL4XJiAvLHG8qyLNSXqIOCwQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.1.1.tgz",
+      "integrity": "sha512-2Muinu5ok4tWxq4nu5l19el48cwCY/vzvI7Vjbkf3CYIQkjxZLyj0Ad37Jv2OtlXYaLvv+Sfu1hFeXt/JwRRXQ==",
       "cpu": [
         "arm64"
       ],
@@ -158,9 +158,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.1.0.tgz",
-      "integrity": "sha512-epLFRbMjYS/Cu9Kc5gM3wzUExsKj2Z0oxIiuxlI4ZterIqm19yvTOtJoqSec8gjUXOTNvPVoEIfSSXg37yepow==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.1.1.tgz",
+      "integrity": "sha512-cC8HM5lrgKQXLAK+6Iz2FrYW5A62pAAX6KAnRlEyLb+Q3+Kr6ur/sSuoIacqlp1yvmjHJqjYfZjPvHWnqxoEIA==",
       "cpu": [
         "x64"
       ],
@@ -175,9 +175,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.1.0.tgz",
-      "integrity": "sha512-HZys1/TeIH5lagwtf9yKSO+gtA+cYMJW22ckDGuKt2xIvPu7VqgTNjJtTdRcetXe0+benlMMo+KFs3xL2b/2QA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.1.1.tgz",
+      "integrity": "sha512-tw4BEbhAUkWPe4WBr6IX04DJo+2jz5qpPzpW/SWvqMjb9QuHY8+J0M23V8EPY/zWU4IG8Ui0XESapR1CB49Q7g==",
       "cpu": [
         "arm64"
       ],
@@ -192,9 +192,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.1.0.tgz",
-      "integrity": "sha512-J7z6s/M50wt5lhSkivAs2GJHPhiah3hkdg1LipM6wlK6cVC3YeIA/X6pgWBfjEwyfsFlpc3nRM+pQ17DI8FpDQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.1.1.tgz",
+      "integrity": "sha512-/7FBLnTswu4jgV9ttI3AMIdDGqVEPIZd8I5u2D4tfCoj8rl9dnjrEQbAIDlWhUXdyWlFSz8JypH3swU9h9P+2A==",
       "cpu": [
         "arm64"
       ],
@@ -209,9 +209,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.1.0.tgz",
-      "integrity": "sha512-nAVAP1ov/zcXMhNq3WCbYZmlU/YTF3ZT+LeXR1CEJnDgunPC/Srp7j1LWlrIx6wxNOCDOFow8fmyfC7c/BKLig==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.1.1.tgz",
+      "integrity": "sha512-3WJ1GKjU7NzZb6RTbwLB59v9cTIlzjbiFLDB0z4376TkDqoNYilJaC37IomCr/aXwuU8QKkrYoHrgpSq5ffJ4Q==",
       "cpu": [
         "x64"
       ],
@@ -226,9 +226,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.1.0.tgz",
-      "integrity": "sha512-uj8felYcBeXh32kznnKrAQoZ9pLqta/6qvwLJ4AZtUmY6cSUUa5c+VLnFtxMfuhvps/M4D55VGnwSINOEblPQg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.1.1.tgz",
+      "integrity": "sha512-kUu+loNI3OCD2c12cUt7M5yaaSjDnGIksZwKnueubX6c/HWUyi/0mPbTBHR49Me3F0KKjWiKM+ZOjsmC+lUt9g==",
       "cpu": [
         "x64"
       ],
@@ -243,9 +243,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.1.0.tgz",
-      "integrity": "sha512-eGGqGs+8Q34n1zp/rEadFRKjzwFszpZ2+p6B1Dmi7dn1DNEYhNXoRWLcjyca+ZSTrdV7COx0scyjgF9Tg73kBw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.1.1.tgz",
+      "integrity": "sha512-vEHK0v0oW+E6RUWLoxb2isI3rZo57OX9ZNyyGH701fZPj6Il0Rn1f5DMNyCmyflMwTnIQstEbs7n2BxYSqQx4Q==",
       "cpu": [
         "arm64"
       ],
@@ -260,9 +260,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.1.0.tgz",
-      "integrity": "sha512-pkp6jucyvE8DJSXXwSKs+Mxx1KXkMJ2d8GbBu4Lf0nAQHl40TZjjp1RuNEo9Z7NNXPQzbLACDtK6/vDalO2WRg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.1.1.tgz",
+      "integrity": "sha512-i2PKdn70kY++KEF/zkQFvQfX1e8SkA8hq4BgC+yE9dZqyLzB/XStY2MvwI3qswlRgnGpgncgqe0QYKVS1blksg==",
       "cpu": [
         "x64"
       ],
@@ -2318,9 +2318,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.0.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.10.tgz",
-      "integrity": "sha512-ENHwaH+JIRTDIEEbDK6QSQntAYGtbvdDXnMXnZaZ6k13Du1dPMmprkEHIL7ok2Wl2aZevetwTAb5S+7yIF+enA==",
+      "version": "24.0.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.12.tgz",
+      "integrity": "sha512-LtOrbvDf5ndC9Xi+4QZjVL0woFymF/xSTKZKPgrrl7H7XoeDvnD+E2IclKVDyaK9UM756W/3BXqSU+JEHopA9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "check": "biome check --write"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.1.0",
-    "@types/node": "^24.0.10"
+    "@biomejs/biome": "^2.1.1",
+    "@types/node": "^24.0.12"
   }
 }


### PR DESCRIPTION
## Sourcery によるサマリー

devDependencies を @biomejs/biome と @types/node の最新パッチバージョンに更新します。

ビルド:
- @biomejs/biome を v2.1.0 から v2.1.1 に更新
- @types/node を v24.0.10 から v24.0.12 に更新

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update devDependencies to the latest patch versions of @biomejs/biome and @types/node

Build:
- Bump @biomejs/biome from v2.1.0 to v2.1.1
- Bump @types/node from v24.0.10 to v24.0.12

</details>