### PR TITLE
build: version up dependencies

### DIFF
--- a/@robopo/web/package.json
+++ b/@robopo/web/package.json
@@ -47,7 +47,7 @@
     "@heroicons/react": "^2.2.0",
     "@tailwindcss/postcss": "^4.1.11",
     "@types/bcrypt": "^5.0.2",
-    "@types/node": "^24.0.13",
+    "@types/node": "^24.0.14",
     "@types/pg": "^8.15.4",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       ],
       "devDependencies": {
         "@biomejs/biome": "^2.1.1",
-        "@types/node": "^24.0.13"
+        "@types/node": "^24.0.14"
       }
     },
     "@robopo/web": {
@@ -30,7 +30,7 @@
         "@heroicons/react": "^2.2.0",
         "@tailwindcss/postcss": "^4.1.11",
         "@types/bcrypt": "^5.0.2",
-        "@types/node": "^24.0.13",
+        "@types/node": "^24.0.14",
         "@types/pg": "^8.15.4",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
@@ -2000,9 +2000,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.0.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.13.tgz",
-      "integrity": "sha512-Qm9OYVOFHFYg3wJoTSrz80hoec5Lia/dPp84do3X7dZvLikQvM1YpmvTBEdIr/e+U8HTkFjLHLnl78K/qjf+jQ==",
+      "version": "24.0.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.14.tgz",
+      "integrity": "sha512-4zXMWD91vBLGRtHK3YbIoFMia+1nqEz72coM42C5ETjnNCa/heoj7NT1G67iAfOqMmcfhuCZ4uNpyz8EjlAejw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2465,9 +2465,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.0.11",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.0.11.tgz",
-      "integrity": "sha512-QxG7EaliDARm1O1S8BGakqncGT9s25bKL1WSf6/oa17Tkqwi8D2ZNglqCF+DsYF88/rV66Q/Q2mFAy697E1DUg==",
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.0.12.tgz",
+      "integrity": "sha512-T8xypXs8CpmiIi78k0E+Lk7T2zlK4zDyg+o1CZ4AkOHgDg98ogdP2BeZ61lTFKFyoEwJ9RgAgN+SdM3iPgNonQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -2878,9 +2878,9 @@
       }
     },
     "node_modules/next-rspack": {
-      "version": "15.4.2-canary.0",
-      "resolved": "https://registry.npmjs.org/next-rspack/-/next-rspack-15.4.2-canary.0.tgz",
-      "integrity": "sha512-Y9l8+EUAcs7yjuoMp7ws2HyepiKBIjtF0DIY7XzFUord1/LXz87M4EQFGKsig9/BDDN33LQ1UWXICleYRWXK/A==",
+      "version": "15.4.2-canary.1",
+      "resolved": "https://registry.npmjs.org/next-rspack/-/next-rspack-15.4.2-canary.1.tgz",
+      "integrity": "sha512-ZGftvWghc+G4Y89N+OUdXjzdYEAimS3CqaoDTKKpu36Ao2L0WBJI/JJPfcOX1xRvPPJE894pJNcYBIwgpsWHLw==",
       "dev": true,
       "dependencies": {
         "@rspack/core": "1.4.5",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.1.1",
-    "@types/node": "^24.0.13"
+    "@types/node": "^24.0.14"
   },
   "overrides": {
     "@esbuild-kit/core-utils": {


### PR DESCRIPTION
## Sourcery によるサマリー

@types/node の依存関係を最新のパッチバージョンに更新します。

雑務:
- @robopo/web package.json の @types/node を 24.0.13 から 24.0.14 に更新
- ルート package.json の @types/node を 24.0.13 から 24.0.14 に更新

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bump the @types/node dependency to the latest patch version.

Chores:
- Update @types/node from 24.0.13 to 24.0.14 in @robopo/web package.json
- Update @types/node from 24.0.13 to 24.0.14 in root package.json

</details>