### PR TITLE
fix: add index to key prop for mission list items

### DIFF
--- a/@robopo/web/app/components/course/missionList.tsx
+++ b/@robopo/web/app/components/course/missionList.tsx
@@ -87,7 +87,7 @@ export function MissionList({
             {statePair.length > 0 ? (
               statePair.map((mission, index) => (
                 <tr
-                  key={`${mission[0] ?? "null"}-${mission[1] ?? "null"}`}
+                  key={`${mission[0] ?? "null"}-${mission[1] ?? "null"}-${index}`}
                   className="hover cursor-pointer"
                   onClick={() => handleRadioChange(index)}
                   onKeyDown={(e) => {

--- a/@robopo/web/app/components/course/missionList.tsx
+++ b/@robopo/web/app/components/course/missionList.tsx
@@ -19,12 +19,15 @@ export function MissionList({
   radio: number | null
   handleRadioChange: (selectedIndex: number) => void
 }) {
-  const [statePair, setMissionStatePair] = useState<MissionValue[][]>(
-    missionStatePair(mission),
-  )
+  const [statePair, setMissionStatePair] = useState<
+    { id: string; mission: MissionValue[] }[]
+  >([])
 
   useEffect(() => {
-    const newStatePair = missionStatePair(mission)
+    const newStatePair = missionStatePair(mission).map((m) => ({
+      id: crypto.randomUUID(),
+      mission: m,
+    }))
     setMissionStatePair(newStatePair)
   }, [mission])
 
@@ -85,9 +88,9 @@ export function MissionList({
               <td>{point[0]}</td>
             </tr>
             {statePair.length > 0 ? (
-              statePair.map((mission, index) => (
+              statePair.map(({ id, mission }, index) => (
                 <tr
-                  key={`${mission[0] ?? "null"}-${mission[1] ?? "null"}-${index}`}
+                  key={id}
                   className="hover cursor-pointer"
                   onClick={() => handleRadioChange(index)}
                   onKeyDown={(e) => {


### PR DESCRIPTION
-同じミッションが追加された時にkeyが同じになってしまうbug修正

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

- [ ] Documentation (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- 
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

## Sourceryによる要約

バグ修正:
- 同じミッションが複数回レンダリングされる際に発生する重複キー警告を回避するため、ミッションリストアイテムのキーにインデックスを追加します。

<details>
<summary>Original summary in English</summary>

## Sourceryによる要約

バグ修正:
- 同じミッションが複数回出現する場合に重複キーの警告を防ぐため、ミッションリスト項目で`key`プロパティにインデックスを追加

<details>
<summary>Original summary in English</summary>

## Sourceryによる概要

各項目に一意のUUIDを割り当てることで、ミッションリストにおけるReactの重複キー警告を防ぎます。

バグ修正:
- リスト内で同一のミッションをレンダリングする際の重複キー警告を修正

改善点:
- `statePair`を、`id`と`mission`配列を持つオブジェクトを格納するようにリファクタリング
- `crypto.randomUUID`を使用して各ミッションに一意の`id`を生成し、それを`key`プロパティとして使用

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent duplicate React key warnings in mission list by assigning a unique UUID to each item.

Bug Fixes:
- Fix duplicate key warning when rendering identical missions in the list

Enhancements:
- Refactor statePair to store objects with an `id` and `mission` array
- Generate unique `id` for each mission using `crypto.randomUUID` and use it as the `key` prop

</details>

</details>

</details>