### PR TITLE
refactor: sort imports on config/view.tsx

### DIFF
--- a/@robopo/web/app/config/view.tsx
+++ b/@robopo/web/app/config/view.tsx
@@ -1,18 +1,14 @@
 "use client"
+import { useState } from "react"
 import { ThreeTabs } from "@/app/components/parts/threeTabs"
 import { CompetitionListTab, NewCompetitionTab } from "@/app/config/tabs"
-import type {
-  SelectCompetition,
-} from "@/app/lib/db/schema"
-import { useState } from "react"
+import type { SelectCompetition } from "@/app/lib/db/schema"
 
 type ViewProps = {
   initialCompetitionList: { competitions: SelectCompetition[] }
 }
 
-export function View({
-  initialCompetitionList,
-}: ViewProps) {
+export function View({ initialCompetitionList }: ViewProps) {
   const [competitionId, setCompetitionId] = useState<number | null>(null)
   const [competitionList, setCompetitionList] = useState<SelectCompetition[]>(
     initialCompetitionList.competitions,


### PR DESCRIPTION
## Sourcery による概要

config/view.tsx 内のインポートの順序とフォーマットをリファクタリングし、View コンポーネントのシグネチャを合理化しました。

改善点:
- view.tsx 内で、外部、内部、型のみのインポートを一貫してグループ化するようにインポートの順序を変更。
- SelectCompetition 型のインポートを1行に統合。
- View コンポーネントの props の分割代入を1行のパラメータに簡素化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor import ordering and formatting in config/view.tsx and streamline the View component signature.

Enhancements:
- Reorder imports to group external, internal, and type-only imports consistently in view.tsx
- Consolidate the SelectCompetition type import into a single line
- Simplify the View component’s props destructuring to a single-line parameter

</details>