### PR TITLE
ci: add user mention to gemini cli

### DIFF
--- a/.github/workflows/gemini-cli.yml
+++ b/.github/workflows/gemini-cli.yml
@@ -34,54 +34,26 @@ jobs:
       (
         github.event_name == 'issues' && github.event.action == 'opened' &&
         contains(github.event.issue.body, '@gemini-cli') &&
-        !contains(github.event.issue.body, '/review') &&
-        !contains(github.event.issue.body, '/triage') &&
-        (
-          github.event.sender.type == 'User' && (
-            github.event.issue.author_association == 'OWNER' ||
-            github.event.issue.author_association == 'MEMBER' ||
-            github.event.issue.author_association == 'COLLABORATOR'
-          )
-        )
+        !contains(github.event.issue.body, '@gemini-cli /review') &&
+        !contains(github.event.issue.body, '@gemini-cli /triage') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association)
       ) ||
       (
-        github.event_name == 'issue_comment' &&
-        contains(github.event.comment.body, '@gemini-cli') &&
-        !contains(github.event.comment.body, '/review') &&
-        !contains(github.event.comment.body, '/triage') &&
         (
-          github.event.sender.type == 'User' && (
-            github.event.comment.author_association == 'OWNER' ||
-            github.event.comment.author_association == 'MEMBER' ||
-            github.event.comment.author_association == 'COLLABORATOR'
-          )
-        )
+          github.event_name == 'issue_comment' ||
+          github.event_name == 'pull_request_review_comment'
+        ) &&
+        contains(github.event.comment.body, '@gemini-cli') &&
+        !contains(github.event.comment.body, '@gemini-cli /review') &&
+        !contains(github.event.comment.body, '@gemini-cli /triage') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
       ) ||
       (
         github.event_name == 'pull_request_review' &&
         contains(github.event.review.body, '@gemini-cli') &&
-        !contains(github.event.review.body, '/review') &&
-        !contains(github.event.review.body, '/triage') &&
-        (
-          github.event.sender.type == 'User' && (
-            github.event.review.author_association == 'OWNER' ||
-            github.event.review.author_association == 'MEMBER' ||
-            github.event.review.author_association == 'COLLABORATOR'
-          )
-        )
-      ) ||
-      (
-        github.event_name == 'pull_request_review_comment' &&
-        contains(github.event.comment.body, '@gemini-cli') &&
-        !contains(github.event.comment.body, '/review') &&
-        !contains(github.event.comment.body, '/triage') &&
-        (
-          github.event.sender.type == 'User' && (
-            github.event.comment.author_association == 'OWNER' ||
-            github.event.comment.author_association == 'MEMBER' ||
-            github.event.comment.author_association == 'COLLABORATOR'
-          )
-        )
+        !contains(github.event.review.body, '@gemini-cli /review') &&
+        !contains(github.event.review.body, '@gemini-cli /triage') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)
       )
     timeout-minutes: 10
     runs-on: 'ubuntu-latest'
@@ -162,13 +134,14 @@ jobs:
 
       - name: 'Acknowledge request'
         env:
+          GITHUB_ACTOR: '${{ github.actor }}'
           GITHUB_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
           ISSUE_NUMBER: '${{ steps.get_context.outputs.issue_number }}'
           REPOSITORY: '${{ github.repository }}'
           REQUEST_TYPE: '${{ steps.get_context.outputs.request_type }}'
         run: |-
           set -euo pipefail
-          MESSAGE="I've received your request and I'm working on it now! 🤖"
+          MESSAGE="@${GITHUB_ACTOR} I've received your request and I'm working on it now! 🤖"
           if [[ -n "${MESSAGE}" ]]; then
             gh issue comment "${ISSUE_NUMBER}" \
               --body "${MESSAGE}" \


### PR DESCRIPTION
## Sourceryによる要約

gemini-cli GitHub Actionsワークフローを、イベントフィルターの統合とボット応答におけるユーザーメンションの追加により改善しました。

改善点:
- 重複チェックを統合し、JSONベースの作成者関連付けリストを使用することで、issue、コメント、およびレビューイベントフィルターを効率化しました。
- コマンドマッチングを更新し、'@gemini-cli' がプレフィックスされている場合に '/review' および '/triage' を明示的に無視するようにしました。
- GITHUB_ACTOR環境変数を追加し、確認コメントでリクエストしたユーザーをメンションするようにしました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the gemini-cli GitHub Actions workflow by consolidating event filters and including user mentions in bot responses.

Enhancements:
- Streamline issue, comment, and review event filters by merging duplicate checks and using a JSON-based author association list
- Update command matching to explicitly ignore '/review' and '/triage' when prefixed with '@gemini-cli'
- Add GITHUB_ACTOR environment variable and mention the requesting user in the acknowledgment comment

</details>