### PR TITLE
ci: update gemini-cli.yml

### DIFF
--- a/.github/workflows/gemini-cli.yml
+++ b/.github/workflows/gemini-cli.yml
@@ -28,7 +28,9 @@ permissions:
 
 jobs:
   gemini-cli:
-    # This condition is complex to ensure we only run when explicitly invoked.
+    # This condition seeks to ensure the action is only run when it is triggered by a trusted user.
+    # For private repos, users who have access to the repo are considered trusted.
+    # For public repos, users who members, owners, or collaborators are considered trusted.
     if: |-
       github.event_name == 'workflow_dispatch' ||
       (
@@ -36,7 +38,10 @@ jobs:
         contains(github.event.issue.body, '@gemini-cli') &&
         !contains(github.event.issue.body, '@gemini-cli /review') &&
         !contains(github.event.issue.body, '@gemini-cli /triage') &&
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association)
+        (
+          github.event.repository.private == true ||
+          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association)
+        )
       ) ||
       (
         (
@@ -46,18 +51,23 @@ jobs:
         contains(github.event.comment.body, '@gemini-cli') &&
         !contains(github.event.comment.body, '@gemini-cli /review') &&
         !contains(github.event.comment.body, '@gemini-cli /triage') &&
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+        (
+          github.event.repository.private == true ||
+          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+        )
       ) ||
       (
         github.event_name == 'pull_request_review' &&
         contains(github.event.review.body, '@gemini-cli') &&
         !contains(github.event.review.body, '@gemini-cli /review') &&
         !contains(github.event.review.body, '@gemini-cli /triage') &&
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)
+        (
+          github.event.repository.private == true ||
+          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)
+        )
       )
     timeout-minutes: 10
     runs-on: 'ubuntu-latest'
-
     steps:
       - name: 'Generate GitHub App Token'
         id: 'generate_token'
@@ -205,6 +215,7 @@ jobs:
           use_gemini_code_assist: '${{ vars.GOOGLE_GENAI_USE_GCA }}'
           settings: |-
             {
+              "debug": ${{ fromJSON(env.DEBUG || env.ACTIONS_STEP_DEBUG || false) }},
               "maxSessionTurns": 50,
               "telemetry": {
                 "enabled": false,


### PR DESCRIPTION
## Sourceryによる要約

Gemini CLI GitHub Actions ワークフローを改善し、プライベートリポジトリのすべてのコントリビューターを信頼できるものとして扱い、パブリックリポジトリのトリガーを特定の関連付けに制限することで、信頼できるユーザーをより適切に区別するようにします。また、アクション設定にデバッグトグルを追加します。

Enhancements:
- ワークフローの`if`条件を拡張し、プライベートリポジトリではアクセス権を持つすべてのユーザーを許可し、パブリックリポジトリではissue、コメント、レビューのトリガーにおいてOWNER、MEMBER、またはCOLLABORATORのみを許可するようにします。
- プライベートリポジトリとパブリックリポジトリにおける信頼できるユーザーロジックを明確にする説明的なコメントを追加します。
- Gemini CLI設定に`debug`フラグを導入し、環境デバッグ変数によって制御できるようにします。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the Gemini CLI GitHub Actions workflow to better distinguish trusted users by treating all private repo contributors as trusted and restricting public repo triggers to specific associations, and add a debug toggle to the action settings.

Enhancements:
- Expand the workflow `if` conditions to allow any user with access in private repositories and only OWNER, MEMBER, or COLLABORATOR for public repositories across issue, comment, and review triggers
- Add descriptive comments clarifying the trusted user logic for private and public repos
- Introduce a `debug` flag in the Gemini CLI settings, controlled by environment debug variables

</details>