### PR TITLE
fix: use string type at intercepting routes

### DIFF
--- a/@robopo/web/app/api/competition/[id]/route.ts
+++ b/@robopo/web/app/api/competition/[id]/route.ts
@@ -10,7 +10,7 @@ export const revalidate = 0
 
 export async function POST(
   req: Request,
-  props: { params: Promise<{ id: number }> },
+  props: { params: Promise<{ id: string }> },
 ) {
   const { id } = await props.params
   const { type } = await req.json()
@@ -19,13 +19,13 @@ export async function POST(
 
   switch (type) {
     case "open":
-      result = await openCompetitionById(id)
+      result = await openCompetitionById(Number(id))
       break
     case "return":
-      result = await returnCompetitionById(id)
+      result = await returnCompetitionById(Number(id))
       break
     case "close":
-      result = await closeCompetitionById(id)
+      result = await closeCompetitionById(Number(id))
       break
     default:
       return Response.json(

--- a/@robopo/web/app/api/summary/[competitionId]/[courseId]/route.ts
+++ b/@robopo/web/app/api/summary/[competitionId]/[courseId]/route.ts
@@ -8,20 +8,23 @@ export const revalidate = 0
 
 export async function GET(
   _req: Request,
-  { params }: { params: Promise<{ competitionId: number; courseId: number }> },
+  { params }: { params: Promise<{ competitionId: string; courseId: string }> },
 ) {
   const { competitionId, courseId } = await params
 
   // データ取得
-  const courseSummary = await getCourseSummary(competitionId, courseId)
-  const course = await getCourseById(courseId)
+  const courseSummary = await getCourseSummary(
+    Number(competitionId),
+    Number(courseId),
+  )
+  const course = await getCourseById(Number(courseId))
   const pointState = deserializePoint(course?.point as string)
 
   // 各プレイヤーの総得点と一本橋の総得点を計算
   const courseSummaryWithPoints = await Promise.all(
     courseSummary.map(async (player) => {
       const sumIpponPoints = await sumIpponPoint(
-        competitionId,
+        Number(competitionId),
         player.playerId || 0,
       )
       const totalPoint =


### PR DESCRIPTION
## Sourceryによる概要

ルートパラメータの型を文字列に標準化し、数値IDがサービス関数に渡される前に正しく変換されることを保証します。

改善点:
- サマリーおよびコンペティションのエンドポイントについて、ルートハンドラのパラメータ型を数値型から文字列型に変更。
- IDに依存するサービス関数を呼び出す際に、文字列ベースのルートパラメータを数値に変換。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize route parameter types to string and ensure numeric IDs are correctly converted before passing to service functions

Enhancements:
- Change route handler parameter typings from number to string for summary and competition endpoints
- Convert string-based route params to numbers when calling ID-dependent service functions

</details>