### PR TITLE
refactor: remove unnecessary global.css import

### DIFF
--- a/@robopo/web/app/@auth/signIn/layout.tsx
+++ b/@robopo/web/app/@auth/signIn/layout.tsx
@@ -1,6 +1,5 @@
-import { Suspense } from "react"
-import "@/app/globals.css"
 import type React from "react"
+import { Suspense } from "react"
 import { PageLoading } from "@/app/components/parts/pageLoading"
 
 export default function Layout({

--- a/@robopo/web/app/course/edit/layout.tsx
+++ b/@robopo/web/app/course/edit/layout.tsx
@@ -1,5 +1,4 @@
 import { Suspense } from "react"
-import "@/app/globals.css"
 import { PageLoading } from "@/app/components/parts/pageLoading"
 
 export default function Layout({

--- a/@robopo/web/app/course/layout.tsx
+++ b/@robopo/web/app/course/layout.tsx
@@ -1,6 +1,5 @@
 import { NavigationGuardProvider } from "next-navigation-guard"
 import { CourseEditProvider } from "@/app/course/edit/courseEditContext"
-import "@/app/globals.css"
 
 export default function Layout({
   children,

--- a/@robopo/web/app/globals.css
+++ b/@robopo/web/app/globals.css
@@ -1,3 +1,4 @@
+/** biome-ignore-all lint/suspicious/noUnknownAtRules: tailwind plugin and daisyui */
 @import "tailwindcss";
 @plugin "daisyui";
 
@@ -5,7 +6,10 @@
 
 @theme {
   --background-image-gradient-radial: radial-gradient(var(--tw-gradient-stops));
-  --background-image-gradient-conic: conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops));
+  --background-image-gradient-conic: conic-gradient(
+    from 180deg at 50% 50%,
+    var(--tw-gradient-stops)
+  );
 }
 
 /*
@@ -47,12 +51,21 @@
 
   body {
     color: rgb(var(--foreground-rgb));
-    background: linear-gradient(to bottom, transparent, rgb(var(--background-end-rgb))) rgb(var(--background-start-rgb));
+    background: linear-gradient(
+        to bottom,
+        transparent,
+        rgb(var(--background-end-rgb))
+      )
+      rgb(var(--background-start-rgb));
   }
 }
 
 .gradient-button {
-  background: radial-gradient(circle, rgba(144, 238, 144, 1) 0%, rgba(0, 128, 0, 1) 100%);
+  background: radial-gradient(
+    circle,
+    rgba(144, 238, 144, 1) 0%,
+    rgba(0, 128, 0, 1) 100%
+  );
   border: none;
   padding: 0;
   color: #fff;
@@ -75,7 +88,11 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: radial-gradient(circle, rgba(144, 238, 144, 1) 0%, rgba(0, 128, 0, 1) 100%);
+  background: radial-gradient(
+    circle,
+    rgba(144, 238, 144, 1) 0%,
+    rgba(0, 128, 0, 1) 100%
+  );
   z-index: 0;
 }
 

--- a/@robopo/web/app/player/layout.tsx
+++ b/@robopo/web/app/player/layout.tsx
@@ -1,5 +1,3 @@
-import "@/app/globals.css"
-
 export default function Layout({
   children,
   modal,

--- a/@robopo/web/app/umpire/layout.tsx
+++ b/@robopo/web/app/umpire/layout.tsx
@@ -1,5 +1,3 @@
-import "@/app/globals.css"
-
 export default function Layout({
   children,
   modal,


### PR DESCRIPTION
## Sourceryによる要約

複数のレイアウトコンポーネントから未使用の`global.css`インポートを削除し、`globals.css`のCSSフォーマットを改善しました。

改善点:
- `signIn`、`player`、`umpire`、`course`の各レイアウトコンポーネントから重複する`global.css`のインポートを削除
- `globals.css`内のグラデーション定義を可読性向上のため複数行ブロックに再フォーマット
- 誤検知を抑制するため、`globals.css`の先頭に`biome-ignore`リンターディレクティブを追加

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove unused global.css imports from multiple layout components and improve CSS formatting in globals.css.

Enhancements:
- Remove redundant global.css imports from signIn, player, umpire, and course layout components
- Reformat gradient definitions in globals.css into multiline blocks for improved readability
- Add biome-ignore lint directive to the top of globals.css to suppress false positives

</details>