### PR TITLE
build: version up dependencies

### DIFF
--- a/@robopo/web/package.json
+++ b/@robopo/web/package.json
@@ -43,13 +43,13 @@
     "react-dom": "^19.1.1"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.2.0",
+    "@biomejs/biome": "^2.2.2",
     "@heroicons/react": "^2.2.0",
     "@tailwindcss/postcss": "^4.1.12",
     "@types/bcrypt": "^6.0.0",
     "@types/node": "^24.3.0",
     "@types/pg": "^8.15.5",
-    "@types/react": "^19.1.10",
+    "@types/react": "^19.1.11",
     "@types/react-dom": "^19.1.7",
     "bcrypt": "^6.0.0",
     "daisyui": "^5.0.50",
@@ -62,6 +62,6 @@
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.12",
     "typescript": "^5.9.2",
-    "zod": "^4.0.17"
+    "zod": "^4.1.1"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "./@robopo/*"
       ],
       "devDependencies": {
-        "@biomejs/biome": "^2.2.0",
+        "@biomejs/biome": "^2.2.2",
         "@types/node": "^24.3.0"
       }
     },
@@ -51,13 +51,13 @@
         "react-dom": "^19.1.1"
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.2.0",
+        "@biomejs/biome": "^2.2.2",
         "@heroicons/react": "^2.2.0",
         "@tailwindcss/postcss": "^4.1.12",
         "@types/bcrypt": "^6.0.0",
         "@types/node": "^24.3.0",
         "@types/pg": "^8.15.5",
-        "@types/react": "^19.1.10",
+        "@types/react": "^19.1.11",
         "@types/react-dom": "^19.1.7",
         "bcrypt": "^6.0.0",
         "daisyui": "^5.0.50",
@@ -70,7 +70,7 @@
         "postcss": "^8.5.6",
         "tailwindcss": "^4.1.12",
         "typescript": "^5.9.2",
-        "zod": "^4.0.17"
+        "zod": "^4.1.1"
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -2108,9 +2108,9 @@
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.2.0.tgz",
-      "integrity": "sha512-3On3RSYLsX+n9KnoSgfoYlckYBoU6VRM22cw1gB4Y0OuUVSYd/O/2saOJMrA4HFfA1Ff0eacOvMN1yAAvHtzIw==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.2.2.tgz",
+      "integrity": "sha512-j1omAiQWCkhuLgwpMKisNKnsM6W8Xtt1l0WZmqY/dFj8QPNkIoTvk4tSsi40FaAAkBE1PU0AFG2RWFBWenAn+w==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -2124,20 +2124,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.2.0",
-        "@biomejs/cli-darwin-x64": "2.2.0",
-        "@biomejs/cli-linux-arm64": "2.2.0",
-        "@biomejs/cli-linux-arm64-musl": "2.2.0",
-        "@biomejs/cli-linux-x64": "2.2.0",
-        "@biomejs/cli-linux-x64-musl": "2.2.0",
-        "@biomejs/cli-win32-arm64": "2.2.0",
-        "@biomejs/cli-win32-x64": "2.2.0"
+        "@biomejs/cli-darwin-arm64": "2.2.2",
+        "@biomejs/cli-darwin-x64": "2.2.2",
+        "@biomejs/cli-linux-arm64": "2.2.2",
+        "@biomejs/cli-linux-arm64-musl": "2.2.2",
+        "@biomejs/cli-linux-x64": "2.2.2",
+        "@biomejs/cli-linux-x64-musl": "2.2.2",
+        "@biomejs/cli-win32-arm64": "2.2.2",
+        "@biomejs/cli-win32-x64": "2.2.2"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.2.0.tgz",
-      "integrity": "sha512-zKbwUUh+9uFmWfS8IFxmVD6XwqFcENjZvEyfOxHs1epjdH3wyyMQG80FGDsmauPwS2r5kXdEM0v/+dTIA9FXAg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.2.2.tgz",
+      "integrity": "sha512-6ePfbCeCPryWu0CXlzsWNZgVz/kBEvHiPyNpmViSt6A2eoDf4kXs3YnwQPzGjy8oBgQulrHcLnJL0nkCh80mlQ==",
       "cpu": [
         "arm64"
       ],
@@ -2152,9 +2152,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.2.0.tgz",
-      "integrity": "sha512-+OmT4dsX2eTfhD5crUOPw3RPhaR+SKVspvGVmSdZ9y9O/AgL8pla6T4hOn1q+VAFBHuHhsdxDRJgFCSC7RaMOw==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.2.2.tgz",
+      "integrity": "sha512-Tn4JmVO+rXsbRslml7FvKaNrlgUeJot++FkvYIhl1OkslVCofAtS35MPlBMhXgKWF9RNr9cwHanrPTUUXcYGag==",
       "cpu": [
         "x64"
       ],
@@ -2169,9 +2169,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.2.0.tgz",
-      "integrity": "sha512-6eoRdF2yW5FnW9Lpeivh7Mayhq0KDdaDMYOJnH9aT02KuSIX5V1HmWJCQQPwIQbhDh68Zrcpl8inRlTEan0SXw==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.2.2.tgz",
+      "integrity": "sha512-JfrK3gdmWWTh2J5tq/rcWCOsImVyzUnOS2fkjhiYKCQ+v8PqM+du5cfB7G1kXas+7KQeKSWALv18iQqdtIMvzw==",
       "cpu": [
         "arm64"
       ],
@@ -2186,9 +2186,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.2.0.tgz",
-      "integrity": "sha512-egKpOa+4FL9YO+SMUMLUvf543cprjevNc3CAgDNFLcjknuNMcZ0GLJYa3EGTCR2xIkIUJDVneBV3O9OcIlCEZQ==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.2.2.tgz",
+      "integrity": "sha512-/MhYg+Bd6renn6i1ylGFL5snYUn/Ct7zoGVKhxnro3bwekiZYE8Kl39BSb0MeuqM+72sThkQv4TnNubU9njQRw==",
       "cpu": [
         "arm64"
       ],
@@ -2203,9 +2203,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.2.0.tgz",
-      "integrity": "sha512-5UmQx/OZAfJfi25zAnAGHUMuOd+LOsliIt119x2soA2gLggQYrVPA+2kMUxR6Mw5M1deUF/AWWP2qpxgH7Nyfw==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.2.2.tgz",
+      "integrity": "sha512-Ogb+77edO5LEP/xbNicACOWVLt8mgC+E1wmpUakr+O4nKwLt9vXe74YNuT3T1dUBxC/SnrVmlzZFC7kQJEfquQ==",
       "cpu": [
         "x64"
       ],
@@ -2220,9 +2220,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.2.0.tgz",
-      "integrity": "sha512-I5J85yWwUWpgJyC1CcytNSGusu2p9HjDnOPAFG4Y515hwRD0jpR9sT9/T1cKHtuCvEQ/sBvx+6zhz9l9wEJGAg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.2.2.tgz",
+      "integrity": "sha512-ZCLXcZvjZKSiRY/cFANKg+z6Fhsf9MHOzj+NrDQcM+LbqYRT97LyCLWy2AS+W2vP+i89RyRM+kbGpUzbRTYWig==",
       "cpu": [
         "x64"
       ],
@@ -2237,9 +2237,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.2.0.tgz",
-      "integrity": "sha512-n9a1/f2CwIDmNMNkFs+JI0ZjFnMO0jdOyGNtihgUNFnlmd84yIYY2KMTBmMV58ZlVHjgmY5Y6E1hVTnSRieggA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.2.2.tgz",
+      "integrity": "sha512-wBe2wItayw1zvtXysmHJQoQqXlTzHSpQRyPpJKiNIR21HzH/CrZRDFic1C1jDdp+zAPtqhNExa0owKMbNwW9cQ==",
       "cpu": [
         "arm64"
       ],
@@ -2254,9 +2254,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.2.0.tgz",
-      "integrity": "sha512-Nawu5nHjP/zPKTIryh2AavzTc/KEg4um/MxWdXW0A6P/RZOyIpa7+QSjeXwAwX/utJGaCoXRPWtF3m5U/bB3Ww==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.2.2.tgz",
+      "integrity": "sha512-DAuHhHekGfiGb6lCcsT4UyxQmVwQiBCBUMwVra/dcOSs9q8OhfaZgey51MlekT3p8UwRqtXQfFuEJBhJNdLZwg==",
       "cpu": [
         "x64"
       ],
@@ -7589,9 +7589,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.1.10",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.10.tgz",
-      "integrity": "sha512-EhBeSYX0Y6ye8pNebpKrwFJq7BoQ8J5SO6NlvNwwHjSj6adXJViPQrKlsyPw7hLBLvckEMO1yxeGdR82YBBlDg==",
+      "version": "19.1.11",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.11.tgz",
+      "integrity": "sha512-lr3jdBw/BGj49Eps7EvqlUaoeA0xpj3pc0RoJkHpYaCHkVK7i28dKyImLQb3JVlqs3aYSXf7qYuWOW/fgZnTXQ==",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -22981,9 +22981,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.17.tgz",
-      "integrity": "sha512-1PHjlYRevNxxdy2JZ8JcNAw7rX8V9P1AKkP+x/xZfxB0K5FYfuV+Ug6P/6NVSR2jHQ+FzDDoDHS04nYUsOIyLQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.1.tgz",
+      "integrity": "sha512-SgMZK/h8Tigt9nnKkfJMvB/mKjiJXaX26xegP4sa+0wHIFVFWVlsQGdhklDmuargBD3Hsi3rsQRIzwJIhTPJHA==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "check": "biome check --write"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.2.0",
+    "@biomejs/biome": "^2.2.2",
     "@types/node": "^24.3.0"
   },
   "overrides": {


### PR DESCRIPTION
## Sourceryによる要約

ワークスペース全体の開発依存関係を最新のパッチバージョンに更新しました。

改善点:
- root と @robopo/web の両方で @biomejs/biome を v2.2.2 に更新
- @robopo/web で @types/react を v19.1.11 にアップグレード
- @robopo/web で zod を v4.1.1 にアップグレード

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bump development dependencies across the workspace to their latest patch versions

Enhancements:
- Update @biomejs/biome to v2.2.2 in both root and @robopo/web
- Upgrade @types/react to v19.1.11 in @robopo/web
- Upgrade zod to v4.1.1 in @robopo/web

</details>