### PR TITLE
ci: bump `actions/upload-pages-artifact` from 3 to 4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
         run: npm run docs-build
 
       - name: Upload Build Artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: "@robopo/docs/build"
 


### PR DESCRIPTION
## Sourceryによる要約

CI:
- .github/workflows/deploy.yml 内で actions/upload-pages-artifact を v3 から v4 に更新

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Update actions/upload-pages-artifact from v3 to v4 in .github/workflows/deploy.yml

</details>