### PR TITLE
fix: remove unnecessary id and use data attribute

### DIFF
--- a/@robopo/web/app/@auth/signIn/page.tsx
+++ b/@robopo/web/app/@auth/signIn/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useSearchParams } from "next/navigation"
-import { useActionState, useEffect } from "react"
+import { useActionState, useEffect, useId } from "react"
 import {
   ModalBackButton,
   ModalBackdrop,
@@ -12,6 +12,10 @@ import { SIGN_IN_CONST } from "@/app/lib/const"
 export default function SignIn() {
   const params = useSearchParams()
   const rawCallbackUrl = params.get("callbackUrl") || "/"
+  const usernameId = useId()
+  const passwordId = useId()
+
+  // callbackUrlのバリデーション
   // クロスサイトスクリプティング&フィッシング攻撃対策
   function getSafeCallbackUrl(cb: string) {
     try {
@@ -42,10 +46,10 @@ export default function SignIn() {
     <dialog className="modal modal-open">
       <div className="modal-box">
         <form action={action} className="flex flex-col items-center">
-          <label className="input" htmlFor="username">
+          <label className="input" htmlFor={usernameId}>
             <span className="label">ユーザー名</span>
             <input
-              id="username"
+              id={usernameId}
               type="text"
               name="username"
               placeholder="robosava"
@@ -53,10 +57,10 @@ export default function SignIn() {
             />
           </label>
           <br />
-          <label className="input" htmlFor="password">
+          <label className="input" htmlFor={passwordId}>
             <span className="label">パスワード</span>
             <input
-              id="password"
+              id={passwordId}
               type="password"
               name="password"
               placeholder="12345678"

--- a/@robopo/web/app/challenge/[competitionId]/[courseId]/[playerId]/audioContext.tsx
+++ b/@robopo/web/app/challenge/[competitionId]/[courseId]/[playerId]/audioContext.tsx
@@ -49,7 +49,6 @@ export function SoundControlUI({
       <span className="text-lg">効果音: {soundOn ? "ON" : "OFF"}</span>
       <label className="flex items-center gap-1">
         <input
-          id="sound-toggle"
           type="checkbox"
           checked={soundOn}
           onChange={(e) => setSoundOn(e.target.checked)}

--- a/@robopo/web/app/challenge/challenge.tsx
+++ b/@robopo/web/app/challenge/challenge.tsx
@@ -134,7 +134,6 @@ function IpponBashiSection({
         <div className="flex w-full flex-col justify-items-end">
           <button
             type="button"
-            id="add"
             className="btn btn-primary m-3 mx-auto"
             onClick={handleBack}
             disabled={nowMission === 0}
@@ -280,7 +279,6 @@ function NormalChallengeSection({
       <div className="grid grid-cols-2 gap-4 p-4">
         <button
           type="button"
-          id="add"
           className="btn btn-primary mx-auto"
           onClick={handleBack}
           disabled={FieldProps.nowMission === 0}

--- a/@robopo/web/app/challenge/challengeModal.tsx
+++ b/@robopo/web/app/challenge/challengeModal.tsx
@@ -30,11 +30,7 @@ export function ChallengeModal({
     setModalOpen(0)
   }
   return (
-    <dialog
-      id="challenge-modal"
-      className="modal modal-open"
-      onClose={() => setModalOpen(0)}
-    >
+    <dialog className="modal modal-open" onClose={() => setModalOpen(0)}>
       <div className="modal-box">
         {isSuccess ? (
           <>
@@ -104,11 +100,7 @@ export function RetryModal({
     setModalOpen(0)
   }
   return (
-    <dialog
-      id="retry-modal"
-      className="modal modal-open"
-      onClose={() => setModalOpen(0)}
-    >
+    <dialog className="modal modal-open" onClose={() => setModalOpen(0)}>
       <div className="modal-box">
         <p>1回目のポイントを保存して再チャレンジしますか?</p>
         <p>1回目: {result1Point}ポイント</p>
@@ -160,11 +152,7 @@ export function CourseOutModal({
     setModalOpen(0)
   }
   return (
-    <dialog
-      id="course-out-modal"
-      className="modal modal-open"
-      onClose={() => setModalOpen(0)}
-    >
+    <dialog className="modal modal-open" onClose={() => setModalOpen(0)}>
       <div className="modal-box">
         {isSuccess ? (
           <>

--- a/@robopo/web/app/components/challenge/sensorCourse.tsx
+++ b/@robopo/web/app/components/challenge/sensorCourse.tsx
@@ -35,11 +35,11 @@ export function SensorCourse({
   // 選択で得点計算する
   function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
     // トンネル停止
-    if (e.target.id === "tunnelradio") {
+    if (e.target.dataset.id === "tunnelradio") {
       const value = Number(e.target.value)
       setTunnelPoint(value)
       setPointCount(wallPoint + value)
-    } else if (e.target.id === "tunnelcheckbox") {
+    } else if (e.target.dataset.id === "tunnelcheckbox") {
       if (e.target.checked) {
         setTunnelPoint(10)
         setPointCount(wallPoint + 10)
@@ -50,7 +50,7 @@ export function SensorCourse({
     }
 
     // 壁停止
-    if (e.target.id === "wallradio") {
+    if (e.target.dataset.id === "wallradio") {
       const value = Number(e.target.value)
       setWallPoint(value)
       setPointCount(tunnelPoint + value)
@@ -88,7 +88,7 @@ export function SensorCourse({
             <label className="label mx-auto justify-start text-xl">
               <input
                 type="checkbox"
-                id="tunnelcheckbox"
+                data-id="tunnelcheckbox"
                 checked={tunnelPoint === 10}
                 className="checkbox checkbox-lg checkbox-primary"
                 onChange={(e) => handleChange(e)}
@@ -99,7 +99,7 @@ export function SensorCourse({
               <label className="label mx-auto justify-start text-xl">
                 <input
                   type="radio"
-                  id="tunnelradio"
+                  data-id="tunnelradio"
                   className="radio radio-lg radio-primary"
                   onChange={(e) => handleChange(e)}
                   checked={tunnelPoint === 0}
@@ -110,7 +110,7 @@ export function SensorCourse({
               <label className="label mx-auto justify-start text-xl">
                 <input
                   type="radio"
-                  id="tunnelradio"
+                  data-id="tunnelradio"
                   className="radio radio-lg radio-primary"
                   onChange={(e) => handleChange(e)}
                   checked={tunnelPoint === 10}
@@ -123,7 +123,7 @@ export function SensorCourse({
             <label className="label mx-auto justify-start text-xl">
               <input
                 type="checkbox"
-                id="wallcheckbox"
+                data-id="wallcheckbox"
                 className="checkbox checkbox-lg checkbox-primary"
                 onChange={(e) => handleChange(e)}
                 checked={wallPoint !== 0 && wallPoint !== -5}
@@ -136,7 +136,7 @@ export function SensorCourse({
                   <label className="label mx-auto justify-start text-xl">
                     <input
                       type="radio"
-                      id="wallradio"
+                      data-id="wallradio"
                       className="radio radio-lg radio-primary"
                       onChange={(e) => handleChange(e)}
                       checked={wallPoint === point}

--- a/@robopo/web/app/components/common/commonModal.tsx
+++ b/@robopo/web/app/components/common/commonModal.tsx
@@ -73,7 +73,7 @@ export function DeleteModal({ type, ids }: { type: InputType; ids: number[] }) {
   }
 
   return (
-    <dialog id="challenge-modal" className="modal modal-open">
+    <dialog className="modal modal-open">
       <div className="modal-box">
         {successMessage ? (
           successMessage
@@ -167,7 +167,7 @@ export function AssignModal({
   }
 
   return (
-    <dialog id="challenge-modal" className="modal modal-open">
+    <dialog className="modal modal-open">
       <div className="modal-box">
         <div>
           <select

--- a/@robopo/web/app/components/course/missionUI.tsx
+++ b/@robopo/web/app/components/course/missionUI.tsx
@@ -126,7 +126,7 @@ export function MissionUI({
   }
 
   function handleButtonClick(event: React.MouseEvent<HTMLButtonElement>) {
-    const { id } = event.currentTarget
+    const { id } = event.currentTarget.dataset
     if (selectedId === null) {
       return
     }
@@ -385,7 +385,7 @@ export function MissionUI({
         <div />
         <button
           type="button"
-          id="add"
+          data-id="add"
           className="btn btn-primary mx-auto"
           disabled={
             isStartGoal() ||
@@ -400,7 +400,7 @@ export function MissionUI({
         </button>
         <button
           type="button"
-          id="update"
+          data-id="update"
           className="btn btn-primary mx-auto"
           onClick={handleButtonClick}
           disabled={
@@ -417,7 +417,7 @@ export function MissionUI({
         </button>
         <button
           type="button"
-          id="delete"
+          data-id="delete"
           className="btn btn-warning mx-auto"
           onClick={handleButtonClick}
           disabled={isStartGoal() || selectedId === null}

--- a/@robopo/web/app/components/course/modals.tsx
+++ b/@robopo/web/app/components/course/modals.tsx
@@ -29,7 +29,7 @@ export function BackModal() {
     router.back()
   }
   return (
-    <dialog id="fin-modal" className="modal modal-open">
+    <dialog className="modal modal-open">
       <div className="modal-box">
         <p>保存しますか?保存していない編集内容は失われます。</p>
         <div className="modal-action">
@@ -111,7 +111,7 @@ export function SaveModal({ courseId }: { courseId: number | null }) {
   }
 
   return (
-    <dialog id="save-modal" className="modal modal-open">
+    <dialog className="modal modal-open">
       <div className="modal-box">
         <form>
           <label htmlFor="name" className="label">
@@ -217,11 +217,7 @@ export function validationModal({
     setModalOpen(0)
   }
   return (
-    <dialog
-      id="validation-modal"
-      className="modal modal-open"
-      onClose={() => setModalOpen(0)}
-    >
+    <dialog className="modal modal-open" onClose={() => setModalOpen(0)}>
       <div className="modal-box">
         {check ? (
           <>

--- a/@robopo/web/app/config/tabs.tsx
+++ b/@robopo/web/app/config/tabs.tsx
@@ -73,50 +73,6 @@ export function CompetitionListTab({
     }
   }
 
-  function DeleteModal() {
-    return (
-      <dialog
-        id="challenge-modal"
-        className="modal modal-open"
-        onClose={() => setModalOpen(false)}
-      >
-        <div className="modal-box">
-          {isSuccess ? <p>{message}</p> : <p>選択した大会を削除しますか?</p>}
-
-          {!isSuccess && (
-            <button
-              type="button"
-              className="btn btn-accent m-3"
-              value="delete"
-              onClick={(e) => handleButtonClick(e)}
-              disabled={loading}
-            >
-              はい
-            </button>
-          )}
-          <button
-            type="button"
-            className="btn btn-accent m-3"
-            onClick={() => setModalOpen(false)}
-            disabled={loading}
-          >
-            <BackLabelWithIcon />
-          </button>
-        </div>
-        <form
-          method="dialog"
-          className="modal-backdrop"
-          onClick={() => setModalOpen(false)}
-          onKeyDown={(e) => e.key === "Escape" && setModalOpen(false)}
-        >
-          <button type="button" className="cursor-default">
-            close
-          </button>
-        </form>
-      </dialog>
-    )
-  }
-
   return (
     <>
       <CommonRadioList
@@ -176,7 +132,46 @@ export function CompetitionListTab({
       </button>
       {isSuccess && <p>{message}</p>}
       <p>{loading && <span className="loading loading-spinner"></span>}</p>
-      {modalOpen && <DeleteModal />}
+      {modalOpen && (
+        <dialog
+          className="modal modal-open"
+          onClose={() => setModalOpen(false)}
+        >
+          <div className="modal-box">
+            {isSuccess ? <p>{message}</p> : <p>選択した大会を削除しますか?</p>}
+
+            {!isSuccess && (
+              <button
+                type="button"
+                className="btn btn-accent m-3"
+                value="delete"
+                onClick={(e) => handleButtonClick(e)}
+                disabled={loading}
+              >
+                はい
+              </button>
+            )}
+            <button
+              type="button"
+              className="btn btn-accent m-3"
+              onClick={() => setModalOpen(false)}
+              disabled={loading}
+            >
+              <BackLabelWithIcon />
+            </button>
+          </div>
+          <form
+            method="dialog"
+            className="modal-backdrop"
+            onClick={() => setModalOpen(false)}
+            onKeyDown={(e) => e.key === "Escape" && setModalOpen(false)}
+          >
+            <button type="button" className="cursor-default">
+              close
+            </button>
+          </form>
+        </dialog>
+      )}
     </>
   )
 }


### PR DESCRIPTION
## Sourceryによる要約

モーダルダイアログとインタラクティブ要素から不要なid属性を削除し、手動のid使用をdata属性とReactの`useId`で生成された一意のIDに置き換え、明確さのためにモーダルコンポーネントをインライン化しました。

改善点:
- 複数のコンポーネントのダイアログ要素から静的なid属性を削除し、重複や衝突を回避
- イベントハンドラのロジックを、要素のidではなくdata-id属性から読み取るように置き換え
- Reactの`useId`フックを使用して、SignInフォームの入力要素に一意のid属性を生成
- よりシンプルなコンポーネント構造のために、`CompetitionListTab`内の`DeleteModal` JSXをインライン化

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove unnecessary id attributes from modal dialogs and interactive elements, replacing manual id usage with data attributes and unique IDs generated by React's useId, and inline a modal component for clarity.

Enhancements:
- Remove static id attributes from dialog elements in multiple components to avoid duplication and collisions
- Replace event handler logic to read from data-id attributes instead of element id
- Use React useId hook to generate unique id attributes for SignIn form inputs
- Inline the DeleteModal JSX in CompetitionListTab for simpler component structure

</details>