### PR TITLE
build: version up dependencies

### DIFF
--- a/@robopo/web/package.json
+++ b/@robopo/web/package.json
@@ -50,7 +50,7 @@
     "@types/node": "^24.3.0",
     "@types/pg": "^8.15.5",
     "@types/react": "^19.1.12",
-    "@types/react-dom": "^19.1.8",
+    "@types/react-dom": "^19.1.9",
     "bcrypt": "^6.0.0",
     "daisyui": "^5.0.54",
     "drizzle-kit": "^0.31.4",
@@ -62,6 +62,6 @@
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.12",
     "typescript": "^5.9.2",
-    "zod": "^4.1.4"
+    "zod": "^4.1.5"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "@types/node": "^24.3.0",
         "@types/pg": "^8.15.5",
         "@types/react": "^19.1.12",
-        "@types/react-dom": "^19.1.8",
+        "@types/react-dom": "^19.1.9",
         "bcrypt": "^6.0.0",
         "daisyui": "^5.0.54",
         "drizzle-kit": "^0.31.4",
@@ -70,7 +70,7 @@
         "postcss": "^8.5.6",
         "tailwindcss": "^4.1.12",
         "typescript": "^5.9.2",
-        "zod": "^4.1.4"
+        "zod": "^4.1.5"
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -5859,27 +5859,27 @@
       "link": true
     },
     "node_modules/@rspack/binding": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.5.0.tgz",
-      "integrity": "sha512-UGXQmwEu2gdO+tnGv2q4rOWJdWioy6dlLXeZOLYAZVh3mrfKJhZWtDEygX9hCdE5thWNRTlEvx30QQchJAszIQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.5.1.tgz",
+      "integrity": "sha512-/RdQwmnXNjUG1ysf63R/tdWCyDQ5GSqbvOMsTuBd+3r3qnyCCAEPg6ed3vwI+GvnRXw1QzOXF98b+tkt0eFESA==",
       "license": "MIT",
       "optionalDependencies": {
-        "@rspack/binding-darwin-arm64": "1.5.0",
-        "@rspack/binding-darwin-x64": "1.5.0",
-        "@rspack/binding-linux-arm64-gnu": "1.5.0",
-        "@rspack/binding-linux-arm64-musl": "1.5.0",
-        "@rspack/binding-linux-x64-gnu": "1.5.0",
-        "@rspack/binding-linux-x64-musl": "1.5.0",
-        "@rspack/binding-wasm32-wasi": "1.5.0",
-        "@rspack/binding-win32-arm64-msvc": "1.5.0",
-        "@rspack/binding-win32-ia32-msvc": "1.5.0",
-        "@rspack/binding-win32-x64-msvc": "1.5.0"
+        "@rspack/binding-darwin-arm64": "1.5.1",
+        "@rspack/binding-darwin-x64": "1.5.1",
+        "@rspack/binding-linux-arm64-gnu": "1.5.1",
+        "@rspack/binding-linux-arm64-musl": "1.5.1",
+        "@rspack/binding-linux-x64-gnu": "1.5.1",
+        "@rspack/binding-linux-x64-musl": "1.5.1",
+        "@rspack/binding-wasm32-wasi": "1.5.1",
+        "@rspack/binding-win32-arm64-msvc": "1.5.1",
+        "@rspack/binding-win32-ia32-msvc": "1.5.1",
+        "@rspack/binding-win32-x64-msvc": "1.5.1"
       }
     },
     "node_modules/@rspack/binding-darwin-arm64": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.5.0.tgz",
-      "integrity": "sha512-7909YLNnKf0BYxiCpCWOk13WyWS4493Kxk1NQwy9KPLY9ydQExk84KVsix2NuNBaI8Pnk3aVLBPJiSNXtHLjnA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.5.1.tgz",
+      "integrity": "sha512-iPQUqNrwmr3IH451EOrmAnADEwkxMnM83VnG3opzYMu2ipuWQdJXcnQ0m/qzoKeoNQ9zhLfdGdMQqvP5pV/Tlg==",
       "cpu": [
         "arm64"
       ],
@@ -5890,9 +5890,9 @@
       ]
     },
     "node_modules/@rspack/binding-darwin-x64": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.5.0.tgz",
-      "integrity": "sha512-poGuQsGKCMQqSswgrz8X+frqMVTdmtzUDyvi/p9BLwW+2DwWgmywU8jwE+BYtjfWp1tErBSTlLxmEPQTdcIQgQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.5.1.tgz",
+      "integrity": "sha512-Kcx8bTDdKqOe5sDUw+NFF+GzRgBHRYVs0NlVKlvKW59EIw0PEvcs0GKL0wDwkFuTL3+GRk4Uec+qHyIkv50SNA==",
       "cpu": [
         "x64"
       ],
@@ -5903,9 +5903,9 @@
       ]
     },
     "node_modules/@rspack/binding-linux-arm64-gnu": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.5.0.tgz",
-      "integrity": "sha512-Bvmk8h3tRhN9UgOtH+vK0SgFM3qEO36eJz7oddOl4lJQxBf2GNA87bGtkMtX+AVPz/PUn7r82uWxrlVNQHAbFg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.5.1.tgz",
+      "integrity": "sha512-6TeGUOy9De3E/XcbmcPW9YkAK2wfB7/K6UAtXp4oWiVjueQJj3FMFnRkzatagOUDoSRASqz2JiQKiMDvQpGu+g==",
       "cpu": [
         "arm64"
       ],
@@ -5916,9 +5916,9 @@
       ]
     },
     "node_modules/@rspack/binding-linux-arm64-musl": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.5.0.tgz",
-      "integrity": "sha512-bH7UwkbACDYT37YnN9kkhaF9niFFK9ndcdNvYFFr1oUT4W9Ie3V9b41EXijqp3pyh0mDSeeLPFY0aEx1t3e7Pw==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.5.1.tgz",
+      "integrity": "sha512-qHXHDG+5z2zZ2CYYisvmLQQ6f8E1yiP/lyfGTpOF8KGz5eZEWkSdYXUdctE9PWW9lVkapWcuz9eP1Nt74KSvvA==",
       "cpu": [
         "arm64"
       ],
@@ -5929,9 +5929,9 @@
       ]
     },
     "node_modules/@rspack/binding-linux-x64-gnu": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.5.0.tgz",
-      "integrity": "sha512-xZ5dwNrE5KtpQyMd9israpJTcTQ3UYUUq23fTcNc79xE5aspkGixDFAYoql4YkhO0O+JWRmdSaFAn6jD+IQWQA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-ywQcyc3s0XNspkbsN+glrnSoyWJOcaLDr536kY5SoAgfiaKlg9Fmg42jAwEv9SUSx3jRxyqaFCsSjNv5/mvBsA==",
       "cpu": [
         "x64"
       ],
@@ -5942,9 +5942,9 @@
       ]
     },
     "node_modules/@rspack/binding-linux-x64-musl": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.5.0.tgz",
-      "integrity": "sha512-mv65jYvcyYPkPZJ9kjSvTAcH0o7C5jfICWCQcMmN1tCGD3b8gmf9GqSZ8e+W/JkuvrJ05qTo/PvEq9nhu+pNIg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.5.1.tgz",
+      "integrity": "sha512-0nF959K2pZMdRQewohjHxWSD97lIXlOh/xznr0f3zpFv2M/cB1HjHqD/yvZNgU+/hDdEeXplJp7WpD+/tJzX3w==",
       "cpu": [
         "x64"
       ],
@@ -5955,9 +5955,9 @@
       ]
     },
     "node_modules/@rspack/binding-wasm32-wasi": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-wasm32-wasi/-/binding-wasm32-wasi-1.5.0.tgz",
-      "integrity": "sha512-8rVpl6xfaAFJgo1wCd+emksfl+/8nlehrtkmjY9bj79Ou+kp07L9e1B+UU0jfs8e7aLPntQuF68kzLHwYLzWIQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-wasm32-wasi/-/binding-wasm32-wasi-1.5.1.tgz",
+      "integrity": "sha512-iM+p8qIWH1uYxKh+MfNyCQ5Ia2QaGeKaGYPzikKakLAK2XaUCflmWP8fGppVUYxX0+b1a4tBOZveN8g1QeZsXw==",
       "cpu": [
         "wasm32"
       ],
@@ -5968,9 +5968,9 @@
       }
     },
     "node_modules/@rspack/binding-win32-arm64-msvc": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.5.0.tgz",
-      "integrity": "sha512-dWSmNm+GR6WSkOwbhlUcot4Oqwyon+1PRZ9E0vIMFHKGvESf9CQjgHAX0QE9G0kJmRM5x3I16J4x44Kw3W/98Q==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.5.1.tgz",
+      "integrity": "sha512-vTbYk5wixqTNs7DE+HHYYol1bl1wg8vkvShdnWFV8kQ8PPwZymNuLbuLng7yp8tN2FKWaQ5YTuhmIrzF3dLuzw==",
       "cpu": [
         "arm64"
       ],
@@ -5981,9 +5981,9 @@
       ]
     },
     "node_modules/@rspack/binding-win32-ia32-msvc": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.5.0.tgz",
-      "integrity": "sha512-YtOrFEkwhO3Y3sY6Jq0OOYPY7NBTNYuwJ6epTgzPEDGs2cBnwZfzhq0jmD/koWtv1L9+twX95vKosBdauF0tNA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.5.1.tgz",
+      "integrity": "sha512-QPUy14Lu4CVpnarGhLoe0Dg+zF1bUAonVdEZSP9DttI1NOBkvl39c1WnnY33c1nwps0n/EQBoGJXDaTVuZfS+Q==",
       "cpu": [
         "ia32"
       ],
@@ -5994,9 +5994,9 @@
       ]
     },
     "node_modules/@rspack/binding-win32-x64-msvc": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.5.0.tgz",
-      "integrity": "sha512-V4fcPVYWJgDkIkSsFwmUdwC9lkL8+1dzDOwyTWe6KW2MYHF2D148WPHNyVVE6gum12TShpbIsh0j4NiiMhkMtw==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.5.1.tgz",
+      "integrity": "sha512-Qxl/P2NPYhKM1RqQZtSNauYIvTXb4G4gPOFRHc8iLZRnjN0cxRxJcoonz/hBX436qnv5ZYs7wEqZe2HQCBUtmw==",
       "cpu": [
         "x64"
       ],
@@ -6007,13 +6007,13 @@
       ]
     },
     "node_modules/@rspack/core": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-1.5.0.tgz",
-      "integrity": "sha512-eEtiKV+CUcAtnt1K+eiHDzmBXQcNM8CfCXOzr0+gHGp4w4Zks2B8RF36sYD03MM2bg8VRXXsf0MicQ8FvRMCOg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-1.5.1.tgz",
+      "integrity": "sha512-/zWrSNFfdTFKyZP1X3Hhg7kcEsd5//GUABbVvr3P5z4HO+gYEnnaXP1Ciu0wlYke+c3M0b5pvnqB+ka0YbYeTg==",
       "license": "MIT",
       "dependencies": {
         "@module-federation/runtime-tools": "0.18.0",
-        "@rspack/binding": "1.5.0",
+        "@rspack/binding": "1.5.1",
         "@rspack/lite-tapable": "1.0.1"
       },
       "engines": {
@@ -7657,9 +7657,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.1.8",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.8.tgz",
-      "integrity": "sha512-xG7xaBMJCpcK0RpN8jDbAACQo54ycO6h4dSSmgv8+fu6ZIAdANkx/WsawASUjVXYfy+J9AbUpRMNNEsXCDfDBQ==",
+      "version": "19.1.9",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.9.tgz",
+      "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -8577,9 +8577,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.25.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.3.tgz",
-      "integrity": "sha512-cDGv1kkDI4/0e5yON9yM5G/0A5u8sf5TnmdX5C9qHzI9PPu++sQ9zjm1k9NiOrf3riY4OkK0zSGqfvJyJsgCBQ==",
+      "version": "4.25.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.4.tgz",
+      "integrity": "sha512-4jYpcjabC606xJ3kw2QwGEZKX0Aw7sgQdZCvIK9dhVSPh76BKo+C+btT1RRofH7B+8iNpEbgGNVWiLki5q93yg==",
       "funding": [
         {
           "type": "opencollective",
@@ -8596,8 +8596,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001735",
-        "electron-to-chromium": "^1.5.204",
+        "caniuse-lite": "^1.0.30001737",
+        "electron-to-chromium": "^1.5.211",
         "node-releases": "^2.0.19",
         "update-browserslist-db": "^1.1.3"
       },
@@ -16752,14 +16752,196 @@
       }
     },
     "node_modules/next-rspack": {
-      "version": "15.5.1-canary.14",
-      "resolved": "https://registry.npmjs.org/next-rspack/-/next-rspack-15.5.1-canary.14.tgz",
-      "integrity": "sha512-P6K0FjBR9cOcYlPnDpcsWBdJxdb8jmuNQXi9J6Cn/lA8iCUcBejuflTdjLm9eQXW6jl/lDBdSfhlfmhoIv7q6A==",
+      "version": "15.5.1-canary.17",
+      "resolved": "https://registry.npmjs.org/next-rspack/-/next-rspack-15.5.1-canary.17.tgz",
+      "integrity": "sha512-ALVAv8Rkjr5yZCotTK2Tts6It965Jq+dbbMIq+PWEGu+gl1gYdq+eLWzLVduX4dRYsonGctc29shtXe+au73IA==",
       "dev": true,
       "dependencies": {
         "@rspack/core": "1.5.0",
         "@rspack/plugin-react-refresh": "1.2.0",
         "react-refresh": "0.12.0"
+      }
+    },
+    "node_modules/next-rspack/node_modules/@rspack/binding": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.5.0.tgz",
+      "integrity": "sha512-UGXQmwEu2gdO+tnGv2q4rOWJdWioy6dlLXeZOLYAZVh3mrfKJhZWtDEygX9hCdE5thWNRTlEvx30QQchJAszIQ==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "@rspack/binding-darwin-arm64": "1.5.0",
+        "@rspack/binding-darwin-x64": "1.5.0",
+        "@rspack/binding-linux-arm64-gnu": "1.5.0",
+        "@rspack/binding-linux-arm64-musl": "1.5.0",
+        "@rspack/binding-linux-x64-gnu": "1.5.0",
+        "@rspack/binding-linux-x64-musl": "1.5.0",
+        "@rspack/binding-wasm32-wasi": "1.5.0",
+        "@rspack/binding-win32-arm64-msvc": "1.5.0",
+        "@rspack/binding-win32-ia32-msvc": "1.5.0",
+        "@rspack/binding-win32-x64-msvc": "1.5.0"
+      }
+    },
+    "node_modules/next-rspack/node_modules/@rspack/binding-darwin-arm64": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.5.0.tgz",
+      "integrity": "sha512-7909YLNnKf0BYxiCpCWOk13WyWS4493Kxk1NQwy9KPLY9ydQExk84KVsix2NuNBaI8Pnk3aVLBPJiSNXtHLjnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/next-rspack/node_modules/@rspack/binding-darwin-x64": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.5.0.tgz",
+      "integrity": "sha512-poGuQsGKCMQqSswgrz8X+frqMVTdmtzUDyvi/p9BLwW+2DwWgmywU8jwE+BYtjfWp1tErBSTlLxmEPQTdcIQgQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/next-rspack/node_modules/@rspack/binding-linux-arm64-gnu": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.5.0.tgz",
+      "integrity": "sha512-Bvmk8h3tRhN9UgOtH+vK0SgFM3qEO36eJz7oddOl4lJQxBf2GNA87bGtkMtX+AVPz/PUn7r82uWxrlVNQHAbFg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/next-rspack/node_modules/@rspack/binding-linux-arm64-musl": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.5.0.tgz",
+      "integrity": "sha512-bH7UwkbACDYT37YnN9kkhaF9niFFK9ndcdNvYFFr1oUT4W9Ie3V9b41EXijqp3pyh0mDSeeLPFY0aEx1t3e7Pw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/next-rspack/node_modules/@rspack/binding-linux-x64-gnu": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.5.0.tgz",
+      "integrity": "sha512-xZ5dwNrE5KtpQyMd9israpJTcTQ3UYUUq23fTcNc79xE5aspkGixDFAYoql4YkhO0O+JWRmdSaFAn6jD+IQWQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/next-rspack/node_modules/@rspack/binding-linux-x64-musl": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.5.0.tgz",
+      "integrity": "sha512-mv65jYvcyYPkPZJ9kjSvTAcH0o7C5jfICWCQcMmN1tCGD3b8gmf9GqSZ8e+W/JkuvrJ05qTo/PvEq9nhu+pNIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/next-rspack/node_modules/@rspack/binding-wasm32-wasi": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-wasm32-wasi/-/binding-wasm32-wasi-1.5.0.tgz",
+      "integrity": "sha512-8rVpl6xfaAFJgo1wCd+emksfl+/8nlehrtkmjY9bj79Ou+kp07L9e1B+UU0jfs8e7aLPntQuF68kzLHwYLzWIQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.0.1"
+      }
+    },
+    "node_modules/next-rspack/node_modules/@rspack/binding-win32-arm64-msvc": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.5.0.tgz",
+      "integrity": "sha512-dWSmNm+GR6WSkOwbhlUcot4Oqwyon+1PRZ9E0vIMFHKGvESf9CQjgHAX0QE9G0kJmRM5x3I16J4x44Kw3W/98Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/next-rspack/node_modules/@rspack/binding-win32-ia32-msvc": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.5.0.tgz",
+      "integrity": "sha512-YtOrFEkwhO3Y3sY6Jq0OOYPY7NBTNYuwJ6epTgzPEDGs2cBnwZfzhq0jmD/koWtv1L9+twX95vKosBdauF0tNA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/next-rspack/node_modules/@rspack/binding-win32-x64-msvc": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.5.0.tgz",
+      "integrity": "sha512-V4fcPVYWJgDkIkSsFwmUdwC9lkL8+1dzDOwyTWe6KW2MYHF2D148WPHNyVVE6gum12TShpbIsh0j4NiiMhkMtw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/next-rspack/node_modules/@rspack/core": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-1.5.0.tgz",
+      "integrity": "sha512-eEtiKV+CUcAtnt1K+eiHDzmBXQcNM8CfCXOzr0+gHGp4w4Zks2B8RF36sYD03MM2bg8VRXXsf0MicQ8FvRMCOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/runtime-tools": "0.18.0",
+        "@rspack/binding": "1.5.0",
+        "@rspack/lite-tapable": "1.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "@swc/helpers": ">=0.5.1"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
       }
     },
     "node_modules/next/node_modules/postcss": {
@@ -22810,9 +22992,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.4.tgz",
-      "integrity": "sha512-2YqJuWkU6IIK9qcE4k1lLLhyZ6zFw7XVRdQGpV97jEIZwTrscUw+DY31Xczd8nwaoksyJUIxCojZXwckJovWxA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.5.tgz",
+      "integrity": "sha512-rcUUZqlLJgBC33IT3PNMgsCq6TzLQEG/Ei/KTCU0PedSWRMAXoOUN+4t/0H+Q8bdnLPdqUYnvboJT0bn/229qg==",
       "dev": true,
       "license": "MIT",
       "funding": {


### PR DESCRIPTION
## Sourceryによる要約

`@robopo/web` パッケージ内の開発依存関係を更新し、ロックファイルを更新しました

改善点:
- `@types/react-dom` を 19.1.9 にアップグレード
- `zod` を 4.1.5 にアップグレード

ビルド:
- 依存関係の更新を反映するため、`package-lock.json` を再生成しました

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bump dev dependencies in the @robopo/web package and update lockfile

Enhancements:
- Upgrade @types/react-dom to 19.1.9
- Upgrade zod to 4.1.5

Build:
- Regenerate package-lock.json to reflect dependency bumps

</details>