### PR TITLE
feat: enable `typedRoutes` config option

### DIFF
--- a/@robopo/web/app/components/course/modals.tsx
+++ b/@robopo/web/app/components/course/modals.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import type { Route } from "next"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { useState } from "react"
@@ -21,7 +22,7 @@ export function BackModal() {
   function handleYes() {
     // 今のurlから/back を削除して、/saveに遷移する
     const currentUrl = window.location.href
-    const newUrl = currentUrl.replace(/\/back$/, "/save")
+    const newUrl = currentUrl.replace(/\/back$/, "/save") as Route
     router.push(newUrl)
   }
 

--- a/@robopo/web/app/components/home/tabs.tsx
+++ b/@robopo/web/app/components/home/tabs.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { CalculatorIcon } from "@heroicons/react/24/outline"
+import type { Route } from "next"
 import Link from "next/link"
 import type React from "react"
 import { useMemo, useState } from "react"
@@ -19,13 +20,13 @@ function ContentButton({
   disabled,
 }: {
   name: string
-  link: string
+  link: Route
   icon?: React.JSX.Element
   disabled: boolean
 }) {
   return (
     <Link
-      href={disabled ? "" : link}
+      href={disabled ? ("" as Route) : link}
       className={`btn m-3 flex min-h-20 min-w-40 max-w-fit text-2xl ${disabled ? "btn-disabled" : "btn-primary"}`}
     >
       {icon}
@@ -104,18 +105,22 @@ export function ChallengeTab({
             <ContentButton
               key={course.id}
               name={course.name}
-              link={`/challenge/${competitionId}/${course.id}`}
+              link={`/challenge/${competitionId}/${course.id}` as Route}
               disabled={disableCondition}
             />
           ))}
           <ContentButton
             name="THE一本橋"
-            link={`/challenge/${competitionId}/${RESERVED_COURSE_IDS.IPPON}`}
+            link={
+              `/challenge/${competitionId}/${RESERVED_COURSE_IDS.IPPON}` as Route
+            }
             disabled={disableCondition}
           />
           <ContentButton
             name="センサーコース"
-            link={`/challenge/${competitionId}/${RESERVED_COURSE_IDS.SENSOR}`}
+            link={
+              `/challenge/${competitionId}/${RESERVED_COURSE_IDS.SENSOR}` as Route
+            }
             disabled={disableCondition}
           />
         </div>
@@ -153,7 +158,7 @@ export function SummaryTab({
       </select>
       <ContentButton
         name="集計結果"
-        link={`/summary/${competitionId}`}
+        link={`/summary/${competitionId}` as Route}
         icon={<CalculatorIcon className="h-6 w-6" />}
         disabled={disableCondition}
       />

--- a/@robopo/web/app/lib/const.tsx
+++ b/@robopo/web/app/lib/const.tsx
@@ -10,6 +10,7 @@ import {
   UserIcon,
   WrenchIcon,
 } from "@heroicons/react/24/outline"
+import type { Route } from "next"
 import type { JSX } from "react"
 
 export const BASE_URL: string = process.env.VERCEL
@@ -20,7 +21,7 @@ export const BASE_URL: string = process.env.VERCEL
 
 export interface NavItem {
   label: string
-  href: string
+  href: Route
   icon: JSX.Element
 }
 
@@ -38,7 +39,7 @@ export const SIGN_IN_CONST: NavItem = {
 
 export const SIGN_OUT_CONST: NavItem = {
   label: "サインアウト",
-  href: "/signOut",
+  href: "/signOut" as Route,
   icon: <ArrowRightStartOnRectangleIcon className="size-6" />,
 }
 

--- a/@robopo/web/next.config.ts
+++ b/@robopo/web/next.config.ts
@@ -4,6 +4,7 @@ import withRspack from "next-rspack"
 const mp3TestRegExp = /\.(mp3)$/
 
 const nextConfig: NextConfig = {
+  typedRoutes: true,
   webpack(config) {
     config.module.rules.push({
       test: mp3TestRegExp,


### PR DESCRIPTION
## Sourceryによる要約

Next.js の型付きルートを有効化し、すべてのルート関連プロパティをプレーンな文字列ではなく Route 型を使用するように変更します。

新機能:
- next.config.ts で typedRoutes オプションを有効化

改善点:
- Next.js から Route 型をインポートし、ContentButton の link プロパティおよび NavItem の href を Route を使用するように更新
- 様々なコンポーネントおよびモーダルナビゲーションで、リテラルパス文字列を Route 型にキャスト

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable Next.js typed routes and migrate all route-related props to use the Route type instead of plain strings.

New Features:
- Enable typedRoutes option in next.config.ts

Enhancements:
- Import Route type from Next.js and update ContentButton link prop and NavItem href to use Route
- Cast literal path strings to Route in various components and modal navigation

</details>