### PR TITLE
feat: enable route props helpers

### DIFF
--- a/@robopo/web/app/challenge/[competitionId]/[courseId]/[playerId]/layout.tsx
+++ b/@robopo/web/app/challenge/[competitionId]/[courseId]/[playerId]/layout.tsx
@@ -1,14 +1,12 @@
-import type React from "react"
 import { AudioProvider } from "@/app/challenge/[competitionId]/[courseId]/[playerId]/audioContext"
 
-export default function Layout({
-  children,
-  modal,
-}: Readonly<{ children: React.ReactNode; modal: React.ReactNode }>) {
+export default function Layout(
+  props: LayoutProps<"/challenge/[competitionId]/[courseId]/[playerId]">,
+) {
   return (
     <AudioProvider>
-      {children}
-      {modal}
+      {props.children}
+      {props.modal}
     </AudioProvider>
   )
 }

--- a/@robopo/web/app/course/layout.tsx
+++ b/@robopo/web/app/course/layout.tsx
@@ -1,18 +1,12 @@
 import { NavigationGuardProvider } from "next-navigation-guard"
 import { CourseEditProvider } from "@/app/course/edit/courseEditContext"
 
-export default function Layout({
-  children,
-  modal,
-}: Readonly<{
-  children: React.ReactNode
-  modal: React.ReactNode
-}>) {
+export default function Layout(props: LayoutProps<"/course">) {
   return (
     <NavigationGuardProvider>
       <CourseEditProvider>
-        {children}
-        {modal}
+        {props.children}
+        {props.modal}
       </CourseEditProvider>
     </NavigationGuardProvider>
   )

--- a/@robopo/web/app/layout.tsx
+++ b/@robopo/web/app/layout.tsx
@@ -11,21 +11,15 @@ export const metadata: Metadata = {
   description: "robopo",
 }
 
-export default async function RootLayout({
-  children,
-  auth,
-}: Readonly<{
-  children: React.ReactNode
-  auth: React.ReactNode
-}>) {
+export default async function RootLayout(props: LayoutProps<"/">) {
   const { session } = await HeaderServer()
   return (
     <html lang="ja" className={inter.className}>
       <body className="font-zenKakuGothicNew">
         <main className="mx-auto h-screen w-screen text-xs sm:px-12 lg:text-base">
           <Header session={session} />
-          {children}
-          {auth}
+          {props.children}
+          {props.auth}
         </main>
       </body>
     </html>

--- a/@robopo/web/app/player/layout.tsx
+++ b/@robopo/web/app/player/layout.tsx
@@ -1,14 +1,8 @@
-export default function Layout({
-  children,
-  modal,
-}: Readonly<{
-  children: React.ReactNode
-  modal: React.ReactNode
-}>) {
+export default function Layout(props: LayoutProps<"/player">) {
   return (
     <>
-      {children}
-      {modal}
+      {props.children}
+      {props.modal}
     </>
   )
 }

--- a/@robopo/web/app/umpire/layout.tsx
+++ b/@robopo/web/app/umpire/layout.tsx
@@ -1,14 +1,8 @@
-export default function Layout({
-  children,
-  modal,
-}: Readonly<{
-  children: React.ReactNode
-  modal: React.ReactNode
-}>) {
+export default function Layout(props: LayoutProps<"/umpire">) {
   return (
     <>
-      {children}
-      {modal}
+      {props.children}
+      {props.modal}
     </>
   )
 }


### PR DESCRIPTION
## Sourceryによる要約

レイアウトコンポーネントをリファクタリングし、childrenとmodalの手動での分割代入を`LayoutProps<T>`に置き換え、`props.children`と`props.modal`への参照を更新することで、汎用的なルートpropsヘルパーを活用するようにしました。

改善点:
- すべてのレイアウトコンポーネントで`LayoutProps<route>`ジェネリックを使用し、childrenとmodalへのアクセスを標準化しました。
- レイアウトファイルにおける明示的なReactインポートとpropsの手動での分割代入を削除しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor layout components to leverage generic route props helpers by replacing manual destructuring of children and modal with LayoutProps<T> and updating references to props.children and props.modal

Enhancements:
- Use LayoutProps<route> generic in all layout components to standardize children and modal access
- Remove explicit React imports and manual destructuring of props in layout files

</details>