### PR TITLE
fix: move getCompetitionList call to after switch statement

### DIFF
--- a/@robopo/web/app/api/competition/[id]/route.ts
+++ b/@robopo/web/app/api/competition/[id]/route.ts
@@ -14,7 +14,6 @@ export async function POST(
 ) {
   const { id } = await props.params
   const { type } = await req.json()
-  const newList = await getCompetitionList()
   let result: QueryResult
 
   switch (type) {
@@ -37,6 +36,7 @@ export async function POST(
         { status: 400 },
       )
   }
+  const newList = await getCompetitionList()
   return Response.json(
     { success: true, data: result, newList: newList },
     { status: 200 },

--- a/@robopo/web/app/components/common/commonList.tsx
+++ b/@robopo/web/app/components/common/commonList.tsx
@@ -11,11 +11,11 @@ import type {
 type CommonListProps = {
   type: "player" | "umpire" | "course" | "competition"
   commonDataList:
-    | SelectPlayer[]
-    | SelectUmpire[]
-    | SelectCompetition[]
-    | SelectPlayerWithCompetition[]
-    | SelectUmpireWithCompetition[]
+  | SelectPlayer[]
+  | SelectUmpire[]
+  | SelectCompetition[]
+  | SelectPlayerWithCompetition[]
+  | SelectUmpireWithCompetition[]
 }
 
 function TableComponent({
@@ -24,11 +24,11 @@ function TableComponent({
 }: {
   type: CommonListProps["type"]
   common:
-    | SelectPlayer
-    | SelectUmpire
-    | SelectCompetition
-    | SelectPlayerWithCompetition
-    | SelectUmpireWithCompetition
+  | SelectPlayer
+  | SelectUmpire
+  | SelectCompetition
+  | SelectPlayerWithCompetition
+  | SelectUmpireWithCompetition
 }) {
   return (
     <>
@@ -105,7 +105,7 @@ function itemNames(type: CommonListProps["type"]): string[] {
   } else if (type === "course") {
     itemNames.push("ID", "コース名", "作成日時", "使用大会")
   } else if (type === "competition") {
-    itemNames.push("ID", "名前", "開催中")
+    itemNames.push("ID", "名前", "開催状況")
   }
   return itemNames
 }

--- a/@robopo/web/app/components/common/commonList.tsx
+++ b/@robopo/web/app/components/common/commonList.tsx
@@ -11,11 +11,11 @@ import type {
 type CommonListProps = {
   type: "player" | "umpire" | "course" | "competition"
   commonDataList:
-  | SelectPlayer[]
-  | SelectUmpire[]
-  | SelectCompetition[]
-  | SelectPlayerWithCompetition[]
-  | SelectUmpireWithCompetition[]
+    | SelectPlayer[]
+    | SelectUmpire[]
+    | SelectCompetition[]
+    | SelectPlayerWithCompetition[]
+    | SelectUmpireWithCompetition[]
 }
 
 function TableComponent({
@@ -24,11 +24,11 @@ function TableComponent({
 }: {
   type: CommonListProps["type"]
   common:
-  | SelectPlayer
-  | SelectUmpire
-  | SelectCompetition
-  | SelectPlayerWithCompetition
-  | SelectUmpireWithCompetition
+    | SelectPlayer
+    | SelectUmpire
+    | SelectCompetition
+    | SelectPlayerWithCompetition
+    | SelectUmpireWithCompetition
 }) {
   return (
     <>

--- a/@robopo/web/app/config/tabs.tsx
+++ b/@robopo/web/app/config/tabs.tsx
@@ -37,12 +37,12 @@ export function CompetitionListTab({
     const requestBody =
       type === "delete"
         ? {
-            type: type,
-            id: competitionId,
-          }
+          type: type,
+          id: competitionId,
+        }
         : {
-            type: type,
-          }
+          type: type,
+        }
 
     const url =
       type === "delete"
@@ -117,7 +117,7 @@ export function CompetitionListTab({
         }
         onClick={(e) => handleButtonClick(e)}
       >
-        停止
+        終了
       </button>
       <button
         type="button"

--- a/@robopo/web/app/config/tabs.tsx
+++ b/@robopo/web/app/config/tabs.tsx
@@ -37,12 +37,12 @@ export function CompetitionListTab({
     const requestBody =
       type === "delete"
         ? {
-          type: type,
-          id: competitionId,
-        }
+            type: type,
+            id: competitionId,
+          }
         : {
-          type: type,
-        }
+            type: type,
+          }
 
     const url =
       type === "delete"


### PR DESCRIPTION
-大会開催状況表示の適正化。

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

- [ ] Documentation (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- 
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

## Sourceryによる要約

競技ステータスの表示を調整し、APIがリクエスト処理後に更新された競技リストを返すように、`getCompetitionList` の呼び出し位置を変更します。

バグ修正:
- 更新されたリストを正しく取得するため、`getCompetitionList` の呼び出しを `switch` ステートメントの後に移動しました。

改善点:
- 競技テーブルのヘッダー名を「開催中」から「開催状況」に変更しました。
- インデントの一貫性を保つため、`CommonList` コンポーネント内のユニオン型宣言の書式を再調整しました。

<details>
<summary>Original summary in English</summary>

## Sourceryによる要約

更新されたリストを返すために、競技リストの取得を処理後に移動し、競技テーブルヘッダーのラベルを「開催中」ではなく「開催状況」を反映するように更新しました。

バグ修正:
- APIが更新された競技リストを返すように、`getCompetitionList` の呼び出しを switch 文の後に移動しました。

機能強化:
- 競技テーブルヘッダーの名前を「開催中」から「開催状況」に変更しました。

<details>
<summary>Original summary in English</summary>

## Sourceryによる要約

更新された競技リストを返すため、`getCompetitionList` の呼び出しを `switch` ステートメントの後に移動し、競技ステータスと終了ボタンのUIラベルを更新しました。

バグ修正:
- 更新されたリストを取得するため、競技APIルートの `switch` ステートメントの後に `getCompetitionList` の呼び出しを移動

改善点:
- 競技テーブルのヘッダーラベルを「開催中」から「開催状況」に更新
- 競技リストのタブボタンラベルを「停止」から「終了」に変更

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Move the getCompetitionList invocation to after the switch statement to return the updated competition list, and update UI labels for competition status and the end button.

Bug Fixes:
- Move getCompetitionList call to after switch in the competition API route to fetch the updated list

Enhancements:
- Update competition table header label from "開催中" to "開催状況"
- Change competition list tab button label from "停止" to "終了"

</details>

</details>

</details>