### PR TITLE
feat: add password visibility toggle to sign-in form and hide default…

### DIFF
--- a/@robopo/web/app/@auth/signIn/page.tsx
+++ b/@robopo/web/app/@auth/signIn/page.tsx
@@ -1,7 +1,8 @@
 "use client"
 
+import { EyeIcon, EyeSlashIcon } from "@heroicons/react/24/outline"
 import { useSearchParams } from "next/navigation"
-import { useActionState, useEffect, useId } from "react"
+import { useActionState, useEffect, useId, useState } from "react"
 import {
   ModalBackButton,
   ModalBackdrop,
@@ -35,6 +36,7 @@ export default function SignIn() {
 
   const callbackUrl = getSafeCallbackUrl(rawCallbackUrl)
   const [state, action] = useActionState(signInAction, undefined)
+  const [showPassword, setShowPassword] = useState(false)
 
   useEffect(() => {
     if (state?.success) {
@@ -57,15 +59,27 @@ export default function SignIn() {
             />
           </label>
           <br />
-          <label className="input" htmlFor={passwordId}>
+          <label className="input relative" htmlFor={passwordId}>
             <span className="label">パスワード</span>
             <input
               id={passwordId}
-              type="password"
+              type={showPassword ? "text" : "password"}
               name="password"
               placeholder="12345678"
               required={true}
             />
+            <button
+              type="button"
+              onClick={() => setShowPassword((prev) => !prev)}
+              className="absolute inset-y-0 right-2 flex items-center text-gray-500 text-sm"
+              aria-label="Show password"
+            >
+              {showPassword ? (
+                <EyeSlashIcon className="size-6" />
+              ) : (
+                <EyeIcon className="size-6" />
+              )}
+            </button>
           </label>
           <div className="flex">
             <button className="btn btn-accent my-3 flex" type="submit">

--- a/@robopo/web/app/globals.css
+++ b/@robopo/web/app/globals.css
@@ -99,3 +99,13 @@
 .gradient-button span {
   z-index: 1; /* 文字を前面に表示 */
 }
+
+/* hide default password visibility toggle button */
+input[type="password"]::-ms-reveal,
+input[type="password"]::-ms-clear,
+input[type="password"]::-webkit-credentials-auto-fill-button,
+input[type="password"]::-webkit-password-toggle-button {
+  /* biome-ignore lint/complexity/noImportantStyles: 各ブラウザの UA stylesheet（ブラウザ内部のデフォルト CSS）はかなり強い優先度を持っています。
+  Safari や一部のモバイルブラウザでは !important を付けないと UA stylesheet に勝てず、::-webkit-password-toggle-button が消せないことがあります。 */
+  display: none !important;
+}


### PR DESCRIPTION
… toggle button

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.
-->

### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

- [ ] Documentation (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- 
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

## Sourceryによる要約

サインインフォームにカスタムのパスワード表示/非表示トグルを追加し、CSS経由でネイティブブラウザの表示トグルを削除

新機能:
- サインインフォームにパスワード表示/非表示トグルボタンを追加

改善点:
- CSS経由でデフォルトのブラウザのパスワード表示トグルボタンを非表示にする

<details>
<summary>Original summary in English</summary>

## Sourceryによる概要

サインインフォームにカスタムのパスワード表示/非表示トグルを追加し、CSSによってブラウザ標準のパスワード表示コントロールを削除しました。

新機能:
- サインインフォームにパスワードの表示/非表示を切り替えるボタンを追加

機能強化:
- CSSを使用して、ブラウザ標準のパスワード表示およびクリアボタンを非表示にします。

<details>
<summary>Original summary in English</summary>

## Sourceryによる概要

サインインフォームにカスタムのパスワード表示/非表示切り替え機能を追加し、CSSを使用してブラウザのネイティブなパスワード表示/クリアコントロールを削除します。

新機能:
- サインインフォームにパスワードの表示を切り替えるボタンを追加

改善点:
- CSSを介して、ブラウザのデフォルトのパスワード表示およびクリアボタンを非表示にする

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a custom show/hide password toggle to the sign-in form and remove the native browser password reveal/clear controls using CSS.

New Features:
- Add a button to toggle password visibility in the sign-in form

Enhancements:
- Hide default browser password reveal and clear buttons via CSS

</details>

</details>

</details>