### PR TITLE
fix: show cancel button when the goai is completed

### DIFF
--- a/@robopo/web/app/api/course/route.ts
+++ b/@robopo/web/app/api/course/route.ts
@@ -1,5 +1,12 @@
 import type { NextRequest } from "next/server"
 import { deleteById } from "@/app/api/delete"
+import {
+  checkValidity,
+  deserializeField,
+  deserializeMission,
+  isGoal,
+  isStart,
+} from "@/app/components/course/utils"
 import { createCourse } from "@/app/lib/db/queries/insert"
 import { getCourseById } from "@/app/lib/db/queries/queries"
 import { updateCourse } from "@/app/lib/db/queries/update"
@@ -19,17 +26,27 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
-  const { name, field, fieldvalid, mission, missionvalid, point } =
-    await req.json()
+  const { name, field, mission, point } = await req.json()
   const searchParams = req.nextUrl.searchParams
   const rawId = searchParams.get("id")
   const id = rawId ? Number.parseInt(rawId, 10) : null
+
+  const parsedField = field ? deserializeField(field) : null
+  const parsedMission = mission ? deserializeMission(mission) : null
+  const computedFieldValid = parsedField
+    ? isStart(parsedField) && isGoal(parsedField)
+    : false
+  const computedMissionValid =
+    parsedField && parsedMission
+      ? checkValidity(parsedField, parsedMission)
+      : false
+
   const courseData = {
     name: name,
     field: field,
-    fieldValid: fieldvalid,
+    fieldValid: computedFieldValid,
     mission: mission,
-    missionValid: missionvalid,
+    missionValid: computedMissionValid,
     point: point,
   }
 

--- a/@robopo/web/app/challenge/challenge.tsx
+++ b/@robopo/web/app/challenge/challenge.tsx
@@ -216,14 +216,9 @@ function NormalChallengeSection({
             </p>
           )}
           {isSuccess ? (
-            <button
-              type="button"
-              className="btn btn-success"
-              onClick={() => window.location.reload()}
-            >
-              コース一覧に
-              <BackLabelWithIcon />
-            </button>
+            <p className="text-base-content/50 text-sm">
+              ホーム画面へ自動遷移します
+            </p>
           ) : (
             <button
               type="button"
@@ -273,17 +268,17 @@ function NormalChallengeSection({
       </div>
 
       {/* Action bar */}
-      {!isGoal && (
-        <div className="border-base-300 border-t bg-base-100 px-4 py-3">
-          <div className="flex items-center gap-3">
-            <button
-              type="button"
-              className="btn btn-outline flex-1"
-              onClick={handleBack}
-              disabled={FieldProps.nowMission === 0}
-            >
-              <BackLabelWithIcon />
-            </button>
+      <div className="border-base-300 border-t bg-base-100 px-4 py-3">
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            className="btn btn-outline flex-1"
+            onClick={handleBack}
+            disabled={FieldProps.nowMission === 0}
+          >
+            <BackLabelWithIcon />
+          </button>
+          {!isGoal && (
             <button
               type="button"
               className="btn btn-error flex-1"
@@ -291,12 +286,12 @@ function NormalChallengeSection({
             >
               失敗
             </button>
-          </div>
-          <div className="mt-2 flex justify-center">
-            <SoundController />
-          </div>
+          )}
         </div>
-      )}
+        <div className="mt-2 flex justify-center">
+          <SoundController />
+        </div>
+      </div>
     </div>
   )
 }

--- a/@robopo/web/app/challenge/challengeModal.tsx
+++ b/@robopo/web/app/challenge/challengeModal.tsx
@@ -35,14 +35,9 @@ export function ChallengeModal({
         {isSuccess ? (
           <div className="flex flex-col items-center gap-4">
             <p className="text-base text-base-content/70">{message}</p>
-            <button
-              type="button"
-              className="btn btn-success w-full"
-              onClick={() => window.location.reload()}
-            >
-              コース一覧に
-              <BackLabelWithIcon />
-            </button>
+            <p className="text-base-content/50 text-sm">
+              ホーム画面へ自動遷移します
+            </p>
           </div>
         ) : (
           <div className="flex flex-col gap-4">
@@ -190,14 +185,9 @@ export function CourseOutModal({
         {isSuccess ? (
           <div className="flex flex-col items-center gap-4">
             <p className="text-base text-base-content/70">{message}</p>
-            <button
-              type="button"
-              className="btn btn-success w-full"
-              onClick={() => window.location.reload()}
-            >
-              コース一覧に
-              <BackLabelWithIcon />
-            </button>
+            <p className="text-base-content/50 text-sm">
+              ホーム画面へ自動遷移します
+            </p>
           </div>
         ) : (
           <div className="flex flex-col gap-4">

--- a/@robopo/web/app/components/challenge/ipponBashi.tsx
+++ b/@robopo/web/app/components/challenge/ipponBashi.tsx
@@ -28,7 +28,7 @@ export function IpponBashiUI({
   for (let i = 0; i < length - 1; i++) {
     field.push(["route"])
   }
-  field.push(["start"])
+  field.push(["startGoal"])
 
   const ipponBashiStyle: React.CSSProperties = {
     position: "relative",

--- a/@robopo/web/app/components/course/modals.tsx
+++ b/@robopo/web/app/components/course/modals.tsx
@@ -7,6 +7,8 @@ import { useState } from "react"
 import { useFormStatus } from "react-dom"
 import {
   checkValidity,
+  isGoal,
+  isStart,
   serializeField,
   serializeMission,
   serializePoint,
@@ -83,9 +85,9 @@ export function SaveModal({ courseId }: { courseId: number | null }) {
     const courseData = {
       name: name,
       field: serializeField(field),
-      fieldValid: true,
+      fieldvalid: isStart(field) && isGoal(field),
       mission: serializeMission(mission),
-      missionValid: true,
+      missionvalid: checkValidity(field, mission),
       point: serializePoint(point),
     }
 

--- a/@robopo/web/app/components/course/robot.tsx
+++ b/@robopo/web/app/components/course/robot.tsx
@@ -38,7 +38,7 @@ export function Robot({
 
   return (
     <div style={botStyle}>
-      <Image src="/robot.png" alt="bot" fill sizes="100vw" />
+      <Image src="/robot.png" alt="bot" fill sizes={`${PANEL_SIZE}px`} />
     </div>
   )
 }

--- a/@robopo/web/app/lib/db/queries/initial.sql
+++ b/@robopo/web/app/lib/db/queries/initial.sql
@@ -1,5 +1,5 @@
 -- THE 一本橋のコースをID -1 に挿入する
-INSERT INTO course (id, name, field, fieldvalid, mission, missionvalid, point) VALUES (-1, 'THE IpponBashi', 'route;route;route;route;start', TRUE, 'u;null;mf;1;mf;1;mf;1;mf;1;tr;180;mf;1;mf;1;mf;1;mf;1', TRUE, '0;20;1;1;1;1;0;2;2;2;2');
+INSERT INTO course (id, name, field, fieldvalid, mission, missionvalid, point) VALUES (-1, 'THE IpponBashi', 'route;route;route;route;startGoal', TRUE, 'u;null;mf;1;mf;1;mf;1;mf;1;tr;180;mf;1;mf;1;mf;1;mf;1', TRUE, '0;20;1;1;1;1;0;2;2;2;2');
 
 -- センサーコースをID -2 に挿入する
 INSERT INTO course (id, name, fieldvalid, missionvalid) VALUES (-2, 'SensorCourse', TRUE, TRUE);

--- a/@robopo/web/app/lib/db/seed.ts
+++ b/@robopo/web/app/lib/db/seed.ts
@@ -8,10 +8,13 @@ async function seed() {
     // Reserved courses
     await db.execute(sql`
       INSERT INTO course (id, name, field, fieldvalid, mission, missionvalid, point)
-      VALUES (-1, 'THE IpponBashi', 'route;route;route;route;start', TRUE,
+      VALUES (-1, 'THE IpponBashi', 'route;route;route;route;startGoal', TRUE,
         'u;null;mf;1;mf;1;mf;1;mf;1;tr;180;mf;1;mf;1;mf;1;mf;1', TRUE,
         '0;20;1;1;1;1;0;2;2;2;2')
-      ON CONFLICT (id) DO NOTHING
+      ON CONFLICT (id) DO UPDATE SET
+        field = EXCLUDED.field,
+        mission = EXCLUDED.mission,
+        point = EXCLUDED.point
     `)
     await db.execute(sql`
       INSERT INTO course (id, name, fieldvalid, missionvalid)
@@ -68,7 +71,7 @@ async function seed() {
     const courseResult = await db.execute<{ id: number }>(sql`
       INSERT INTO course (name, field, fieldvalid, mission, missionvalid, point)
       VALUES ('TestCourse',
-        'start,null,null;route,null,null;route,null,null',
+        'goal,null,null;route,null,null;start,null,null',
         TRUE,
         'u;null;mf;1;mf;1',
         TRUE,
@@ -123,11 +126,11 @@ async function seed() {
     const course2Result = await db.execute<{ id: number }>(sql`
       INSERT INTO course (name, field, fieldvalid, mission, missionvalid, point)
       VALUES ('TestCourse2',
-        'start,null,null;route,null,null;route,null,null;route,null,null',
+        'goal,route,null;null,route,null;null,start,null',
         TRUE,
-        'u;null;mf;1;mf;1;mr;90',
+        'u;null;mf;1;mf;1;tl;90;mf;1',
         TRUE,
-        '0;15;5;5;10')
+        '0;15;5;5;0;10')
       RETURNING id
     `)
     const testCourse2Id = course2Result.rows[0].id

--- a/@robopo/web/test/unit/lib/db/seed.test.ts
+++ b/@robopo/web/test/unit/lib/db/seed.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test"
 import { eq } from "drizzle-orm"
-import { RESERVED_COURSE_IDS } from "@/app/components/course/utils"
+import {
+  checkValidity,
+  deserializeField,
+  deserializeMission,
+  RESERVED_COURSE_IDS,
+} from "@/app/components/course/utils"
 import { db } from "@/app/lib/db/db"
 import { course, umpire } from "@/app/lib/db/schema"
 
@@ -38,5 +43,39 @@ describe("seed data", () => {
   test("reserved courses are hidden in list (id < 0)", () => {
     expect(RESERVED_COURSE_IDS.IPPON).toBeLessThan(0)
     expect(RESERVED_COURSE_IDS.SENSOR).toBeLessThan(0)
+  })
+
+  test("IpponBashi course passes checkValidity", async () => {
+    const ippon = await db
+      .select()
+      .from(course)
+      .where(eq(course.id, RESERVED_COURSE_IDS.IPPON))
+      .limit(1)
+    expect(ippon).toHaveLength(1)
+    const field = deserializeField(ippon[0].field ?? "")
+    const mission = deserializeMission(ippon[0].mission ?? "")
+    expect(checkValidity(field, mission)).toBe(true)
+  })
+
+  test("test courses pass checkValidity", async () => {
+    const testCourses = await db
+      .select()
+      .from(course)
+      .where(eq(course.name, "TestCourse"))
+      .limit(1)
+    expect(testCourses).toHaveLength(1)
+    const field1 = deserializeField(testCourses[0].field ?? "")
+    const mission1 = deserializeMission(testCourses[0].mission ?? "")
+    expect(checkValidity(field1, mission1)).toBe(true)
+
+    const testCourses2 = await db
+      .select()
+      .from(course)
+      .where(eq(course.name, "TestCourse2"))
+      .limit(1)
+    expect(testCourses2).toHaveLength(1)
+    const field2 = deserializeField(testCourses2[0].field ?? "")
+    const mission2 = deserializeMission(testCourses2[0].mission ?? "")
+    expect(checkValidity(field2, mission2)).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary by Sourcery

コースのバリデーションロジック、シードデータ、UI を更新し、正しいコース完了動作と完了後の自動遷移をサポートします。

バグ修正:
- ゴール到達後でもキャンセル/失敗ボタンが表示されたままになり、ユーザーが完了済みの走行をキャンセルできるようにします。
- クライアントから渡されたフラグを信用せず、デシリアライズしたデータを用いてサーバー側でコースフィールドとミッションの有効性を計算します。
- IpponBashi コースおよびテストコースの定義を修正し、スタート/ゴールの配置とミッションが有効性チェックを通過するようにします。

機能拡張:
- コース完了後に、手動リロードボタンの代わりにホーム画面への自動遷移を示す成功メッセージを表示します。
- より正確な見た目になるよう、IpponBashi の UI フィールド構成とロボット画像のサイズを調整します。

テスト:
- IpponBashi コースおよびテストコースがミッションの有効性チェックを通過することを検証するデータベースシードテストを追加します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update course validation logic, seed data, and UI to support correct course completion behavior and automatic navigation after success.

Bug Fixes:
- Ensure the cancel/fail button remains visible even after the goal is reached so users can cancel a completed run.
- Compute course field and mission validity on the server using deserialized data instead of trusting client-provided flags.
- Correct IpponBashi and test course definitions so that start/goal placement and missions pass validity checks.

Enhancements:
- Show a success message indicating automatic navigation to the home screen instead of a manual reload button after course completion.
- Adjust the IpponBashi UI field configuration and robot image sizing for more accurate visual representation.

Tests:
- Add database seed tests to verify IpponBashi and test courses pass mission validity checks.

</details>