### PR TITLE
feat: remove re-sync button

### DIFF
--- a/@robopo/web/app/components/course/modals.tsx
+++ b/@robopo/web/app/components/course/modals.tsx
@@ -7,8 +7,6 @@ import { useState } from "react"
 import { useFormStatus } from "react-dom"
 import {
   checkValidity,
-  isGoal,
-  isStart,
   serializeField,
   serializeMission,
   serializePoint,
@@ -85,9 +83,7 @@ export function SaveModal({ courseId }: { courseId: number | null }) {
     const courseData = {
       name: name,
       field: serializeField(field),
-      fieldvalid: isStart(field) && isGoal(field),
       mission: serializeMission(mission),
-      missionvalid: checkValidity(field, mission),
       point: serializePoint(point),
     }
 

--- a/@robopo/web/app/lib/db/seed.ts
+++ b/@robopo/web/app/lib/db/seed.ts
@@ -13,7 +13,9 @@ async function seed() {
         '0;20;1;1;1;1;0;2;2;2;2')
       ON CONFLICT (id) DO UPDATE SET
         field = EXCLUDED.field,
+        fieldvalid = EXCLUDED.fieldvalid,
         mission = EXCLUDED.mission,
+        missionvalid = EXCLUDED.missionvalid,
         point = EXCLUDED.point
     `)
     await db.execute(sql`

--- a/@robopo/web/test/unit/lib/db/seed.test.ts
+++ b/@robopo/web/test/unit/lib/db/seed.test.ts
@@ -52,30 +52,34 @@ describe("seed data", () => {
       .where(eq(course.id, RESERVED_COURSE_IDS.IPPON))
       .limit(1)
     expect(ippon).toHaveLength(1)
+    expect(ippon[0].fieldValid).toBe(true)
+    expect(ippon[0].missionValid).toBe(true)
     const field = deserializeField(ippon[0].field ?? "")
     const mission = deserializeMission(ippon[0].mission ?? "")
     expect(checkValidity(field, mission)).toBe(true)
   })
 
-  test("test courses pass checkValidity", async () => {
+  test("TestCourse passes checkValidity", async () => {
     const testCourses = await db
       .select()
       .from(course)
       .where(eq(course.name, "TestCourse"))
       .limit(1)
     expect(testCourses).toHaveLength(1)
-    const field1 = deserializeField(testCourses[0].field ?? "")
-    const mission1 = deserializeMission(testCourses[0].mission ?? "")
-    expect(checkValidity(field1, mission1)).toBe(true)
+    const field = deserializeField(testCourses[0].field ?? "")
+    const mission = deserializeMission(testCourses[0].mission ?? "")
+    expect(checkValidity(field, mission)).toBe(true)
+  })
 
+  test("TestCourse2 passes checkValidity", async () => {
     const testCourses2 = await db
       .select()
       .from(course)
       .where(eq(course.name, "TestCourse2"))
       .limit(1)
     expect(testCourses2).toHaveLength(1)
-    const field2 = deserializeField(testCourses2[0].field ?? "")
-    const mission2 = deserializeMission(testCourses2[0].mission ?? "")
-    expect(checkValidity(field2, mission2)).toBe(true)
+    const field = deserializeField(testCourses2[0].field ?? "")
+    const mission = deserializeMission(testCourses2[0].mission ?? "")
+    expect(checkValidity(field, mission)).toBe(true)
   })
 })


### PR DESCRIPTION
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/OpenUp-LabTakizawa/robopo/pull/450).
* #451
* __->__ #450

## Summary by Sourcery

クライアント側の有効性フラグを保存フローから削除したことに伴い、コースのシーディングおよびバリデーション処理を更新しました。

Enhancements:
- コンフリクト時にフィールドおよびミッションの有効性フラグを更新することで、コースのシーディング時にこれらのフラグを保持するようにしました。
- フィールドおよびミッションの有効性プロパティをペイロードから削除し、別の箇所で導出されるようになったことで、コース保存ペイロードを簡素化しました。

Tests:
- IPPON コースの有効性フラグを検証するシードデータテストを拡張し、TestCourse と TestCourse2 に対する別々の有効性チェックを明確にしました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update course seeding and validation handling after removing client-side validity flags from the save flow.

Enhancements:
- Preserve field and mission validity flags when seeding courses by updating them on conflict.
- Simplify course save payload by removing field and mission validity properties now derived elsewhere.

Tests:
- Extend seed data tests to assert validity flags for the IPPON course and clarify separate validity checks for TestCourse and TestCourse2.

</details>