### PR TITLE
feat: polish challenge confirmination page

### DIFF
--- a/@robopo/web/app/challenge/[competitionId]/[courseId]/[playerId]/@modal/modal.tsx
+++ b/@robopo/web/app/challenge/[competitionId]/[courseId]/[playerId]/@modal/modal.tsx
@@ -1,13 +1,13 @@
 "use client"
 
-import { PlayIcon } from "@heroicons/react/24/outline"
+import { MapIcon, PlayIcon, UserIcon } from "@heroicons/react/24/outline"
 import { useRouter } from "next/navigation"
 import { type RefObject, useEffect, useRef } from "react"
 import {
   SoundController,
   useAudioContext,
 } from "@/app/challenge/[competitionId]/[courseId]/[playerId]/audioContext"
-import { BackLabelWithIcon } from "@/app/lib/const"
+import { BackButton } from "@/app/components/parts/buttons"
 import type { SelectCourse, SelectPlayer } from "@/app/lib/db/schema"
 
 export function Modal({
@@ -20,7 +20,7 @@ export function Modal({
   const audioRef = useRef<HTMLAudioElement | null>(null)
   const startSound = audioRef.current
   const router = useRouter()
-  const { muted } = useAudioContext()
+  const { muted, setStarted } = useAudioContext()
   const dialogRef: RefObject<HTMLDialogElement | null> =
     useRef<HTMLDialogElement | null>(null)
 
@@ -35,36 +35,74 @@ export function Modal({
 
   return (
     <dialog ref={dialogRef} className="modal">
-      <div className="modal-box mt-auto mb-0 flex flex-col">
-        <div className="flex w-full flex-col items-center overflow-y-auto">
-          <div className="grid items-start gap-6">
-            <h2 className="text-lg">チャレンジを開始しますか?</h2>
-            <p className="text-2xl">コース: {courseData.name}</p>
-            <p className="text-2xl">選手: {playerData.name}</p>
+      <div className="modal-box mt-auto mb-0 flex max-w-md flex-col p-0">
+        {/* Hero header with gradient accent bar */}
+        <div className="relative overflow-hidden rounded-t-[1.5rem] bg-gradient-to-br from-primary to-primary/80 px-6 pt-6 pb-5">
+          {/* Decorative background circles */}
+          <div className="pointer-events-none absolute top-0 right-0 h-32 w-32 translate-x-8 -translate-y-8 rounded-full bg-white/5" />
+          <div className="pointer-events-none absolute bottom-0 left-0 h-24 w-24 -translate-x-6 translate-y-6 rounded-full bg-white/5" />
+
+          <p className="relative mb-3 text-center font-semibold text-primary-content/70 text-xs uppercase tracking-widest">
+            Challenge Ready
+          </p>
+          <h2 className="relative text-center font-bold text-2xl text-primary-content tracking-tight">
+            チャレンジを開始しますか?
+          </h2>
+        </div>
+
+        {/* Info cards */}
+        <div className="flex flex-col gap-3 px-6 pt-5">
+          {/* Course info card */}
+          <div className="flex items-center gap-4 rounded-2xl border border-base-300/50 bg-base-200/50 px-4 py-3.5 transition-all">
+            <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
+              <MapIcon className="size-5" />
+            </div>
+            <div className="min-w-0 flex-1">
+              <p className="font-medium text-base-content/50 text-xs uppercase tracking-wider">
+                コース
+              </p>
+              <p className="truncate font-bold text-base-content text-lg leading-tight">
+                {courseData.name}
+              </p>
+            </div>
           </div>
+
+          {/* Player info card */}
+          <div className="flex items-center gap-4 rounded-2xl border border-base-300/50 bg-base-200/50 px-4 py-3.5 transition-all">
+            <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-accent/10 text-accent">
+              <UserIcon className="size-5" />
+            </div>
+            <div className="min-w-0 flex-1">
+              <p className="font-medium text-base-content/50 text-xs uppercase tracking-wider">
+                選手
+              </p>
+              <p className="truncate font-bold text-base-content text-lg leading-tight">
+                {playerData.name}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Action area */}
+        <div className="flex flex-col items-center gap-3 px-6 pt-5 pb-6">
+          {/* Start button - big, bold, energetic */}
           <button
             type="button"
-            className="btn btn-accent m-5 mx-auto min-w-28 max-w-fit text-3xl"
+            className="btn btn-accent start-btn-glow w-full rounded-2xl py-7 font-bold text-2xl tracking-wide shadow-accent/30 shadow-xl transition-all duration-200 hover:shadow-2xl hover:shadow-accent/40 active:scale-[0.97] motion-reduce:transition-none motion-reduce:transform-none"
             onClick={() => {
               !muted && startSound?.play()
+              setStarted(true)
               dialogRef.current?.close()
             }}
           >
+            <PlayIcon className="size-7" />
             スタート
-            <PlayIcon className="size-6" />
           </button>
+
           <SoundController />
           <audio src="/sound/01_start.mp3" ref={audioRef} muted={muted} />
-          <button
-            type="button"
-            className="btn btn-primary mx-auto mt-5 min-w-28 max-w-fit"
-            onClick={() => {
-              router.back()
-            }}
-          >
-            選手選択に
-            <BackLabelWithIcon />
-          </button>
+
+          <BackButton onClick={() => router.back()} fullWidth />
         </div>
       </div>
     </dialog>

--- a/@robopo/web/app/challenge/[competitionId]/[courseId]/[playerId]/@modal/modal.tsx
+++ b/@robopo/web/app/challenge/[competitionId]/[courseId]/[playerId]/@modal/modal.tsx
@@ -88,7 +88,7 @@ export function Modal({
           {/* Start button - big, bold, energetic */}
           <button
             type="button"
-            className="btn btn-accent start-btn-glow w-full rounded-2xl py-7 font-bold text-2xl tracking-wide shadow-accent/30 shadow-xl transition-all duration-200 hover:shadow-2xl hover:shadow-accent/40 active:scale-[0.97] motion-reduce:transition-none motion-reduce:transform-none"
+            className="btn btn-accent start-btn-glow w-full rounded-2xl py-7 font-bold text-2xl tracking-wide shadow-accent/30 shadow-xl transition-all duration-200 hover:shadow-2xl hover:shadow-accent/40 active:scale-[0.97] motion-reduce:transform-none motion-reduce:transition-none"
             onClick={() => {
               !muted && startSound?.play()
               setStarted(true)

--- a/@robopo/web/app/challenge/[competitionId]/[courseId]/[playerId]/audioContext.tsx
+++ b/@robopo/web/app/challenge/[competitionId]/[courseId]/[playerId]/audioContext.tsx
@@ -2,17 +2,30 @@
 
 import { SpeakerWaveIcon, SpeakerXMarkIcon } from "@heroicons/react/24/outline"
 import type React from "react"
-import { createContext, useContext, useState } from "react"
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
 
 export type AudioContextType = {
   muted: boolean
   setMuted: React.Dispatch<React.SetStateAction<boolean>>
+  started: boolean
+  setStarted: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 const dummy: AudioContextType = {
   muted: true,
   setMuted: () => {
-    throw new Error("setSoundOn called outside of AudioContext provider")
+    throw new Error("setMuted called outside of AudioContext provider")
+  },
+  started: false,
+  setStarted: () => {
+    throw new Error("setStarted called outside of AudioContext provider")
   },
 }
 
@@ -24,9 +37,10 @@ export function useAudioContext() {
 
 export function AudioProvider({ children }: { children: React.ReactNode }) {
   const [muted, setMuted] = useState<boolean>(dummy.muted)
+  const [started, setStarted] = useState<boolean>(false)
 
   return (
-    <AudioContext.Provider value={{ muted, setMuted }}>
+    <AudioContext.Provider value={{ muted, setMuted, started, setStarted }}>
       {children}
     </AudioContext.Provider>
   )
@@ -34,20 +48,48 @@ export function AudioProvider({ children }: { children: React.ReactNode }) {
 
 export function SoundController() {
   const { muted, setMuted } = useAudioContext()
+  const previewRef = useRef<HTMLAudioElement | null>(null)
+
+  const handleToggle = useCallback(() => {
+    if (muted) {
+      // OFF → ON: プレビュー音を鳴らして音量を確認させる
+      if (!previewRef.current) {
+        previewRef.current = new Audio("/sound/02_next.mp3")
+        previewRef.current.volume = 0.4
+      }
+      const audio = previewRef.current
+      audio.currentTime = 0
+      audio.play().catch(() => {
+        // Ignore play errors (e.g. autoplay policies or rapid toggling)
+      })
+    }
+    setMuted(!muted)
+  }, [muted, setMuted])
+
+  // Cleanup: アンマウント時にAudioインスタンスを解放
+  useEffect(() => {
+    return () => {
+      if (previewRef.current) {
+        previewRef.current.pause()
+        previewRef.current.currentTime = 0
+        previewRef.current = null
+      }
+    }
+  }, [])
 
   return (
     <button
       type="button"
       className="btn btn-ghost mx-auto bg-gray-100"
-      onClick={() => setMuted(!muted)}
+      onClick={handleToggle}
       aria-label="効果音のオン・オフ切り替え"
     >
-      <span className="text-lg">効果音: {muted ? "OFF" : "ON"}</span>
       {muted ? (
-        <SpeakerXMarkIcon className="size-8 text-red-500" />
+        <SpeakerXMarkIcon className="size-6 text-red-500" />
       ) : (
-        <SpeakerWaveIcon className="size-8 text-green-500" />
+        <SpeakerWaveIcon className="size-6 text-green-500" />
       )}
+      <span className="text-base">効果音{muted ? "OFF" : "ON"}</span>
     </button>
   )
 }

--- a/@robopo/web/app/challenge/[competitionId]/[courseId]/[playerId]/view.tsx
+++ b/@robopo/web/app/challenge/[competitionId]/[courseId]/[playerId]/view.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useEffect, useState } from "react"
+import { useAudioContext } from "@/app/challenge/[competitionId]/[courseId]/[playerId]/audioContext"
 import { Challenge } from "@/app/challenge/challenge"
 import { SensorCourse } from "@/app/components/challenge/sensorCourse"
 import { RESERVED_COURSE_IDS } from "@/app/components/course/utils"
@@ -20,7 +21,16 @@ export function View({
   umpireId: number
 }) {
   const playerId = playerData.id
-  const [isEnabled, setIsEnabled] = useState(true)
+  const { started } = useAudioContext()
+  const [isEnabled, setIsEnabled] = useState(false)
+
+  // スタートボタンが押されたら離脱警告を有効化
+  useEffect(() => {
+    if (started) {
+      setIsEnabled(true)
+    }
+  }, [started])
+
   useEffect(() => {
     if (!isEnabled) {
       return

--- a/@robopo/web/app/challenge/[competitionId]/[courseId]/view.tsx
+++ b/@robopo/web/app/challenge/[competitionId]/[courseId]/view.tsx
@@ -1,12 +1,10 @@
 "use client"
 
-import {
-  ArrowUturnLeftIcon,
-  MagnifyingGlassIcon,
-  PlayIcon,
-} from "@heroicons/react/24/outline"
+import { MagnifyingGlassIcon, PlayIcon } from "@heroicons/react/24/outline"
 import Link from "next/link"
+import { useRouter } from "next/navigation"
 import { useMemo, useState } from "react"
+import { BackButton } from "@/app/components/parts/buttons"
 import type { SelectCourse, SelectPlayer } from "@/app/lib/db/schema"
 
 export function View({
@@ -22,6 +20,7 @@ export function View({
   courseId: number
   umpireId: number
 }) {
+  const router = useRouter()
   const [searchQuery, setSearchQuery] = useState("")
   const playerDataList = initialPlayerDataList.players
 
@@ -97,10 +96,7 @@ export function View({
       )}
 
       <div className="mt-6 flex justify-center">
-        <Link href="/" className="btn btn-ghost gap-1">
-          <ArrowUturnLeftIcon className="h-5 w-5" />
-          戻る
-        </Link>
+        <BackButton onClick={() => router.push("/")} />
       </div>
     </div>
   )

--- a/@robopo/web/app/challenge/challenge.tsx
+++ b/@robopo/web/app/challenge/challenge.tsx
@@ -28,8 +28,14 @@ import {
   panelOrDegree,
   RESERVED_COURSE_IDS,
 } from "@/app/components/course/utils"
-import { ReloadButton } from "@/app/components/parts/buttons"
-import { BackLabelWithIcon, SendIcon } from "@/app/lib/const"
+import {
+  BackButton,
+  CourseOutButton,
+  FailButton,
+  ReloadButton,
+  RetryButton,
+  SubmitButton,
+} from "@/app/components/parts/buttons"
 
 // Type definitions
 type ChallengeProps = {
@@ -120,37 +126,26 @@ function IpponBashiSection({
       {/* Action bar */}
       <div className="border-base-300 border-t bg-base-100 px-4 py-3">
         <div className="flex items-center justify-between gap-3">
-          <button
-            type="button"
-            className="btn btn-outline btn-sm flex-1"
+          <BackButton
             onClick={handleBack}
             disabled={nowMission === 0}
-          >
-            <BackLabelWithIcon />
-          </button>
-          <button
-            type="button"
-            className="btn btn-error btn-sm flex-1"
+            variant="outline"
+            className="btn-sm flex-1"
+          />
+          <CourseOutButton
             onClick={() => setModalOpen(3)}
-          >
-            コースアウト
-          </button>
-          <button
-            type="button"
-            className="btn btn-warning btn-sm flex-1"
+            className="btn-sm flex-1"
+          />
+          <RetryButton
             onClick={() => setModalOpen(2)}
+            label="再挑戦"
             disabled={isRetry}
-          >
-            再挑戦
-          </button>
-          <button
-            type="button"
-            className="btn btn-accent btn-sm flex-1"
+            className="btn-sm flex-1"
+          />
+          <SubmitButton
             onClick={() => setModalOpen(1)}
-          >
-            結果送信
-            <SendIcon />
-          </button>
+            className="btn-sm flex-1"
+          />
         </div>
         <div className="mt-2 flex justify-center">
           <SoundController />
@@ -220,21 +215,12 @@ function NormalChallengeSection({
               ホーム画面へ自動遷移します
             </p>
           ) : (
-            <button
-              type="button"
-              className="btn btn-accent btn-lg"
+            <SubmitButton
               onClick={() => setModalOpen(1)}
+              loading={loading}
               disabled={loading}
-            >
-              {loading ? (
-                <span className="loading loading-spinner" />
-              ) : (
-                <>
-                  結果送信
-                  <SendIcon />
-                </>
-              )}
-            </button>
+              className="btn-lg"
+            />
           )}
           {message && <p className="text-base-content/60 text-sm">{message}</p>}
         </div>
@@ -270,22 +256,14 @@ function NormalChallengeSection({
       {/* Action bar */}
       <div className="border-base-300 border-t bg-base-100 px-4 py-3">
         <div className="flex items-center gap-3">
-          <button
-            type="button"
-            className="btn btn-outline flex-1"
+          <BackButton
             onClick={handleBack}
             disabled={FieldProps.nowMission === 0}
-          >
-            <BackLabelWithIcon />
-          </button>
+            variant="outline"
+            className="flex-1"
+          />
           {!isGoal && (
-            <button
-              type="button"
-              className="btn btn-error flex-1"
-              onClick={() => setModalOpen(1)}
-            >
-              失敗
-            </button>
+            <FailButton onClick={() => setModalOpen(1)} className="flex-1" />
           )}
         </div>
         <div className="mt-2 flex justify-center">

--- a/@robopo/web/app/challenge/challengeModal.tsx
+++ b/@robopo/web/app/challenge/challengeModal.tsx
@@ -1,5 +1,9 @@
 import type React from "react"
-import { BackLabelWithIcon, RETRY_CONST, SendIcon } from "@/app/lib/const"
+import {
+  BackButton,
+  RetryButton,
+  SubmitButton,
+} from "@/app/components/parts/buttons"
 
 export function ChallengeModal({
   setModalOpen,
@@ -65,37 +69,30 @@ export function ChallengeModal({
 
             <div className="flex flex-col gap-2">
               {/* Primary action */}
-              <button
-                type="button"
-                className="btn btn-accent w-full"
+              <SubmitButton
                 onClick={handleSubmit}
+                label="結果を送信して終了"
+                loading={loading}
                 disabled={loading}
-              >
-                {loading ? (
-                  <span className="loading loading-spinner" />
-                ) : (
-                  <>
-                    結果を送信して終了
-                    <SendIcon />
-                  </>
-                )}
-              </button>
+                fullWidth
+              />
 
               {/* Secondary action */}
               {result2Point === null && !isGoal && (
-                <RetryButton handleRetry={thisHandleRetry} loading={loading} />
+                <RetryButton
+                  onClick={thisHandleRetry}
+                  disabled={loading}
+                  fullWidth
+                />
               )}
 
               {/* Tertiary action */}
-              <button
-                type="button"
-                className="btn btn-ghost w-full"
+              <BackButton
                 onClick={handleClick}
+                label="採点に戻る"
                 disabled={loading}
-              >
-                採点に
-                <BackLabelWithIcon />
-              </button>
+                fullWidth
+              />
             </div>
           </div>
         )}
@@ -132,20 +129,12 @@ export function RetryModal({
             1回目のポイントを保存して再チャレンジしますか?
           </p>
           <div className="flex flex-col gap-2">
-            <button
-              type="button"
-              className="btn btn-warning w-full"
+            <RetryButton
               onClick={thisHandleRetry}
-            >
-              再チャレンジする{RETRY_CONST.icon}
-            </button>
-            <button
-              type="button"
-              className="btn btn-ghost w-full"
-              onClick={() => setModalOpen(0)}
-            >
-              <BackLabelWithIcon />
-            </button>
+              label="再チャレンジする"
+              fullWidth
+            />
+            <BackButton onClick={() => setModalOpen(0)} fullWidth />
           </div>
         </div>
       </div>
@@ -211,57 +200,29 @@ export function CourseOutModal({
             </div>
 
             <div className="flex flex-col gap-2">
-              <button
-                type="button"
-                className="btn btn-accent w-full"
+              <SubmitButton
                 onClick={handleSubmit}
+                loading={loading}
                 disabled={loading}
-              >
-                {loading ? (
-                  <span className="loading loading-spinner" />
-                ) : (
-                  <>
-                    結果送信
-                    <SendIcon />
-                  </>
-                )}
-              </button>
+                fullWidth
+              />
               {result2Point === null && (
-                <RetryButton handleRetry={thisHandleRetry} loading={loading} />
+                <RetryButton
+                  onClick={thisHandleRetry}
+                  disabled={loading}
+                  fullWidth
+                />
               )}
-              <button
-                type="button"
-                className="btn btn-ghost w-full"
+              <BackButton
                 onClick={() => setModalOpen(0)}
+                label="採点に戻る"
                 disabled={loading}
-              >
-                採点に
-                <BackLabelWithIcon />
-              </button>
+                fullWidth
+              />
             </div>
           </div>
         )}
       </div>
     </dialog>
-  )
-}
-
-function RetryButton({
-  handleRetry,
-  loading,
-}: {
-  handleRetry: () => void
-  loading: boolean
-}) {
-  return (
-    <button
-      type="button"
-      className="btn btn-warning w-full"
-      onClick={handleRetry}
-      disabled={loading}
-    >
-      {RETRY_CONST.label}
-      {RETRY_CONST.icon}
-    </button>
   )
 }

--- a/@robopo/web/app/components/common/commonModal.tsx
+++ b/@robopo/web/app/components/common/commonModal.tsx
@@ -7,7 +7,7 @@ import {
 } from "@heroicons/react/24/outline"
 import { useRouter } from "next/navigation"
 import { useState } from "react"
-import { BackLabelWithIcon } from "@/app/lib/const"
+import { BackButton } from "@/app/components/parts/buttons"
 import type { SelectCompetition } from "@/app/lib/db/schema"
 
 type InputType = "player" | "umpire" | "course"
@@ -38,15 +38,7 @@ export function ModalBackdrop() {
 
 export function ModalBackButton() {
   const router = useRouter()
-  return (
-    <button
-      type="button"
-      className="btn btn-ghost w-full rounded-xl text-base-content/60 transition-colors hover:text-base-content"
-      onClick={() => router.back()}
-    >
-      <BackLabelWithIcon />
-    </button>
-  )
+  return <BackButton onClick={() => router.back()} fullWidth />
 }
 
 export function DeleteModal({ type, ids }: { type: InputType; ids: number[] }) {
@@ -119,16 +111,13 @@ export function DeleteModal({ type, ids }: { type: InputType; ids: number[] }) {
                 )}
               </button>
             )}
-            <button
-              type="button"
-              className="btn btn-ghost w-full rounded-xl text-base-content/60 transition-colors hover:text-base-content"
+            <BackButton
               onClick={() => {
                 window.location.href = `/${type}`
               }}
               disabled={loading}
-            >
-              <BackLabelWithIcon />
-            </button>
+              fullWidth
+            />
           </div>
         </div>
       </div>
@@ -244,16 +233,13 @@ export function AssignModal({
                 "大会割り当て解除"
               )}
             </button>
-            <button
-              type="button"
-              className="btn btn-ghost w-full rounded-xl text-base-content/60 transition-colors hover:text-base-content"
+            <BackButton
               onClick={() => {
                 window.location.href = `/${type}`
               }}
               disabled={loading}
-            >
-              <BackLabelWithIcon />
-            </button>
+              fullWidth
+            />
           </div>
         </div>
       </div>

--- a/@robopo/web/app/components/parts/buttons.tsx
+++ b/@robopo/web/app/components/parts/buttons.tsx
@@ -1,6 +1,13 @@
 "use client"
 
-import { ArrowPathIcon, HomeIcon } from "@heroicons/react/24/outline"
+import {
+  ArrowPathIcon,
+  ArrowUpCircleIcon,
+  ArrowUturnLeftIcon,
+  ExclamationTriangleIcon,
+  HomeIcon,
+  PlayIcon,
+} from "@heroicons/react/24/outline"
 import { useRouter } from "next/navigation"
 
 export function ReloadButton() {
@@ -26,6 +33,147 @@ export function HomeButton() {
     >
       <HomeIcon className="size-6" />
       ホーム
+    </button>
+  )
+}
+
+/** 戻るボタン汎用コンポーネント */
+export function BackButton({
+  onClick,
+  label = "戻る",
+  disabled = false,
+  variant = "ghost",
+  fullWidth = false,
+  className: extraClassName,
+}: {
+  onClick: () => void
+  label?: string
+  disabled?: boolean
+  variant?: "ghost" | "outline"
+  fullWidth?: boolean
+  className?: string
+}) {
+  const base =
+    variant === "ghost"
+      ? "btn btn-ghost rounded-xl text-base-content/60 transition-colors hover:text-base-content"
+      : "btn btn-outline rounded-xl transition-all duration-200"
+  const width = fullWidth ? "w-full" : ""
+  return (
+    <button
+      type="button"
+      className={`${base} ${width} ${extraClassName ?? ""}`.trim()}
+      onClick={onClick}
+      disabled={disabled}
+    >
+      <ArrowUturnLeftIcon className="size-5" />
+      {label}
+    </button>
+  )
+}
+
+/** 送信ボタン汎用コンポーネント */
+export function SubmitButton({
+  onClick,
+  label = "結果送信",
+  disabled = false,
+  loading = false,
+  fullWidth = false,
+  className: extraClassName,
+}: {
+  onClick: () => void
+  label?: string
+  disabled?: boolean
+  loading?: boolean
+  fullWidth?: boolean
+  className?: string
+}) {
+  const width = fullWidth ? "w-full" : ""
+  return (
+    <button
+      type="button"
+      className={`btn btn-accent rounded-xl shadow-accent/20 shadow-lg transition-all duration-200 hover:shadow-accent/30 hover:shadow-xl ${width} ${extraClassName ?? ""}`.trim()}
+      onClick={onClick}
+      disabled={disabled || loading}
+    >
+      {loading ? (
+        <span className="loading loading-spinner" />
+      ) : (
+        <>
+          <ArrowUpCircleIcon className="size-5" />
+          {label}
+        </>
+      )}
+    </button>
+  )
+}
+
+/** リトライボタン汎用コンポーネント */
+export function RetryButton({
+  onClick,
+  label = "2回目のチャレンジへ",
+  disabled = false,
+  fullWidth = false,
+  className: extraClassName,
+}: {
+  onClick: () => void
+  label?: string
+  disabled?: boolean
+  fullWidth?: boolean
+  className?: string
+}) {
+  const width = fullWidth ? "w-full" : ""
+  return (
+    <button
+      type="button"
+      className={`btn btn-warning rounded-xl shadow-lg shadow-warning/20 transition-all duration-200 hover:shadow-warning/30 hover:shadow-xl ${width} ${extraClassName ?? ""}`.trim()}
+      onClick={onClick}
+      disabled={disabled}
+    >
+      <PlayIcon className="size-5" />
+      {label}
+    </button>
+  )
+}
+
+/** コースアウトボタン */
+export function CourseOutButton({
+  onClick,
+  disabled = false,
+  className: extraClassName,
+}: {
+  onClick: () => void
+  disabled?: boolean
+  className?: string
+}) {
+  return (
+    <button
+      type="button"
+      className={`btn btn-error rounded-xl transition-all duration-200 ${extraClassName ?? ""}`.trim()}
+      onClick={onClick}
+      disabled={disabled}
+    >
+      <ExclamationTriangleIcon className="size-5" />
+      コースアウト
+    </button>
+  )
+}
+
+/** 失敗ボタン */
+export function FailButton({
+  onClick,
+  className: extraClassName,
+}: {
+  onClick: () => void
+  className?: string
+}) {
+  return (
+    <button
+      type="button"
+      className={`btn btn-error rounded-xl transition-all duration-200 ${extraClassName ?? ""}`.trim()}
+      onClick={onClick}
+    >
+      <ExclamationTriangleIcon className="size-5" />
+      失敗
     </button>
   )
 }

--- a/@robopo/web/app/globals.css
+++ b/@robopo/web/app/globals.css
@@ -107,8 +107,30 @@
   }
 }
 
+/* Start button pulsing glow */
+.start-btn-glow {
+  animation: startGlow 2s ease-in-out infinite;
+}
+
+@keyframes startGlow {
+  0%,
+  100% {
+    box-shadow:
+      0 10px 25px -5px oklch(0.7 0.18 55 / 0.3),
+      0 0 0 0 oklch(0.7 0.18 55 / 0);
+  }
+  50% {
+    box-shadow:
+      0 10px 25px -5px oklch(0.7 0.18 55 / 0.45),
+      0 0 20px 4px oklch(0.7 0.18 55 / 0.15);
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .modal-box {
+    animation: none;
+  }
+  .start-btn-glow {
     animation: none;
   }
 }

--- a/@robopo/web/app/lib/const.tsx
+++ b/@robopo/web/app/lib/const.tsx
@@ -73,8 +73,8 @@ const BACK_CONST = {
 export function BackLabelWithIcon(): JSX.Element {
   return (
     <>
-      {BACK_CONST.label}
       {BACK_CONST.icon}
+      {BACK_CONST.label}
     </>
   )
 }

--- a/@robopo/web/test/unit/challenge/[competitionId]/[courseId]/[playerId]/view.test.tsx
+++ b/@robopo/web/test/unit/challenge/[competitionId]/[courseId]/[playerId]/view.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, mock, test } from "bun:test"
-import { cleanup, render } from "@testing-library/react"
+import { act, cleanup, render } from "@testing-library/react"
 
 mock.module("@/app/challenge/challenge", () => ({
   Challenge: () => <div data-testid="challenge" />,
@@ -8,6 +8,9 @@ mock.module("@/app/components/challenge/sensorCourse", () => ({
   SensorCourse: () => <div data-testid="sensor-course" />,
 }))
 
+const { AudioProvider } = await import(
+  "@/app/challenge/[competitionId]/[courseId]/[playerId]/audioContext"
+)
 const { View } = await import(
   "@/app/challenge/[competitionId]/[courseId]/[playerId]/view"
 )
@@ -32,10 +35,24 @@ const playerData = {
   createdAt: null,
 }
 
+function renderView(courseId = 1) {
+  return render(
+    <AudioProvider>
+      <View
+        courseData={courseData}
+        playerData={playerData}
+        competitionId={1}
+        courseId={courseId}
+        umpireId={1}
+      />
+    </AudioProvider>,
+  )
+}
+
 afterEach(cleanup)
 
 describe("View", () => {
-  test("registers beforeunload event listener", () => {
+  test("does not register beforeunload before challenge starts", () => {
     const spy = mock()
     const original = window.addEventListener
     window.addEventListener = mock((event: string, handler: unknown) => {
@@ -45,57 +62,35 @@ describe("View", () => {
       return original.call(window, event, handler as EventListener)
     })
 
-    render(
-      <View
-        courseData={courseData}
-        playerData={playerData}
-        competitionId={1}
-        courseId={1}
-        umpireId={1}
-      />,
-    )
+    renderView()
 
-    expect(spy).toHaveBeenCalled()
+    expect(spy).not.toHaveBeenCalled()
     window.addEventListener = original
   })
 
   test("renders Challenge for non-sensor course", () => {
-    const { getByTestId, queryByTestId } = render(
-      <View
-        courseData={courseData}
-        playerData={playerData}
-        competitionId={1}
-        courseId={1}
-        umpireId={1}
-      />,
-    )
+    const { getByTestId, queryByTestId } = renderView()
     expect(getByTestId("challenge")).toBeDefined()
     expect(queryByTestId("sensor-course")).toBeNull()
   })
 
   test("renders SensorCourse for sensor course (id: -2)", () => {
-    const { getByTestId, queryByTestId } = render(
-      <View
-        courseData={courseData}
-        playerData={playerData}
-        competitionId={1}
-        courseId={-2}
-        umpireId={1}
-      />,
-    )
+    const { getByTestId, queryByTestId } = renderView(-2)
     expect(getByTestId("sensor-course")).toBeDefined()
     expect(queryByTestId("challenge")).toBeNull()
   })
 
   test("passes umpireId to Challenge component", () => {
     const { getByTestId } = render(
-      <View
-        courseData={courseData}
-        playerData={playerData}
-        competitionId={1}
-        courseId={1}
-        umpireId={5}
-      />,
+      <AudioProvider>
+        <View
+          courseData={courseData}
+          playerData={playerData}
+          competitionId={1}
+          courseId={1}
+          umpireId={5}
+        />
+      </AudioProvider>,
     )
     expect(getByTestId("challenge")).toBeDefined()
   })

--- a/@robopo/web/test/unit/challenge/[competitionId]/[courseId]/[playerId]/view.test.tsx
+++ b/@robopo/web/test/unit/challenge/[competitionId]/[courseId]/[playerId]/view.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, mock, test } from "bun:test"
-import { act, cleanup, render } from "@testing-library/react"
+import { cleanup, render } from "@testing-library/react"
 
 mock.module("@/app/challenge/challenge", () => ({
   Challenge: () => <div data-testid="challenge" />,


### PR DESCRIPTION
## Summary by Sourcery

再利用可能なボタンコンポーネントを導入し、オーディオ処理とナビゲーションの一貫性を含めて、チャレンジ開始および確認まわりの UX を強化します。

新機能:
- チャレンジおよび共通モーダル全体で CTA を統一するため、Back、Submit、Retry、CourseOut、Fail の再利用可能なボタンコンポーネントを追加。
- チャレンジ開始モーダルを強化し、コース／プレイヤーのよりリッチな表示、アニメーション付き開始ボタン、レイアウトの改善を実施。
- チャレンジ開始状態のトラッキングと、エフェクト有効化時のプレビュー音再生に対応するよう、audio context を拡張。

改善:
- チャレンジ確認モーダルおよび course-out モーダルで共有ボタンコンポーネントとより明確なラベリングを使用し、重複を削減してレイアウトを標準化。
- チャレンジ画面でナビゲーションおよびアクションバーに新しいボタンコンポーネントを使用し、ビジュアルの一貫性を向上。
- サウンドコントローラーのスタイリングと挙動を調整し、よりコンパクトにするとともに、サウンドをオンにする際に短いプレビューを再生。
- メインの開始ボタンにパルス状のグローアニメーションを追加し、reduced-motion に対応。

テスト:
- チャレンジ画面のテストを更新し、audio provider でラップしてヘルパーの render 関数を再利用し、アンロードハンドラーがチャレンジ開始後にのみ登録されることを検証。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce reusable button components and enhance the challenge start and confirmation UX, including audio handling and navigation consistency.

New Features:
- Add reusable Back, Submit, Retry, CourseOut, and Fail button components for consistent CTAs across challenge and common modals.
- Enhance the challenge start modal with richer course/player presentation, animated start button, and improved layout.
- Extend the audio context to track challenge start state and preview sound when enabling effects.

Enhancements:
- Refine challenge confirmation and course-out modals to use shared button components and clearer labeling, reducing duplication and standardizing layouts.
- Update challenge views to use the new button components for navigation and action bars, improving visual consistency.
- Adjust sound controller styling and behavior to be more compact and to play a short preview when turning sound on.
- Add a pulsing glow animation for the primary start button with reduced-motion support.

Tests:
- Update challenge view tests to wrap in the audio provider, reuse a helper render function, and verify that unload handlers are only registered after a challenge starts.

</details>