### PR TITLE
feat: polish scoring button

### DIFF
--- a/@robopo/web/app/challenge/challenge.tsx
+++ b/@robopo/web/app/challenge/challenge.tsx
@@ -125,26 +125,29 @@ function IpponBashiSection({
 
       {/* Action bar */}
       <div className="border-base-300 border-t bg-base-100 px-4 py-3">
-        <div className="flex items-center justify-between gap-3">
+        <div className="grid grid-cols-2 gap-2">
+          {/* 上段: 補助アクション（控えめ） */}
           <BackButton
             onClick={handleBack}
             disabled={nowMission === 0}
             variant="outline"
-            className="btn-sm flex-1"
+            className="btn-sm"
           />
           <CourseOutButton
             onClick={() => setModalOpen(3)}
-            className="btn-sm flex-1"
+            variant="outline"
+            className="btn-sm"
           />
+          {/* 下段: メインアクション（目立つ） */}
           <RetryButton
             onClick={() => setModalOpen(2)}
             label="再挑戦"
             disabled={isRetry}
-            className="btn-sm flex-1"
+            className="min-h-[44px]"
           />
           <SubmitButton
             onClick={() => setModalOpen(1)}
-            className="btn-sm flex-1"
+            className="min-h-[44px] shadow-accent/25 shadow-lg"
           />
         </div>
         <div className="mt-2 flex justify-center">

--- a/@robopo/web/app/components/parts/buttons.tsx
+++ b/@robopo/web/app/components/parts/buttons.tsx
@@ -139,20 +139,26 @@ export function RetryButton({
 export function CourseOutButton({
   onClick,
   disabled = false,
+  variant = "solid",
   className: extraClassName,
 }: {
   onClick: () => void
   disabled?: boolean
+  variant?: "solid" | "outline"
   className?: string
 }) {
+  const base =
+    variant === "outline"
+      ? "btn btn-outline btn-error rounded-xl transition-all duration-200"
+      : "btn btn-error rounded-xl transition-all duration-200"
   return (
     <button
       type="button"
-      className={`btn btn-error rounded-xl transition-all duration-200 ${extraClassName ?? ""}`.trim()}
+      className={`${base} ${extraClassName ?? ""}`.trim()}
       onClick={onClick}
       disabled={disabled}
     >
-      <ExclamationTriangleIcon className="size-5" />
+      <ExclamationTriangleIcon className="size-4" />
       コースアウト
     </button>
   )


### PR DESCRIPTION
## Summary by Sourcery

チャレンジ画面のアクションバーのレイアウトを再構成し、主要なスコアリングアクションと副次的なナビゲーションを区別できるようにするとともに、コースアウトボタンにスタイリングオプションを追加します。

New Features:
- コースアウトボタンに `variant` プロップを追加し、ソリッドスタイルとアウトラインスタイルをサポート。

Enhancements:
- チャレンジ画面のアクションバーを2行構成のグリッドに調整し、主要なスコアリングアクションと補助的なコントロールを視覚的に分離。
- リトライボタンと送信ボタンに、より大きな最小高さとアクセントシャドウを適用し、主要アクションとして強調。
- コースアウトボタンのアイコンサイズとデフォルトスタイルを調整し、視覚的なバランスを改善。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Rework the challenge action bar layout to distinguish primary scoring actions from secondary navigation, and add styling options to the course-out button.

New Features:
- Add a variant prop to the course-out button to support solid and outline styles.

Enhancements:
- Adjust the challenge screen action bar to a two-row grid that visually separates main scoring actions from auxiliary controls.
- Update retry and submit buttons with larger minimum height and accent shadow to emphasize primary actions.
- Refine course-out button icon size and default styles for better visual balance.

</details>