### PR TITLE
feat: polish mission list

### DIFF
--- a/.mise/prepare-state.toml
+++ b/.mise/prepare-state.toml
@@ -1,3 +1,3 @@
 [providers.bun]
-"bun.lock" = "c79c08ac2769e5aa2d2cad5d934ab7bc5f32ed7532b6a525970ac1eefe9be058"
-"package.json" = "d4b1fcac2f4c072fe17506b2ce49a425f775cea9ac47cbdb777dfc5b92d73c59"
+"bun.lock" = "a31e6c32498512543a3fc266abbe43c696196493d1d1faa70e20673c11dee66c"
+"package.json" = "edc638d02709475b8f0ad93a99725cb7dd93e4a4169effd87685297dc35d8ced"

--- a/@robopo/web/app/components/course/field.tsx
+++ b/@robopo/web/app/components/course/field.tsx
@@ -16,6 +16,8 @@ type FieldProps = {
   type: "edit" | "challenge"
   botPosition?: { row: number; col: number }
   botDirection?: MissionValue
+  botAfterPosition?: { row: number; col: number }
+  botAfterAngle?: number
   nextMission?: MissionValue[]
   onPanelClick: (row: number, col: number) => void
   onPanelPointerDown?: (row: number, col: number) => void
@@ -29,6 +31,8 @@ export function Field({
   type,
   botPosition,
   botDirection,
+  botAfterPosition,
+  botAfterAngle,
   nextMission,
   onPanelClick,
   onPanelPointerDown,
@@ -52,10 +56,13 @@ export function Field({
       ? `min(${PANEL_SIZE}px, (100vw - 80px) / ${renderWidth})`
       : `${PANEL_SIZE}px`
 
-  const styles = customStyle ?? {
-    gridTemplateColumns: `repeat(${renderWidth}, ${responsiveCellSize})`,
-    gridTemplateRows: `repeat(${renderHeight}, ${responsiveCellSize})`,
-  }
+  const styles =
+    customStyle ??
+    ({
+      gridTemplateColumns: `repeat(${renderWidth}, ${responsiveCellSize})`,
+      gridTemplateRows: `repeat(${renderHeight}, ${responsiveCellSize})`,
+      "--cell-size": responsiveCellSize,
+    } as React.CSSProperties)
 
   // Build cells for the visible portion
   const cells: {
@@ -82,6 +89,9 @@ export function Field({
           key={cell.key}
           value={cell.panel}
           isEditMode={type === "edit"}
+          panelNumber={
+            type === "edit" ? cell.r * MAX_FIELD_WIDTH + cell.c + 1 : undefined
+          }
           onClick={() => onPanelClick(cell.r, cell.c)}
           onPointerDown={
             onPanelPointerDown
@@ -111,6 +121,19 @@ export function Field({
             duration={1.5}
           />
         </>
+      )}
+      {/* Show bot preview during edit */}
+      {type === "edit" && botPosition && botDirection && (
+        <Robot
+          row={botPosition.row}
+          col={botPosition.col}
+          direction={botDirection}
+          afterRow={botAfterPosition?.row}
+          afterCol={botAfterPosition?.col}
+          afterAngle={botAfterAngle}
+          responsive
+          opacity={0.6}
+        />
       )}
     </div>
   )

--- a/@robopo/web/app/components/course/missionList.tsx
+++ b/@robopo/web/app/components/course/missionList.tsx
@@ -1,270 +1,1078 @@
-import { MinusCircleIcon, PlusCircleIcon } from "@heroicons/react/24/outline"
-import { Fragment, useEffect, useState } from "react"
 import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core"
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable"
+import { CSS } from "@dnd-kit/utilities"
+import {
+  ArrowUturnLeftIcon,
+  ArrowUturnRightIcon,
+  Bars3Icon,
+  PlusIcon,
+  TrashIcon,
+} from "@heroicons/react/24/outline"
+import { useEffect, useMemo, useState } from "react"
+import {
+  type FieldState,
+  findGoal,
+  findStart,
   getMissionParameterUnit,
+  getRobotPosition,
+  MAX_FIELD_WIDTH,
   type MissionState,
   MissionString,
   type MissionValue,
   missionStatePair,
+  type PointEntry,
   type PointState,
 } from "@/app/components/course/utils"
 
-export function MissionList({
-  mission,
-  point,
-  selectedMissionIndex,
-  handleMissionSelect,
-  insertPosition,
-  setInsertPosition,
-}: {
-  mission: MissionState
-  point: PointState
-  selectedMissionIndex: number | null
-  handleMissionSelect: (selectedIndex: number) => void
-  insertPosition: number
-  setInsertPosition: (mode: number) => void
-}) {
-  const [statePair, setMissionStatePair] = useState<
-    { id: string; mission: MissionValue[] }[]
-  >([])
-  const TOP_INSERT_INDEX = -4 // Special constant for inserting at the top
+// ─── Types ───────────────────────────────────────────────────────────
 
+type MissionPairItem = {
+  id: string
+  index: number
+  mission: MissionValue[]
+}
+
+// ─── Main Component ──────────────────────────────────────────────────
+
+export function MissionList({
+  field,
+  mission,
+  setMission,
+  point,
+  setPoint,
+  selectedMissionIndex,
+  setSelectedMissionIndex,
+  undoMission,
+  redoMission,
+  canUndoMission,
+  canRedoMission,
+  pushMissionHistory,
+  missionPanelHints,
+  setMissionPanelHints,
+}: {
+  field: FieldState
+  mission: MissionState
+  setMission: React.Dispatch<React.SetStateAction<MissionState>>
+  point: PointState
+  setPoint: React.Dispatch<React.SetStateAction<PointState>>
+  selectedMissionIndex: number | null
+  setSelectedMissionIndex: (index: number | null) => void
+  undoMission: () => void
+  redoMission: () => void
+  canUndoMission: boolean
+  canRedoMission: boolean
+  pushMissionHistory: () => void
+  missionPanelHints: (number | null)[]
+  setMissionPanelHints: React.Dispatch<React.SetStateAction<(number | null)[]>>
+}) {
+  const [items, setItems] = useState<MissionPairItem[]>([])
+  const [insertingAt, setInsertingAt] = useState<number | null>(null)
+
+  // Build sortable items from mission state
   useEffect(() => {
-    const newStatePair = missionStatePair(mission).map((m) => ({
-      id: crypto.randomUUID(),
-      mission: m,
-    }))
-    setMissionStatePair(newStatePair)
+    const pairs = missionStatePair(mission)
+    setItems(
+      pairs.map((m, i) => ({
+        id: `mission-${i}-${m[0]}-${m[1]}`,
+        index: i,
+        mission: m,
+      })),
+    )
   }, [mission])
 
-  // Behavior when radio button is pressed
-  // Radio button value >= 0: mission order index
-  // Radio button value = -1: no mission set
-  // Radio button value = -2: Start
-  // Radio button value = -3: Goal
+  // Compute panel positions for each mission
+  const panelPositions = useMemo(() => {
+    const start = findStart(field)
+    if (!start) {
+      return null
+    }
+    const [startRow, startCol] = start
+    const pairs = missionStatePair(mission)
+    const positions: number[] = []
+    for (let i = 0; i <= pairs.length; i++) {
+      const [row, col] = getRobotPosition(startRow, startCol, mission, i)
+      positions.push(row * MAX_FIELD_WIDTH + col + 1)
+    }
+    // Goal panel number comes from actual field position, not robot position
+    const goal = findGoal(field)
+    const goalPanel = goal ? goal[0] * MAX_FIELD_WIDTH + goal[1] + 1 : undefined
+    return {
+      startPanel: startRow * MAX_FIELD_WIDTH + startCol + 1,
+      positions,
+      goalPanel,
+    }
+  }, [field, mission])
+
+  // ─── DnD ─────────────────────────────────────────────────
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  )
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event
+    if (!over || active.id === over.id) {
+      return
+    }
+
+    const oldIndex = items.findIndex((item) => item.id === active.id)
+    const newIndex = items.findIndex((item) => item.id === over.id)
+    if (oldIndex === -1 || newIndex === -1) {
+      return
+    }
+
+    pushMissionHistory()
+
+    // Reorder mission pairs in the flat array
+    const newMission = [...mission]
+    const newPoint = [...point]
+
+    // Extract the pair being moved
+    const missionPairStart = 2 + oldIndex * 2
+    const movedMission = newMission.splice(missionPairStart, 2)
+    const movedPoint = newPoint.splice(oldIndex + 2, 1)
+
+    // Insert at new position
+    const insertMissionAt = 2 + newIndex * 2
+    newMission.splice(insertMissionAt, 0, ...movedMission)
+    newPoint.splice(newIndex + 2, 0, ...movedPoint)
+
+    setMission(newMission)
+    setPoint(newPoint)
+    setSelectedMissionIndex(newIndex)
+
+    // Reorder panel hints
+    setMissionPanelHints((prev) => {
+      const newHints = [...prev]
+      const [movedHint] = newHints.splice(oldIndex, 1)
+      newHints.splice(newIndex, 0, movedHint ?? null)
+      return newHints
+    })
+  }
+
+  // ─── Mission CRUD ────────────────────────────────────────
+
+  function handleAddMission(afterIndex: number) {
+    setInsertingAt(afterIndex)
+    setSelectedMissionIndex(-1)
+  }
+
+  function handleInsertMission(
+    missionType: MissionValue,
+    param: number,
+    pointEntry: PointEntry,
+  ) {
+    if (insertingAt === null) {
+      return
+    }
+    pushMissionHistory()
+
+    const newMission = [...mission]
+    const newPoint = [...point]
+
+    if (mission.length <= 2) {
+      // No missions yet — set first pair
+      while (newMission.length < 4) {
+        newMission.push(null)
+      }
+      newMission[2] = missionType
+      newMission[3] = param
+      while (newPoint.length < 3) {
+        newPoint.push(0)
+      }
+      newPoint[2] = pointEntry
+    } else {
+      const insertIndex = 2 + (insertingAt + 1) * 2
+      newMission.splice(insertIndex, 0, missionType, param)
+      newPoint.splice(insertingAt + 3, 0, pointEntry)
+    }
+
+    setMission(newMission)
+    setPoint(newPoint)
+    setInsertingAt(null)
+    setSelectedMissionIndex(null)
+    // Insert null hint at the new position (manually added missions have no hint)
+    if (insertingAt !== null) {
+      setMissionPanelHints((prev) => {
+        const newHints = [...prev]
+        newHints.splice(insertingAt + 1, 0, null)
+        return newHints
+      })
+    }
+  }
+
+  function handleDeleteMission(index: number) {
+    pushMissionHistory()
+    const newMission = [...mission]
+    const newPoint = [...point]
+    newMission.splice(2 + index * 2, 2)
+    newPoint.splice(index + 2, 1)
+    setMission(newMission)
+    setPoint(newPoint)
+    setSelectedMissionIndex(null)
+    setMissionPanelHints((prev) => {
+      const newHints = [...prev]
+      newHints.splice(index, 1)
+      return newHints
+    })
+  }
+
+  function handleUpdateMission(
+    index: number,
+    missionType: MissionValue,
+    param: MissionValue,
+    pointEntry: PointEntry,
+  ) {
+    pushMissionHistory()
+    const newMission = [...mission]
+    const newPoint = [...point]
+    newMission[2 + index * 2] = missionType
+    newMission[2 + index * 2 + 1] = param
+    newPoint[index + 2] = pointEntry
+    setMission(newMission)
+    setPoint(newPoint)
+    // Clear hint when mission type is set (computed position takes over)
+    if (missionType !== null) {
+      setMissionPanelHints((prev) => {
+        const newHints = [...prev]
+        newHints[index] = null
+        return newHints
+      })
+    }
+  }
+
+  function handleUpdateStart(dir: MissionValue) {
+    pushMissionHistory()
+    const newMission = [...mission]
+    newMission[0] = dir
+    setMission(newMission)
+  }
+
+  function handleUpdateGoalPoint(p: PointEntry) {
+    pushMissionHistory()
+    const newPoint = [...point]
+    newPoint[1] = p
+    setPoint(newPoint)
+  }
+
+  // ─── Render ──────────────────────────────────────────────
 
   return (
-    <div className="max-h-64 w-full overflow-auto p-4">
-      <div>MissionEdit</div>
-      <div className="form-control">
-        <table className="table">
-          <thead>
-            <tr>
-              <th>
-                <input
-                  type="radio"
-                  name="radio-1"
-                  className="radio"
-                  disabled={true}
-                />
-              </th>
-              <th>順番</th>
-              <th>ミッション</th>
-              <th>ポイント</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr
-              className="hover relative cursor-pointer"
-              onClick={() => handleMissionSelect(-2)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === "Space") {
-                  handleMissionSelect(-2)
-                }
-              }}
-            >
-              <th>
-                <input
-                  type="radio"
-                  name="radio-1"
-                  className="radio"
-                  value={-2}
-                  checked={selectedMissionIndex === -2}
-                  readOnly={true}
-                />
-              </th>
-              <td>Start</td>
-              {mission[0] === null ||
-              mission[0] === undefined ||
-              mission[0] === "" ? (
-                <td>-</td>
-              ) : (
-                <td>{MissionString[mission[0]]}</td>
-              )}
-              <td>{point[0]}</td>
-            </tr>
-            {statePair.length > 0 ? (
-              statePair.map(({ id, mission }, index) => (
-                <Fragment key={id}>
-                  {/* Show upper button before the first row (index=0) */}
-                  {index === 0 && (
-                    <>
-                      <tr>
-                        <th colSpan={4} className="relative h-0 p-0">
-                          <AddMissionButton
-                            insertPosition={insertPosition}
-                            setInsertPosition={setInsertPosition}
-                            index={TOP_INSERT_INDEX} // For top insertion only
-                            handleMissionSelect={handleMissionSelect}
-                          />
-                        </th>
-                      </tr>
-                      {insertPosition === TOP_INSERT_INDEX && (
-                        <AddMissionItem
-                          selectedMissionIndex={selectedMissionIndex}
-                          handleMissionSelect={handleMissionSelect}
-                        />
-                      )}
-                    </>
-                  )}
-                  <tr
-                    className="hover relative cursor-pointer"
-                    onClick={() => handleMissionSelect(index)}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter" || e.key === "Space") {
-                        handleMissionSelect(index)
-                      }
-                    }}
-                  >
-                    <th>
-                      <input
-                        type="radio"
-                        name="radio-1"
-                        className="radio"
-                        value={index}
-                        checked={selectedMissionIndex === index}
-                        readOnly={true}
-                      />
-                      <AddMissionButton
-                        insertPosition={insertPosition}
-                        setInsertPosition={setInsertPosition}
-                        index={index}
-                        handleMissionSelect={handleMissionSelect}
-                      />
-                    </th>
-                    <td>{index + 1}</td>
-                    <td>
-                      {mission[0] === null ? "-" : MissionString[mission[0]]}
-                      {mission[1] === null ? "-" : mission[1]}
-                      {getMissionParameterUnit(mission[0])}
-                    </td>
-                    <td>
-                      {Array.isArray(point[index + 2])
-                        ? `[${(point[index + 2] as number[]).join(",")}]`
-                        : point[index + 2]}
-                    </td>
-                  </tr>
-                  {insertPosition === index && (
-                    <AddMissionItem
-                      selectedMissionIndex={selectedMissionIndex}
-                      handleMissionSelect={handleMissionSelect}
-                    />
-                  )}
-                </Fragment>
-              ))
-            ) : (
-              <AddMissionItem
-                selectedMissionIndex={selectedMissionIndex}
-                handleMissionSelect={handleMissionSelect}
-              />
-            )}
-            <tr
-              className="hover cursor-pointer"
-              onClick={() => handleMissionSelect(-3)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === "Space") {
-                  handleMissionSelect(-3)
-                }
-              }}
-            >
-              <th>
-                <input
-                  type="radio"
-                  name="radio-1"
-                  className="radio"
-                  value={-3}
-                  checked={selectedMissionIndex === -3}
-                  readOnly={true}
-                />
-              </th>
-              <td>Goal</td>
-              {mission[1] === null ||
-              mission[1] === undefined ||
-              mission[1] === "" ? (
-                <td>-</td>
-              ) : (
-                <td>{MissionString[mission[1]]}</td>
-              )}
-              <td>{point[1]}</td>
-            </tr>
-          </tbody>
-        </table>
+    <div className="w-full">
+      {/* Header with Undo/Redo */}
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="font-bold text-sm">ミッション</h3>
+        <div className="flex gap-1">
+          <button
+            type="button"
+            className="btn btn-ghost btn-xs"
+            onClick={undoMission}
+            disabled={!canUndoMission}
+            title="元に戻す"
+          >
+            <ArrowUturnLeftIcon className="size-4" />
+          </button>
+          <button
+            type="button"
+            className="btn btn-ghost btn-xs"
+            onClick={redoMission}
+            disabled={!canRedoMission}
+            title="やり直す"
+          >
+            <ArrowUturnRightIcon className="size-4" />
+          </button>
+        </div>
       </div>
-      <div />
+
+      <div className="space-y-0">
+        {/* Start Row */}
+        <StartRow
+          mission={mission}
+          panelNumber={panelPositions?.startPanel}
+          isSelected={selectedMissionIndex === -2}
+          onSelect={() => setSelectedMissionIndex(-2)}
+          onUpdateDirection={handleUpdateStart}
+        />
+
+        {/* Add button before first mission */}
+        <AddButton
+          onClick={() => handleAddMission(-1)}
+          isActive={insertingAt === -1}
+        />
+        {insertingAt === -1 && (
+          <InsertMissionRow
+            onInsert={handleInsertMission}
+            onCancel={() => setInsertingAt(null)}
+          />
+        )}
+
+        {/* Sortable mission items */}
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+        >
+          <SortableContext
+            items={items.map((i) => i.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            {items.map((item, idx) => (
+              <div key={item.id}>
+                <SortableMissionRow
+                  item={item}
+                  index={idx}
+                  panelNumber={
+                    item.mission[0] === null && missionPanelHints[idx]
+                      ? missionPanelHints[idx]
+                      : panelPositions?.positions[idx]
+                  }
+                  point={point[idx + 2]}
+                  isSelected={selectedMissionIndex === idx}
+                  onSelect={() => setSelectedMissionIndex(idx)}
+                  onDelete={() => handleDeleteMission(idx)}
+                  onUpdate={(mt, p, pt) => handleUpdateMission(idx, mt, p, pt)}
+                  onPanelChange={(num) => {
+                    setMissionPanelHints((prev) => {
+                      const newHints = [...prev]
+                      while (newHints.length <= idx) {
+                        newHints.push(null)
+                      }
+                      newHints[idx] = num
+                      return newHints
+                    })
+                  }}
+                />
+                <AddButton
+                  onClick={() => handleAddMission(idx)}
+                  isActive={insertingAt === idx}
+                />
+                {insertingAt === idx && (
+                  <InsertMissionRow
+                    onInsert={handleInsertMission}
+                    onCancel={() => setInsertingAt(null)}
+                  />
+                )}
+              </div>
+            ))}
+          </SortableContext>
+        </DndContext>
+
+        {/* Empty state */}
+        {items.length === 0 && insertingAt === null && (
+          <button
+            type="button"
+            className="w-full cursor-pointer rounded-lg border border-base-300 border-dashed p-4 text-center text-base-content/50 text-sm transition-colors hover:border-primary hover:text-primary"
+            onClick={() => handleAddMission(-1)}
+          >
+            ミッションを追加してください
+          </button>
+        )}
+
+        {/* Goal Row */}
+        <GoalRow
+          point={point}
+          panelNumber={panelPositions?.goalPanel}
+          isSelected={selectedMissionIndex === -3}
+          onSelect={() => setSelectedMissionIndex(-3)}
+          onUpdatePoint={handleUpdateGoalPoint}
+        />
+      </div>
     </div>
   )
 }
 
-const AddMissionButton = ({
-  insertPosition,
-  setInsertPosition,
-  index,
-  handleMissionSelect,
-}: {
-  insertPosition: number
-  setInsertPosition: (mode: number) => void
-  index: number
-  handleMissionSelect: (index: number) => void
-}) => {
-  return (
-    <button
-      type="button"
-      className="absolute -bottom-4 -left-4 cursor-pointer rounded-full border bg-white shadow"
-      onClick={(e) => {
-        e.stopPropagation()
-        setInsertPosition(insertPosition === -1 ? index : -1)
-        handleMissionSelect(-1) // Select row to add
-      }}
-    >
-      {insertPosition === -1 ? (
-        <PlusCircleIcon className="size-5 text-blue-500" />
-      ) : (
-        insertPosition === index && (
-          <MinusCircleIcon className="size-5 text-red-500" />
-        )
-      )}
-    </button>
-  )
-}
+// ─── Start Row ───────────────────────────────────────────────────────
 
-const AddMissionItem = ({
-  selectedMissionIndex,
-  handleMissionSelect,
+function StartRow({
+  mission,
+  panelNumber,
+  isSelected,
+  onSelect,
+  onUpdateDirection,
 }: {
-  selectedMissionIndex: number | null
-  handleMissionSelect: (index: number) => void
-}) => {
+  mission: MissionState
+  panelNumber?: number
+  isSelected: boolean
+  onSelect: () => void
+  onUpdateDirection: (dir: MissionValue) => void
+}) {
+  const dir = mission[0]
   return (
-    <tr
-      className="hover cursor-pointer"
-      onClick={() => handleMissionSelect(-1)}
+    // biome-ignore lint/a11y/useSemanticElements: complex container with child elements
+    <div
+      role="button"
+      tabIndex={0}
+      className={`overflow-hidden rounded-xl transition-all duration-200 ${
+        isSelected
+          ? "ring-2 ring-pink-400 ring-offset-1"
+          : "cursor-pointer hover:shadow-md"
+      }`}
+      onClick={onSelect}
       onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === "Space") {
-          handleMissionSelect(-1)
+        if (e.key === "Enter") {
+          onSelect()
         }
       }}
     >
-      <th>
-        <input
-          type="radio"
-          name="radio-1"
-          className="radio"
-          value={-1}
-          checked={selectedMissionIndex === -1}
-          readOnly={true}
-        />
-      </th>
-      <td colSpan={3}>ミッションを追加してください。</td>
-    </tr>
+      <div className="flex items-stretch">
+        {/* Color accent bar + label */}
+        <div className="flex w-20 shrink-0 flex-col items-center justify-center bg-gradient-to-b from-pink-400 to-pink-300 px-2 py-2.5">
+          <span className="font-bold text-white text-xs tracking-wider">
+            START
+          </span>
+          {panelNumber && (
+            <span className="mt-0.5 font-mono text-[10px] text-white/80">
+              P{panelNumber}
+            </span>
+          )}
+        </div>
+        {/* Content */}
+        <div className="flex flex-1 items-center bg-pink-50/60 px-4 py-2.5">
+          {isSelected ? (
+            <select
+              className="select select-bordered select-xs"
+              value={(dir as string) ?? ""}
+              onChange={(e) => {
+                e.stopPropagation()
+                onUpdateDirection(e.target.value as MissionValue)
+              }}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <option value="">向きを選択</option>
+              {(["u", "r", "d", "l"] as MissionValue[]).map((v) => (
+                <option key={v as string} value={v as string}>
+                  {MissionString[v as Exclude<MissionValue, null>]}
+                </option>
+              ))}
+            </select>
+          ) : (
+            <span className="text-pink-900 text-sm">
+              {dir ? MissionString[dir as Exclude<MissionValue, null>] : "-"}
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ─── Goal Row ────────────────────────────────────────────────────────
+
+function GoalRow({
+  point,
+  panelNumber,
+  isSelected,
+  onSelect,
+  onUpdatePoint,
+}: {
+  point: PointState
+  panelNumber?: number
+  isSelected: boolean
+  onSelect: () => void
+  onUpdatePoint: (p: PointEntry) => void
+}) {
+  const goalPointRaw = point[1]
+  const goalPoint = typeof goalPointRaw === "number" ? goalPointRaw : 0
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: complex container with child elements
+    <div
+      role="button"
+      tabIndex={0}
+      className={`overflow-hidden rounded-xl transition-all duration-200 ${
+        isSelected
+          ? "ring-2 ring-green-400 ring-offset-1"
+          : "cursor-pointer hover:shadow-md"
+      }`}
+      onClick={onSelect}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") {
+          onSelect()
+        }
+      }}
+    >
+      <div className="flex items-stretch">
+        {/* Color accent bar + label */}
+        <div className="flex w-20 shrink-0 flex-col items-center justify-center bg-gradient-to-b from-green-400 to-green-300 px-2 py-2.5">
+          <span className="font-bold text-white text-xs tracking-wider">
+            GOAL
+          </span>
+          {panelNumber && (
+            <span className="mt-0.5 font-mono text-[10px] text-white/80">
+              P{panelNumber}
+            </span>
+          )}
+        </div>
+        {/* Content */}
+        <div className="flex flex-1 items-center bg-green-50/60 px-4 py-2.5">
+          {isSelected ? (
+            // biome-ignore lint/a11y/useSemanticElements: form input group
+            <div
+              role="group"
+              className="flex items-center gap-2"
+              onClick={(e) => e.stopPropagation()}
+              onKeyDown={(e) => e.stopPropagation()}
+            >
+              <input
+                type="number"
+                className="input input-bordered input-xs w-20"
+                value={goalPoint}
+                onChange={(e) => {
+                  const num = Number(e.target.value)
+                  onUpdatePoint(
+                    e.target.value === "" || Number.isNaN(num) ? 0 : num,
+                  )
+                }}
+                placeholder="0"
+              />
+              <span className="text-xs">pt</span>
+            </div>
+          ) : (
+            <span className="text-green-900 text-sm">{goalPoint} pt</span>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ─── Sortable Mission Row ────────────────────────────────────────────
+
+function SortableMissionRow({
+  item,
+  index,
+  panelNumber,
+  point,
+  isSelected,
+  onSelect,
+  onDelete,
+  onUpdate,
+  onPanelChange,
+}: {
+  item: MissionPairItem
+  index: number
+  panelNumber?: number
+  point: PointEntry | undefined
+  isSelected: boolean
+  onSelect: () => void
+  onDelete: () => void
+  onUpdate: (
+    missionType: MissionValue,
+    param: MissionValue,
+    pointEntry: PointEntry,
+  ) => void
+  onPanelChange: (panelNum: number) => void
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: item.id })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  }
+
+  const missionType = item.mission[0]
+  const missionParam = item.mission[1]
+
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: sortable container with drag handle
+    <div
+      ref={setNodeRef}
+      role="button"
+      tabIndex={0}
+      style={style}
+      className={`group rounded-lg border-2 p-3 transition-all duration-150 ${
+        isSelected
+          ? "border-primary bg-primary/5"
+          : "cursor-pointer border-transparent bg-base-200/50 hover:bg-base-200"
+      } ${isDragging ? "z-50 shadow-lg" : ""}`}
+      onClick={onSelect}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") {
+          onSelect()
+        }
+      }}
+    >
+      {/* Collapsed view */}
+      <div className="flex items-center gap-2">
+        {/* Drag handle */}
+        <button
+          type="button"
+          className="cursor-grab touch-none text-base-content/30 hover:text-base-content/60"
+          {...attributes}
+          {...listeners}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <Bars3Icon className="size-4" />
+        </button>
+
+        {/* Order number */}
+        <span className="w-5 font-mono text-base-content/50 text-xs">
+          {index + 1}
+        </span>
+
+        {/* Panel number */}
+        {isSelected ? (
+          // biome-ignore lint/a11y/useSemanticElements: form input group
+          <div
+            role="group"
+            className="flex items-center"
+            onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => e.stopPropagation()}
+          >
+            <span className="font-mono text-xs">P</span>
+            <input
+              type="number"
+              className="input input-bordered input-xs w-12 font-mono"
+              min={1}
+              max={25}
+              value={panelNumber ?? ""}
+              onChange={(e) => {
+                const num = Number(e.target.value)
+                if (num >= 1 && num <= 25) {
+                  onPanelChange(num)
+                }
+              }}
+            />
+          </div>
+        ) : (
+          panelNumber && (
+            <span className="badge badge-ghost badge-sm font-mono">
+              P{panelNumber}
+            </span>
+          )
+        )}
+
+        {/* Mission content */}
+        <div className="flex-1 text-sm">
+          {isSelected ? (
+            <InlineMissionEditor
+              missionType={missionType}
+              missionParam={missionParam}
+              pointEntry={point ?? 0}
+              onUpdate={onUpdate}
+            />
+          ) : (
+            <span>
+              {missionType
+                ? MissionString[missionType as Exclude<MissionValue, null>]
+                : "-"}{" "}
+              {missionParam !== null ? `${missionParam}` : ""}
+              {getMissionParameterUnit(missionType)}
+            </span>
+          )}
+        </div>
+
+        {/* Point display (collapsed) */}
+        {!isSelected && (
+          <span className="font-mono text-base-content/60 text-xs">
+            {Array.isArray(point) ? `[${point.join(",")}]` : (point ?? 0)} pt
+          </span>
+        )}
+
+        {/* Delete button */}
+        <button
+          type="button"
+          className="btn btn-ghost btn-xs text-error opacity-0 transition-opacity group-hover:opacity-100"
+          onClick={(e) => {
+            e.stopPropagation()
+            onDelete()
+          }}
+          title="削除"
+        >
+          <TrashIcon className="size-4" />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ─── Inline Mission Editor ───────────────────────────────────────────
+
+function InlineMissionEditor({
+  missionType,
+  missionParam,
+  pointEntry,
+  onUpdate,
+}: {
+  missionType: MissionValue
+  missionParam: MissionValue
+  pointEntry: PointEntry
+  onUpdate: (
+    missionType: MissionValue,
+    param: MissionValue,
+    pointEntry: PointEntry,
+  ) => void
+}) {
+  const isMove = missionType === "mf" || missionType === "mb"
+  const isTurn = missionType === "tr" || missionType === "tl"
+  const isPause = missionType === "ps"
+  const tierMode = Array.isArray(pointEntry)
+  const tierValues = Array.isArray(pointEntry) ? pointEntry : [0]
+  const singleValue =
+    pointEntry !== null && !Array.isArray(pointEntry) ? pointEntry : 0
+
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: inline editor form group
+    <div
+      role="group"
+      className="space-y-2"
+      onClick={(e) => e.stopPropagation()}
+      onKeyDown={(e) => e.stopPropagation()}
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <select
+          className="select select-bordered select-xs"
+          value={(missionType as string) ?? ""}
+          onChange={(e) => {
+            const val = e.target.value as MissionValue
+            const defaultParam =
+              val === "ps"
+                ? 0
+                : val === "mf" || val === "mb"
+                  ? 1
+                  : val === "tr" || val === "tl"
+                    ? 90
+                    : null
+            if (defaultParam !== null) {
+              onUpdate(val, defaultParam, pointEntry)
+            }
+          }}
+        >
+          <option value="">選択</option>
+          {(["mf", "mb", "tr", "tl", "ps"] as MissionValue[]).map((v) => (
+            <option key={v as string} value={v as string}>
+              {MissionString[v as Exclude<MissionValue, null>]}
+            </option>
+          ))}
+        </select>
+
+        {isMove && (
+          <>
+            <select
+              className="select select-bordered select-xs"
+              value={(missionParam as string) ?? ""}
+              onChange={(e) =>
+                onUpdate(missionType, Number(e.target.value), pointEntry)
+              }
+            >
+              <option value="">選択</option>
+              {[1, 2, 3, 4].map((n) => (
+                <option key={n} value={n}>
+                  {n}
+                </option>
+              ))}
+            </select>
+            <span className="text-xs">パネル</span>
+          </>
+        )}
+
+        {isTurn && (
+          <>
+            <select
+              className="select select-bordered select-xs"
+              value={(missionParam as string) ?? ""}
+              onChange={(e) =>
+                onUpdate(missionType, Number(e.target.value), pointEntry)
+              }
+            >
+              <option value="">選択</option>
+              {[90, 180, 270, 360].map((n) => (
+                <option key={n} value={n}>
+                  {n}
+                </option>
+              ))}
+            </select>
+            <span className="text-xs">度</span>
+          </>
+        )}
+
+        {isPause && (
+          <span className="text-base-content/50 text-xs">パラメータなし</span>
+        )}
+      </div>
+
+      {/* Point settings */}
+      {(isMove || isTurn || isPause) && (
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="flex items-center gap-1">
+            <label className="label cursor-pointer gap-1">
+              <input
+                type="radio"
+                name={`pointMode-${missionType}-${missionParam}`}
+                className="radio radio-xs"
+                checked={!tierMode}
+                onChange={() =>
+                  onUpdate(
+                    missionType,
+                    missionParam,
+                    Array.isArray(pointEntry)
+                      ? (pointEntry[0] ?? 0)
+                      : pointEntry,
+                  )
+                }
+              />
+              <span className="text-xs">単一</span>
+            </label>
+            <label className="label cursor-pointer gap-1">
+              <input
+                type="radio"
+                name={`pointMode-${missionType}-${missionParam}`}
+                className="radio radio-xs"
+                checked={tierMode}
+                onChange={() =>
+                  onUpdate(missionType, missionParam, [
+                    typeof pointEntry === "number" ? pointEntry : 0,
+                    0,
+                  ])
+                }
+              />
+              <span className="text-xs">段階</span>
+            </label>
+          </div>
+
+          {!tierMode ? (
+            <div className="flex items-center gap-1">
+              <input
+                type="number"
+                className="input input-bordered input-xs w-16"
+                value={singleValue}
+                onChange={(e) => {
+                  const num = Number(e.target.value)
+                  onUpdate(
+                    missionType,
+                    missionParam,
+                    e.target.value === "" || Number.isNaN(num) ? 0 : num,
+                  )
+                }}
+              />
+              <span className="text-xs">pt</span>
+            </div>
+          ) : (
+            <div className="flex flex-wrap items-center gap-1">
+              {tierValues.map((val, i) => (
+                <div
+                  // biome-ignore lint/suspicious/noArrayIndexKey: tier values may duplicate
+                  key={i}
+                  className="flex items-center gap-0.5"
+                >
+                  <span className="text-[10px] text-base-content/40">
+                    {i + 1}.
+                  </span>
+                  <input
+                    type="number"
+                    className="input input-bordered input-xs w-14"
+                    value={val}
+                    onChange={(e) => {
+                      const num = Number(e.target.value)
+                      const newTiers = [...tierValues]
+                      newTiers[i] =
+                        e.target.value === "" || Number.isNaN(num) ? 0 : num
+                      onUpdate(missionType, missionParam, newTiers)
+                    }}
+                  />
+                  {tierValues.length > 2 && (
+                    <button
+                      type="button"
+                      className="btn btn-ghost btn-xs text-error"
+                      onClick={() => {
+                        const newTiers = tierValues.filter((_, ti) => ti !== i)
+                        onUpdate(missionType, missionParam, newTiers)
+                      }}
+                    >
+                      ×
+                    </button>
+                  )}
+                </div>
+              ))}
+              <button
+                type="button"
+                className="btn btn-ghost btn-xs text-primary"
+                onClick={() =>
+                  onUpdate(missionType, missionParam, [...tierValues, 0])
+                }
+              >
+                +
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── Insert Mission Row ──────────────────────────────────────────────
+
+function InsertMissionRow({
+  onInsert,
+  onCancel,
+}: {
+  onInsert: (
+    missionType: MissionValue,
+    param: number,
+    pointEntry: PointEntry,
+  ) => void
+  onCancel: () => void
+}) {
+  const [missionType, setMissionType] = useState<MissionValue | null>(null)
+  const [param, setParam] = useState<number | null>(null)
+  const [pointEntry, setPointEntry] = useState<PointEntry>(0)
+
+  const isMove = missionType === "mf" || missionType === "mb"
+  const isTurn = missionType === "tr" || missionType === "tl"
+  const isPause = missionType === "ps"
+  const canInsert = missionType !== null && (param !== null || isPause)
+
+  function handleMissionTypeChange(val: MissionValue) {
+    setMissionType(val)
+    if (val === "ps") {
+      setParam(0)
+    } else if (val === "mf" || val === "mb") {
+      setParam(1)
+    } else if (val === "tr" || val === "tl") {
+      setParam(90)
+    } else {
+      setParam(null)
+    }
+  }
+
+  return (
+    <div className="rounded-lg border-2 border-primary/40 border-dashed bg-primary/5 p-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <select
+          className="select select-bordered select-xs"
+          value={(missionType as string) ?? ""}
+          onChange={(e) =>
+            handleMissionTypeChange(e.target.value as MissionValue)
+          }
+        >
+          <option value="">ミッション選択</option>
+          {(["mf", "mb", "tr", "tl", "ps"] as MissionValue[]).map((v) => (
+            <option key={v as string} value={v as string}>
+              {MissionString[v as Exclude<MissionValue, null>]}
+            </option>
+          ))}
+        </select>
+
+        {isMove && (
+          <>
+            <select
+              className="select select-bordered select-xs"
+              value={param ?? ""}
+              onChange={(e) => setParam(Number(e.target.value))}
+            >
+              {[1, 2, 3, 4].map((n) => (
+                <option key={n} value={n}>
+                  {n}
+                </option>
+              ))}
+            </select>
+            <span className="text-xs">パネル</span>
+          </>
+        )}
+
+        {isTurn && (
+          <>
+            <select
+              className="select select-bordered select-xs"
+              value={param ?? ""}
+              onChange={(e) => setParam(Number(e.target.value))}
+            >
+              {[90, 180, 270, 360].map((n) => (
+                <option key={n} value={n}>
+                  {n}
+                </option>
+              ))}
+            </select>
+            <span className="text-xs">度</span>
+          </>
+        )}
+
+        <div className="flex items-center gap-1">
+          <input
+            type="number"
+            className="input input-bordered input-xs w-16"
+            value={typeof pointEntry === "number" ? pointEntry : 0}
+            onChange={(e) => {
+              const num = Number(e.target.value)
+              setPointEntry(
+                e.target.value === "" || Number.isNaN(num) ? 0 : num,
+              )
+            }}
+            placeholder="pt"
+          />
+          <span className="text-xs">pt</span>
+        </div>
+
+        <button
+          type="button"
+          className="btn btn-primary btn-xs"
+          disabled={!canInsert}
+          onClick={() => {
+            if (canInsert) {
+              onInsert(missionType, param ?? 0, pointEntry)
+            }
+          }}
+        >
+          追加
+        </button>
+        <button
+          type="button"
+          className="btn btn-ghost btn-xs"
+          onClick={onCancel}
+        >
+          取消
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ─── Add Button ──────────────────────────────────────────────────────
+
+function AddButton({
+  onClick,
+  isActive,
+}: {
+  onClick: () => void
+  isActive: boolean
+}) {
+  if (isActive) {
+    return null
+  }
+  return (
+    <div className="flex h-5 items-center justify-center">
+      <button
+        type="button"
+        className="flex size-5 items-center justify-center rounded-full border border-base-300 bg-base-100 shadow-sm transition-colors hover:border-primary hover:bg-primary/10"
+        onClick={onClick}
+        title="ミッションを追加"
+      >
+        <PlusIcon className="size-3 text-primary" />
+      </button>
+    </div>
   )
 }

--- a/@robopo/web/app/components/course/nextArrow.tsx
+++ b/@robopo/web/app/components/course/nextArrow.tsx
@@ -10,12 +10,14 @@ export function NextArrow({
   direction,
   nextMission,
   duration = 1,
+  responsive,
 }: {
   row: number
   col: number
   direction: MissionValue
   nextMission: MissionValue[] | undefined
-  duration?: number // Blink speed (seconds)
+  duration?: number
+  responsive?: boolean
 }) {
   if (
     !nextMission ||
@@ -24,7 +26,6 @@ export function NextArrow({
     nextMission[0] === undefined ||
     nextMission[1] === undefined
   ) {
-    // Show nothing if there is no next mission
     return null
   }
   if (nextMission[0] === "mf" || nextMission[0] === "mb") {
@@ -42,6 +43,7 @@ export function NextArrow({
         nextRow={nextRow}
         nextCol={nextCol}
         duration={duration}
+        responsive={responsive}
       />
     )
   }
@@ -52,6 +54,7 @@ export function NextArrow({
       direction={direction}
       nextMission={nextMission}
       duration={duration}
+      responsive={responsive}
     />
   )
 }
@@ -61,61 +64,62 @@ function NextMoveArrow({
   col,
   nextRow,
   nextCol,
-  duration = 1, // Blink speed
+  duration = 1,
+  responsive,
 }: {
   row: number
   col: number
   nextRow: number
   nextCol: number
-  duration?: number // Blink speed (seconds)
+  duration?: number
+  responsive?: boolean
 }) {
-  // Determine arrow placement and direction
   let colAdd = 0
   let rowAdd = 0
-  // Arrow direction
   let rotate = 0
   if (col < nextCol) {
-    // Moving right on screen
     colAdd = 2
     rowAdd = 1
     rotate = -90
   } else if (col > nextCol) {
-    // Moving left on screen
     colAdd = 0
     rowAdd = 1
     rotate = 90
   } else if (row < nextRow) {
-    // Moving down on screen
     colAdd = 1
     rowAdd = 2
     rotate = 0
   } else if (row > nextRow) {
-    // Moving up on screen
     colAdd = 1
     rowAdd = 0
     rotate = 180
   }
 
-  const midX = ((2 * col + colAdd) * PANEL_SIZE) / 2
-  const midY = ((2 * row + rowAdd) * PANEL_SIZE) / 2
-
-  const arrowStyle: React.CSSProperties = {
-    position: "absolute",
-    top: `${midY}px`,
-    left: `${midX}px`,
-    transform: `rotate(${rotate}deg) translate(0%, 0%)`, // Center placement
-    animation: `blink ${duration}s step-start infinite`,
-    pointerEvents: "none",
-  }
+  const arrowStyle: React.CSSProperties = responsive
+    ? {
+        position: "absolute",
+        top: `calc(var(--cell-size) * ${(2 * row + rowAdd) / 2})`,
+        left: `calc(var(--cell-size) * ${(2 * col + colAdd) / 2})`,
+        transform: `rotate(${rotate}deg)`,
+        animation: `blink ${duration}s step-start infinite`,
+        pointerEvents: "none",
+      }
+    : {
+        position: "absolute",
+        top: `${((2 * row + rowAdd) * PANEL_SIZE) / 2}px`,
+        left: `${((2 * col + colAdd) * PANEL_SIZE) / 2}px`,
+        transform: `rotate(${rotate}deg)`,
+        animation: `blink ${duration}s step-start infinite`,
+        pointerEvents: "none",
+      }
 
   return (
     <>
       <div style={arrowStyle}>
-        {/* Arrow display */}
         <div className="cp_arrows">
-          <div className="cp_arrow"></div>
-          <div className="cp_arrow"></div>
-          <div className="cp_arrow"></div>
+          <div className="cp_arrow" />
+          <div className="cp_arrow" />
+          <div className="cp_arrow" />
         </div>
       </div>
 
@@ -127,22 +131,22 @@ function NextMoveArrow({
             justify-content: center;
             align-items: center;
           }
-          .cp_arrows .cp_arrow {/* Base settings for arrow placement */
+          .cp_arrows .cp_arrow {
             position: absolute;
             width: 60px;
             height: 10px;
-            opacity: 0;/* Start transparent */
-            transform: scale(0.3);/* Start at 30% scale */
+            opacity: 0;
+            transform: scale(0.3);
             animation: arrow-move07 3s ease-out infinite;
           }
-          .cp_arrows .cp_arrow:first-child {/* Animation delayed by 1s */
+          .cp_arrows .cp_arrow:first-child {
             animation: arrow-move07 3s ease-out 1s infinite;
           }
-          .cp_arrows .cp_arrow:nth-child(2) {/* Animation delayed by 2s */
+          .cp_arrows .cp_arrow:nth-child(2) {
             animation: arrow-move07 3s ease-out 2s infinite;
           }
           .cp_arrows .cp_arrow:before,
-          .cp_arrows .cp_arrow:after {/* Arrow overall settings */
+          .cp_arrows .cp_arrow:after {
             position: absolute;
             content: '';
             top: 0;
@@ -153,11 +157,11 @@ function NextMoveArrow({
             background: #2196f3;
             border-radius: 2px;
           }
-          .cp_arrows .cp_arrow:before {/* Arrow line position and skew */
+          .cp_arrows .cp_arrow:before {
             left: 1px;
             transform: skewY(30deg);
           }
-          .cp_arrows .cp_arrow:after {/* Arrow line position and skew */
+          .cp_arrows .cp_arrow:after {
             right: 1px;
             transform: skewY(-30deg);
           }
@@ -178,128 +182,95 @@ function NextTurnArrow({
   col,
   direction,
   nextMission,
-  duration = 1, // Rotation speed
+  duration = 1,
+  responsive,
 }: {
   row: number
   col: number
   direction: MissionValue
   nextMission: MissionValue[]
-  duration?: number // Rotation speed (seconds)
+  duration?: number
+  responsive?: boolean
 }) {
-  // Calculate circle center
-  const midX = (2 * col * PANEL_SIZE) / 2
-  const midY = (2 * row * PANEL_SIZE) / 2
-
-  // Arrow starting point
   let startDeg: number
   let finDeg: number
   let clipDeg: number
+  let initArr = 0
 
-  let initArr: number = 0
-  // Arrow head draw position initArr: left 100% for right rotation, 0% for left rotation
-  // For left rotation, rotate coordinate system 180 degrees so negative direction becomes rotation direction
   if (nextMission[0] === "tr") {
-    // Right rotation
     initArr = 100
     startDeg = getStartDeg(direction)
     finDeg = startDeg + Number(nextMission[1])
     clipDeg = startDeg + 90
   } else {
-    // Left rotation
     initArr = 0
     startDeg = getStartDeg(direction) + 180
     finDeg = startDeg - Number(nextMission[1])
     clipDeg = startDeg + 180
   }
 
-  // Clip path to trim the arrow line
   const clipPath: string = getClipPath(Number(nextMission[1]))
+  const sizeExpr = responsive ? "var(--cell-size)" : `${PANEL_SIZE}px`
 
-  const arrowStyle: React.CSSProperties = {
-    position: "absolute",
-    top: `${midY}px`,
-    left: `${midX}px`,
-    pointerEvents: "none",
-  }
+  const arrowStyle: React.CSSProperties = responsive
+    ? {
+        position: "absolute",
+        top: `calc(var(--cell-size) * ${row})`,
+        left: `calc(var(--cell-size) * ${col})`,
+        pointerEvents: "none",
+      }
+    : {
+        position: "absolute",
+        top: `${row * PANEL_SIZE}px`,
+        left: `${col * PANEL_SIZE}px`,
+        pointerEvents: "none",
+      }
 
   return (
     <>
       <div style={arrowStyle}>
-        {/* Arrow display */}
-        <span className="arc"></span>
-        <span className="turnArrow"></span>
+        <span className="arc" />
+        <span className="turnArrow" />
       </div>
 
       <style>
         {`
         span.turnArrow {
-        position: relative;
-        display: inline-block;
-        width: ` +
-          `${PANEL_SIZE}` +
-          `px;
-        height: ` +
-          `${PANEL_SIZE}` +
-          `px;
-        border: 0px solid #FF0033;
-
-        border-radius: 50%; /* Make circular */
-        animation: rotating ${duration}s linear infinite;
+          position: relative;
+          display: inline-block;
+          width: ${sizeExpr};
+          height: ${sizeExpr};
+          border: 0px solid #FF0033;
+          border-radius: 50%;
+          animation: rotating ${duration}s linear infinite;
         }
-        
-        /* Arrow */
         span.turnArrow:after {
-            position: absolute;
-            display: inline-block;
-            content: " ";
-            left: ` +
-          `${initArr}` +
-          `%;
-            top: 50%;
-            margin-top: -20px;
-            margin-left: -10px;
-            border: 10px solid transparent;
-            border: 10px solid rgba(0, 0, 0, 0);
-            border-top: 20px solid #FF0033;
+          position: absolute;
+          display: inline-block;
+          content: " ";
+          left: ${initArr}%;
+          top: 50%;
+          margin-top: -20px;
+          margin-left: -10px;
+          border: 10px solid transparent;
+          border: 10px solid rgba(0, 0, 0, 0);
+          border-top: 20px solid #FF0033;
         }
-
-        /* Rotation */
         @keyframes rotating {
-            0% {
-                transform: rotate(` +
-          `${startDeg}` +
-          `deg);
-            }
-            100% {
-                transform: rotate(` +
-          `${finDeg}` +
-          `deg);
-            }
+          0% { transform: rotate(${startDeg}deg); }
+          100% { transform: rotate(${finDeg}deg); }
         }
-        /* Arc */
         span.arc {
-        position: absolute;
-        display: inline-block;
-        width: ` +
-          `${PANEL_SIZE}` +
-          `px;
-        height: ` +
-          `${PANEL_SIZE}` +
-          `px;
-        border: 2px solid #FF0033;
-        border-radius: 50%; /* Make circular */
-        transform: rotate(` +
-          `${clipDeg}` +
-          `deg); /* Rotate to position arrow at robot head */
-
-        /* Clip path to display the arc */
-        clip-path: ` +
-          `${clipPath}` +
-          `
-
-        animation: blink 2s linear infinite;
+          position: absolute;
+          display: inline-block;
+          width: ${sizeExpr};
+          height: ${sizeExpr};
+          border: 2px solid #FF0033;
+          border-radius: 50%;
+          transform: rotate(${clipDeg}deg);
+          clip-path: ${clipPath}
+          animation: blink 2s linear infinite;
         }
-
         @keyframes blink {
           25% { opacity: 0.6;}
           43% { opacity: 0.8;}
@@ -312,7 +283,6 @@ function NextTurnArrow({
   )
 }
 
-// Get rotation angle (in 90-degree units) from MissionValue
 function getStartDeg(direction: MissionValue): number {
   switch (direction) {
     case "u":
@@ -328,7 +298,6 @@ function getStartDeg(direction: MissionValue): number {
   }
 }
 
-// Determine clip path shape for arrow line from MissionValue (degree)
 function getClipPath(degree: MissionValue): string {
   switch (degree) {
     case 90:

--- a/@robopo/web/app/components/course/panel.tsx
+++ b/@robopo/web/app/components/course/panel.tsx
@@ -4,12 +4,14 @@ import { PanelString, type PanelValue } from "@/app/components/course/utils"
 export function Panel({
   value,
   isEditMode,
+  panelNumber,
   onClick,
   onPointerDown,
   onPointerEnter,
 }: {
   value: PanelValue
   isEditMode?: boolean
+  panelNumber?: number
   onClick: () => void
   onPointerDown?: () => void
   onPointerEnter?: () => void
@@ -38,23 +40,28 @@ export function Panel({
       onClick={onClick}
       onPointerDown={onPointerDown}
       onPointerEnter={onPointerEnter}
-      className={`flex aspect-square w-full flex-col items-center justify-center border ${
+      className={`relative flex aspect-square w-full flex-col items-center justify-center border ${
         hasRole ? "border-gray-800 bg-white" : emptyStyle
       }`}
     >
+      {panelNumber !== undefined && (
+        <span className="pointer-events-none absolute top-0.5 left-0.5 font-mono text-[9px] text-gray-500 leading-none">
+          P{panelNumber}
+        </span>
+      )}
       {hasRole &&
         (value === "startGoal" ? (
           <>
-            <div className="flex h-[45%] w-[85%] items-center justify-center whitespace-nowrap rounded-t-sm bg-pink-300 font-bold text-[10px] sm:text-sm">
+            <div className="flex h-[34%] w-[68%] items-center justify-center whitespace-nowrap rounded-t-sm bg-pink-300 font-bold text-[10px] sm:text-sm">
               {PanelString.start}
             </div>
-            <div className="flex h-[45%] w-[85%] items-center justify-center whitespace-nowrap rounded-b-sm bg-green-300 font-bold text-[10px] sm:text-sm">
+            <div className="flex h-[34%] w-[68%] items-center justify-center whitespace-nowrap rounded-b-sm bg-green-300 font-bold text-[10px] sm:text-sm">
               {PanelString.goal}
             </div>
           </>
         ) : (
           <div
-            className={`${routeStyle} flex h-[85%] w-[85%] items-center justify-center whitespace-nowrap rounded-sm font-bold text-[10px] sm:text-sm`}
+            className={`${routeStyle} flex h-[68%] w-[68%] items-center justify-center whitespace-nowrap rounded-sm font-bold text-[10px] sm:text-sm`}
           >
             {PanelString[value]}
           </div>

--- a/@robopo/web/app/components/course/robot.tsx
+++ b/@robopo/web/app/components/course/robot.tsx
@@ -1,40 +1,91 @@
 import Image from "next/image"
+import { useEffect, useState } from "react"
 import { type MissionValue, PANEL_SIZE } from "@/app/components/course/utils"
+
+function dirToDeg(dir: MissionValue): number {
+  switch (dir) {
+    case "u":
+      return 0
+    case "r":
+      return 90
+    case "d":
+      return 180
+    case "l":
+      return -90
+    default:
+      return 0
+  }
+}
 
 export function Robot({
   row,
   col,
   direction,
+  afterRow,
+  afterCol,
+  afterAngle,
+  responsive,
+  opacity = 1,
 }: {
   row: number
   col: number
   direction: MissionValue
+  afterRow?: number
+  afterCol?: number
+  afterAngle?: number
+  responsive?: boolean
+  opacity?: number
 }) {
-  function rotationAngle(dir: MissionValue) {
-    switch (dir) {
-      case "u":
-        return "rotate(0deg)"
-      case "r":
-        return "rotate(90deg)"
-      case "d":
-        return "rotate(180deg)"
-      case "l":
-        return "rotate(-90deg)"
-      default:
-        return "rotate(0deg)"
-    }
-  }
+  const hasAfter =
+    afterRow !== undefined && afterCol !== undefined && afterAngle !== undefined
+  const [showAfter, setShowAfter] = useState(false)
 
-  const botStyle: React.CSSProperties = {
-    position: "absolute",
-    top: `${row * PANEL_SIZE}px`,
-    left: `${col * PANEL_SIZE}px`,
-    height: `${PANEL_SIZE}px`,
-    width: `${PANEL_SIZE}px`,
-    transition: "top 0.5s ease, left 0.5s ease, transform 0.5s ease",
-    transform: rotationAngle(direction),
-    pointerEvents: "none",
-  }
+  // Loop animation: toggle between before and after states
+  useEffect(() => {
+    if (!hasAfter) {
+      setShowAfter(false)
+      return
+    }
+    setShowAfter(false)
+    let phase = false
+    const interval = setInterval(() => {
+      phase = !phase
+      setShowAfter(phase)
+    }, 1200)
+
+    return () => {
+      clearInterval(interval)
+    }
+  }, [hasAfter])
+
+  const currentRow = hasAfter && showAfter ? afterRow : row
+  const currentCol = hasAfter && showAfter ? afterCol : col
+  const beforeDeg = dirToDeg(direction)
+  const currentAngle = hasAfter && showAfter ? afterAngle : beforeDeg
+
+  const botStyle: React.CSSProperties = responsive
+    ? {
+        position: "absolute",
+        top: `calc(var(--cell-size) * ${currentRow})`,
+        left: `calc(var(--cell-size) * ${currentCol})`,
+        height: "var(--cell-size)",
+        width: "var(--cell-size)",
+        transition: "top 0.5s ease, left 0.5s ease, transform 0.5s ease",
+        transform: `rotate(${currentAngle}deg)`,
+        pointerEvents: "none",
+        opacity,
+      }
+    : {
+        position: "absolute",
+        top: `${currentRow * PANEL_SIZE}px`,
+        left: `${currentCol * PANEL_SIZE}px`,
+        height: `${PANEL_SIZE}px`,
+        width: `${PANEL_SIZE}px`,
+        transition: "top 0.5s ease, left 0.5s ease, transform 0.5s ease",
+        transform: `rotate(${currentAngle}deg)`,
+        pointerEvents: "none",
+        opacity,
+      }
 
   return (
     <div style={botStyle}>

--- a/@robopo/web/app/components/course/robotPreview.ts
+++ b/@robopo/web/app/components/course/robotPreview.ts
@@ -1,0 +1,106 @@
+import {
+  type FieldState,
+  findStart,
+  getNextPosition,
+  getRobotPosition,
+  type MissionState,
+  type MissionValue,
+  missionStatePair,
+} from "@/app/components/course/utils"
+
+export type RobotPreview = {
+  row: number
+  col: number
+  direction: MissionValue
+  afterRow?: number
+  afterCol?: number
+  afterAngle?: number
+}
+
+function dirToDeg(dir: MissionValue): number {
+  switch (dir) {
+    case "u":
+      return 0
+    case "r":
+      return 90
+    case "d":
+      return 180
+    case "l":
+      return -90
+    default:
+      return 0
+  }
+}
+
+/**
+ * Compute robot preview position and after-mission position for animation.
+ * Returns the robot's position before executing the selected mission,
+ * and optionally the position after execution for loop animation.
+ */
+export function computeRobotPreview(
+  field: FieldState,
+  mission: MissionState,
+  selectedMissionIndex: number | null,
+): RobotPreview | null {
+  const start = findStart(field)
+  if (!start || mission.length === 0) {
+    return null
+  }
+
+  const [startRow, startCol] = start
+  const pairs = missionStatePair(mission)
+
+  if (selectedMissionIndex === -2) {
+    const dir = mission[0] as MissionValue
+    if (!dir) {
+      return null
+    }
+    return { row: startRow, col: startCol, direction: dir }
+  }
+
+  if (selectedMissionIndex !== null && selectedMissionIndex >= 0) {
+    if (selectedMissionIndex >= pairs.length) {
+      return null
+    }
+    const [row, col, dir] = getRobotPosition(
+      startRow,
+      startCol,
+      mission,
+      selectedMissionIndex,
+    )
+    const pair = pairs[selectedMissionIndex]
+    if (pair[0] !== null && pair[1] !== null) {
+      const [afterRow, afterCol] = getNextPosition(
+        row,
+        col,
+        dir,
+        pair[0],
+        pair[1],
+      )
+      const beforeDeg = dirToDeg(dir)
+      let afterAngle = beforeDeg
+      if (pair[0] === "tr") {
+        afterAngle = beforeDeg + Number(pair[1])
+      } else if (pair[0] === "tl") {
+        afterAngle = beforeDeg - Number(pair[1])
+      }
+      return { row, col, direction: dir, afterRow, afterCol, afterAngle }
+    }
+    return { row, col, direction: dir }
+  }
+
+  if (selectedMissionIndex === -3) {
+    if (pairs.length === 0) {
+      return null
+    }
+    const [row, col, dir] = getRobotPosition(
+      startRow,
+      startCol,
+      mission,
+      pairs.length,
+    )
+    return { row, col, direction: dir }
+  }
+
+  return null
+}

--- a/@robopo/web/app/components/course/utils.tsx
+++ b/@robopo/web/app/components/course/utils.tsx
@@ -141,6 +141,18 @@ export function findStart(field: FieldState): [number, number] | null {
   return null
 }
 
+// Get goal position on the field
+export function findGoal(field: FieldState): [number, number] | null {
+  for (let i = 0; i < field.length; i++) {
+    for (let j = 0; j < field[i].length; j++) {
+      if (field[i][j] === "goal" || field[i][j] === "startGoal") {
+        return [i, j]
+      }
+    }
+  }
+  return null
+}
+
 // Place a panel at the specified position
 export function putPanel(
   field: FieldState,
@@ -242,15 +254,14 @@ export function deserializeMission(str: string): MissionState {
 
 // Get mission pairs excluding Start and Goal directions from String
 export function missionStatePair(missionState: MissionState): MissionValue[][] {
-  // Return empty array if no missions are set (excluding Start and Goal directions)
-  if (missionState[3] === null) {
+  // Return empty array if no mission pairs exist
+  if (missionState.length <= 2) {
     return []
   }
 
   const pairs = []
   for (let i = 2; i < missionState.length; i += 2) {
-    // The last pair is probably [goal direction, null]
-    pairs.push([missionState[i], missionState[i + 1]])
+    pairs.push([missionState[i], missionState[i + 1] ?? null])
   }
   return pairs
 }

--- a/@robopo/web/app/course/edit/courseEdit.tsx
+++ b/@robopo/web/app/course/edit/courseEdit.tsx
@@ -6,6 +6,7 @@ import {
   initializeField,
   isGoal,
   isStart,
+  type MissionValue,
   type PanelValue,
   putPanel,
 } from "@/app/components/course/utils"
@@ -23,6 +24,11 @@ type CourseEditProps = {
   canUndo: boolean
   canRedo: boolean
   pushHistory: () => void
+  botPosition?: { row: number; col: number }
+  botDirection?: MissionValue
+  botAfterPosition?: { row: number; col: number }
+  botAfterAngle?: number
+  onRouteAdded?: (row: number, col: number) => void
 }
 
 export default function CourseEdit({
@@ -37,6 +43,11 @@ export default function CourseEdit({
   canUndo,
   canRedo,
   pushHistory,
+  botPosition,
+  botDirection,
+  botAfterPosition,
+  botAfterAngle,
+  onRouteAdded,
 }: CourseEditProps) {
   const [isDragging, setIsDragging] = useState(false)
   const lastCellRef = useRef<{ r: number; c: number } | null>(null)
@@ -54,6 +65,7 @@ export default function CourseEdit({
         return
       }
       const mode = selectedTool as PanelValue
+      const wasEmpty = field[row][col] === null
       const newField = putPanel(field, row, col, mode)
       if (newField) {
         setField(newField)
@@ -65,9 +77,13 @@ export default function CourseEdit({
         if (mode === "goal" && !isGoal(field)) {
           setSelectedTool("route")
         }
+        // Auto-add empty mission when a route panel is newly placed
+        if (mode === "route" && wasEmpty && onRouteAdded) {
+          onRouteAdded(row, col)
+        }
       }
     },
-    [field, setField, selectedTool, setSelectedTool],
+    [field, setField, selectedTool, setSelectedTool, onRouteAdded],
   )
 
   function handlePanelClick(row: number, col: number) {
@@ -131,6 +147,10 @@ export default function CourseEdit({
             <Field
               type="edit"
               field={field}
+              botPosition={botPosition}
+              botDirection={botDirection}
+              botAfterPosition={botAfterPosition}
+              botAfterAngle={botAfterAngle}
               onPanelClick={handlePanelClick}
               onPanelPointerDown={handlePointerDown}
               onPanelPointerEnter={handlePointerEnter}

--- a/@robopo/web/app/course/edit/courseEditContext.tsx
+++ b/@robopo/web/app/course/edit/courseEditContext.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import type React from "react"
-import { createContext, useCallback, useContext, useRef, useState } from "react"
+import { createContext, useCallback, useContext, useState } from "react"
 import {
   type FieldState,
   initializeField,
@@ -9,8 +9,15 @@ import {
   type PanelValue,
   type PointState,
 } from "@/app/components/course/utils"
+import { useUndoRedo } from "@/app/hooks/useUndoRedo"
 
 export type ToolType = PanelValue | "eraser"
+
+export type MissionSnapshot = {
+  mission: MissionState
+  point: PointState
+  panelHints: (number | null)[]
+}
 
 // Form contents
 export type CourseEditState = {
@@ -19,6 +26,7 @@ export type CourseEditState = {
   field: FieldState
   mission: MissionState
   point: PointState
+  missionPanelHints: (number | null)[]
   courseOutRule: string
   selectedTool: ToolType
   setName: React.Dispatch<React.SetStateAction<string>>
@@ -26,6 +34,7 @@ export type CourseEditState = {
   setField: React.Dispatch<React.SetStateAction<FieldState>>
   setMission: React.Dispatch<React.SetStateAction<MissionState>>
   setPoint: React.Dispatch<React.SetStateAction<PointState>>
+  setMissionPanelHints: React.Dispatch<React.SetStateAction<(number | null)[]>>
   setCourseOutRule: React.Dispatch<React.SetStateAction<string>>
   setSelectedTool: React.Dispatch<React.SetStateAction<ToolType>>
   undo: () => void
@@ -33,6 +42,11 @@ export type CourseEditState = {
   canUndo: boolean
   canRedo: boolean
   pushHistory: () => void
+  undoMission: () => void
+  redoMission: () => void
+  canUndoMission: boolean
+  canRedoMission: boolean
+  pushMissionHistory: () => void
 }
 
 // Dummy initial values
@@ -42,6 +56,7 @@ const dummy: CourseEditState = {
   field: initializeField(),
   mission: [],
   point: [],
+  missionPanelHints: [null],
   courseOutRule: "keep",
   selectedTool: "start",
   setName: () => {},
@@ -49,6 +64,7 @@ const dummy: CourseEditState = {
   setField: () => {},
   setMission: () => {},
   setPoint: () => {},
+  setMissionPanelHints: () => {},
   setCourseOutRule: () => {},
   setSelectedTool: () => {},
   undo: () => {},
@@ -56,13 +72,16 @@ const dummy: CourseEditState = {
   canUndo: false,
   canRedo: false,
   pushHistory: () => {},
+  undoMission: () => {},
+  redoMission: () => {},
+  canUndoMission: false,
+  canRedoMission: false,
+  pushMissionHistory: () => {},
 }
 
 const CourseEditContext = createContext<CourseEditState>(dummy)
 
 export const useCourseEdit = () => useContext(CourseEditContext)
-
-const MAX_HISTORY = 50
 
 export function CourseEditProvider({
   children,
@@ -72,65 +91,49 @@ export function CourseEditProvider({
   const [name, setName] = useState<string>("")
   const [description, setDescription] = useState<string>("")
   const [field, setField] = useState<FieldState>(initializeField())
-  const [mission, setMission] = useState<MissionState>([])
-  const [point, setPoint] = useState<PointState>([0, 10])
+  // Default: 1 empty mission for the start panel action
+  const [mission, setMission] = useState<MissionState>([null, null, null, null])
+  const [point, setPoint] = useState<PointState>([0, 10, 0])
+  const [missionPanelHints, setMissionPanelHints] = useState<(number | null)[]>(
+    [null],
+  )
   const [courseOutRule, setCourseOutRule] = useState<string>("keep")
   const [selectedTool, setSelectedTool] = useState<ToolType>("start")
 
-  // Undo/Redo history
-  const historyRef = useRef<FieldState[]>([])
-  const redoRef = useRef<FieldState[]>([])
-  const [canUndo, setCanUndo] = useState(false)
-  const [canRedo, setCanRedo] = useState(false)
+  // Field undo/redo
+  const {
+    push: pushHistory,
+    undo,
+    redo,
+    canUndo,
+    canRedo,
+  } = useUndoRedo<FieldState>({
+    getSnapshot: useCallback(() => field.map((row) => [...row]), [field]),
+    applySnapshot: useCallback((snap: FieldState) => setField(snap), []),
+  })
 
-  const pushHistory = useCallback(() => {
-    historyRef.current = [
-      ...historyRef.current.slice(-MAX_HISTORY + 1),
-      field.map((row) => [...row]),
-    ]
-    // New action clears redo stack
-    redoRef.current = []
-    setCanUndo(true)
-    setCanRedo(false)
-  }, [field])
-
-  const undo = useCallback(() => {
-    const history = historyRef.current
-    if (history.length > 0) {
-      // Save current state to redo stack
-      setField((currentField) => {
-        redoRef.current = [
-          ...redoRef.current,
-          currentField.map((row) => [...row]),
-        ]
-        setCanRedo(true)
-        return currentField
-      })
-      const prev = history[history.length - 1]
-      historyRef.current = history.slice(0, -1)
-      setCanUndo(historyRef.current.length > 0)
-      setField(prev)
-    }
-  }, [])
-
-  const redo = useCallback(() => {
-    const redoStack = redoRef.current
-    if (redoStack.length > 0) {
-      // Save current state to undo stack
-      setField((currentField) => {
-        historyRef.current = [
-          ...historyRef.current,
-          currentField.map((row) => [...row]),
-        ]
-        setCanUndo(true)
-        return currentField
-      })
-      const next = redoStack[redoStack.length - 1]
-      redoRef.current = redoStack.slice(0, -1)
-      setCanRedo(redoRef.current.length > 0)
-      setField(next)
-    }
-  }, [])
+  // Mission undo/redo (includes panelHints for sync - Comment 1 fix)
+  const {
+    push: pushMissionHistory,
+    undo: undoMission,
+    redo: redoMission,
+    canUndo: canUndoMission,
+    canRedo: canRedoMission,
+  } = useUndoRedo<MissionSnapshot>({
+    getSnapshot: useCallback(
+      () => ({
+        mission: [...mission],
+        point: [...point],
+        panelHints: [...missionPanelHints],
+      }),
+      [mission, point, missionPanelHints],
+    ),
+    applySnapshot: useCallback((snap: MissionSnapshot) => {
+      setMission(snap.mission)
+      setPoint(snap.point)
+      setMissionPanelHints(snap.panelHints)
+    }, []),
+  })
 
   return (
     <CourseEditContext.Provider
@@ -140,6 +143,7 @@ export function CourseEditProvider({
         field,
         mission,
         point,
+        missionPanelHints,
         courseOutRule,
         selectedTool,
         setName,
@@ -147,6 +151,7 @@ export function CourseEditProvider({
         setField,
         setMission,
         setPoint,
+        setMissionPanelHints,
         setCourseOutRule,
         setSelectedTool,
         undo,
@@ -154,6 +159,11 @@ export function CourseEditProvider({
         canUndo,
         canRedo,
         pushHistory,
+        undoMission,
+        redoMission,
+        canUndoMission,
+        canRedoMission,
+        pushMissionHistory,
       }}
     >
       {children}

--- a/@robopo/web/app/course/edit/editorPage.tsx
+++ b/@robopo/web/app/course/edit/editorPage.tsx
@@ -1,7 +1,8 @@
 "use client"
 
 import Link from "next/link"
-import { useEffect } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { computeRobotPreview } from "@/app/components/course/robotPreview"
 import {
   deserializeField,
   deserializeMission,
@@ -37,7 +38,19 @@ export function EditorPage({
     canUndo,
     canRedo,
     pushHistory,
+    undoMission,
+    redoMission,
+    canUndoMission,
+    canRedoMission,
+    pushMissionHistory,
+    missionPanelHints,
+    setMissionPanelHints,
   } = useCourseEdit()
+
+  // Lifted from MissionEdit for cross-component access
+  const [selectedMissionIndex, setSelectedMissionIndex] = useState<
+    number | null
+  >(null)
 
   useEffect(() => {
     async function fetchCourseData() {
@@ -62,6 +75,55 @@ export function EditorPage({
     fetchCourseData()
   }, [courseData, setField, setMission, setPoint, setName, setCourseOutRule])
 
+  const robotPreview = useMemo(
+    () => computeRobotPreview(field, mission, selectedMissionIndex),
+    [field, mission, selectedMissionIndex],
+  )
+
+  // Auto-add an empty mission when a route panel is placed
+  // Inserts after the start action (pair 0) + any previously auto-added routes
+  const handleRouteAdded = useCallback(
+    (row: number, col: number) => {
+      pushMissionHistory()
+      const panelNumber = row * 5 + col + 1
+      // Insert position: after start action (pair 0) + existing auto-added count
+      const autoAddedCount = missionPanelHints.filter((h) => h !== null).length
+      setMission((prev) => {
+        const newMission = [...prev]
+        while (newMission.length < 4) {
+          newMission.push(null)
+        }
+        // Insert after pair 0 + autoAddedCount pairs
+        const insertAt = 4 + autoAddedCount * 2
+        newMission.splice(insertAt, 0, null, null)
+        return newMission
+      })
+      setPoint((prev) => {
+        const newPoint = [...prev]
+        while (newPoint.length < 3) {
+          newPoint.push(0)
+        }
+        const insertAt = 3 + autoAddedCount
+        newPoint.splice(insertAt, 0, 0)
+        return newPoint
+      })
+      // Hint index matches mission pair index: insert at 1 + autoAddedCount
+      setMissionPanelHints((prev) => {
+        const newHints = [...prev]
+        const hintInsertAt = 1 + autoAddedCount
+        newHints.splice(hintInsertAt, 0, panelNumber)
+        return newHints
+      })
+    },
+    [
+      pushMissionHistory,
+      setMission,
+      setPoint,
+      setMissionPanelHints,
+      missionPanelHints,
+    ],
+  )
+
   return (
     <div className="h-full w-full">
       <div className="gap-4 sm:grid sm:max-h-screen sm:grid-cols-2">
@@ -78,14 +140,38 @@ export function EditorPage({
             canUndo={canUndo}
             canRedo={canRedo}
             pushHistory={pushHistory}
+            botPosition={
+              robotPreview
+                ? { row: robotPreview.row, col: robotPreview.col }
+                : undefined
+            }
+            botDirection={robotPreview?.direction}
+            botAfterPosition={
+              robotPreview?.afterRow !== undefined &&
+              robotPreview?.afterCol !== undefined
+                ? { row: robotPreview.afterRow, col: robotPreview.afterCol }
+                : undefined
+            }
+            botAfterAngle={robotPreview?.afterAngle}
+            onRouteAdded={handleRouteAdded}
           />
         </div>
         <div className="sm:mx-4 sm:w-full sm:justify-self-start">
           <MissionEdit
+            field={field}
             mission={mission}
             setMission={setMission}
             point={point}
             setPoint={setPoint}
+            selectedMissionIndex={selectedMissionIndex}
+            setSelectedMissionIndex={setSelectedMissionIndex}
+            undoMission={undoMission}
+            redoMission={redoMission}
+            canUndoMission={canUndoMission}
+            canRedoMission={canRedoMission}
+            pushMissionHistory={pushMissionHistory}
+            missionPanelHints={missionPanelHints}
+            setMissionPanelHints={setMissionPanelHints}
           />
         </div>
       </div>

--- a/@robopo/web/app/course/edit/missionEdit.tsx
+++ b/@robopo/web/app/course/edit/missionEdit.tsx
@@ -1,83 +1,62 @@
-import { useState } from "react"
 import { MissionList } from "@/app/components/course/missionList"
-import { MissionUI } from "@/app/components/course/missionUI"
 import type {
+  FieldState,
   MissionState,
-  MissionValue,
   PointState,
-  PointValue,
 } from "@/app/components/course/utils"
 
 type MissionEditProps = {
+  field: FieldState
   mission: MissionState
   setMission: React.Dispatch<React.SetStateAction<MissionState>>
   point: PointState
   setPoint: React.Dispatch<React.SetStateAction<PointState>>
+  selectedMissionIndex: number | null
+  setSelectedMissionIndex: (index: number | null) => void
+  undoMission: () => void
+  redoMission: () => void
+  canUndoMission: boolean
+  canRedoMission: boolean
+  pushMissionHistory: () => void
+  missionPanelHints: (number | null)[]
+  setMissionPanelHints: React.Dispatch<React.SetStateAction<(number | null)[]>>
 }
 
 export default function MissionEdit({
+  field,
   mission,
   setMission,
   point,
   setPoint,
+  selectedMissionIndex,
+  setSelectedMissionIndex,
+  undoMission,
+  redoMission,
+  canUndoMission,
+  canRedoMission,
+  pushMissionHistory,
+  missionPanelHints,
+  setMissionPanelHints,
 }: MissionEditProps) {
-  const [selectedMissionIndex, setSelectedMissionIndex] = useState<
-    number | null
-  >(null)
-  const [selectedMission, setSelectedMission] = useState<MissionValue | null>(
-    null,
-  )
-  const [selectedParam, setSelectedParam] = useState<number | null>(null) // 選択されたミッションのパラメータ
-  const [selectedPoint, setSelectedPoint] = useState<PointValue | null>(null)
-  const [insertPosition, setInsertPosition] = useState<number>(-1)
-
-  function handleMissionSelect(selectedIndex: number) {
-    setSelectedMissionIndex(selectedIndex) // Save selected index as state
-    setSelectedMission(null) // Reset selected mission
-    setSelectedParam(null) // Reset selected parameter
-    setSelectedPoint(null) // Reset selected point
-  }
-  // Behavior when radio button is pressed
-  // Radio button value >= 0: mission order index
-  // Radio button value = -1: no mission set
-  // Radio button value = -2: Start
-  // Radio button value = -3: Goal
-
   return (
     <div className="container mx-auto">
       <div className="card w-full min-w-72 bg-base-100 shadow-xl">
         <div className="card-body">
           <MissionList
-            mission={mission}
-            point={point}
-            selectedMissionIndex={selectedMissionIndex}
-            handleMissionSelect={handleMissionSelect}
-            insertPosition={insertPosition}
-            setInsertPosition={setInsertPosition}
-          />
-        </div>
-      </div>
-      <div className="card w-full min-w-72 bg-base-100 shadow-xl">
-        <div className="card-body">
-          <MissionUI
+            field={field}
             mission={mission}
             setMission={setMission}
             point={point}
-            selectedMissionIndex={selectedMissionIndex}
             setPoint={setPoint}
-            selectedId={
-              selectedMissionIndex === -1
-                ? insertPosition
-                : selectedMissionIndex
-            }
-            selectedMission={selectedMission}
-            setSelectedMission={setSelectedMission}
-            selectedParam={selectedParam}
-            setSelectedParam={setSelectedParam}
-            selectedPoint={selectedPoint}
-            setSelectedPoint={setSelectedPoint}
+            selectedMissionIndex={selectedMissionIndex}
             setSelectedMissionIndex={setSelectedMissionIndex}
-            setInsertPosition={setInsertPosition}
+            undoMission={undoMission}
+            redoMission={redoMission}
+            canUndoMission={canUndoMission}
+            canRedoMission={canRedoMission}
+            pushMissionHistory={pushMissionHistory}
+            missionPanelHints={missionPanelHints}
+            setMissionPanelHints={setMissionPanelHints}
           />
         </div>
       </div>

--- a/@robopo/web/app/hooks/useUndoRedo.ts
+++ b/@robopo/web/app/hooks/useUndoRedo.ts
@@ -1,0 +1,65 @@
+import { useCallback, useRef, useState } from "react"
+
+const DEFAULT_MAX_HISTORY = 50
+
+/**
+ * Generic undo/redo hook for any state type.
+ * Manages history and redo stacks with a configurable max size.
+ */
+export function useUndoRedo<T>({
+  max = DEFAULT_MAX_HISTORY,
+  getSnapshot,
+  applySnapshot,
+}: {
+  max?: number
+  getSnapshot: () => T
+  applySnapshot: (snap: T) => void
+}) {
+  const historyRef = useRef<T[]>([])
+  const redoRef = useRef<T[]>([])
+  const [canUndo, setCanUndo] = useState(false)
+  const [canRedo, setCanRedo] = useState(false)
+
+  const push = useCallback(() => {
+    historyRef.current = [...historyRef.current.slice(-max + 1), getSnapshot()]
+    redoRef.current = []
+    setCanUndo(true)
+    setCanRedo(false)
+  }, [getSnapshot, max])
+
+  const undo = useCallback(() => {
+    const history = historyRef.current
+    if (history.length === 0) {
+      return
+    }
+
+    // Save current state to redo stack
+    redoRef.current = [...redoRef.current, getSnapshot()]
+    setCanRedo(true)
+
+    const prev = history[history.length - 1]
+    historyRef.current = history.slice(0, -1)
+    setCanUndo(historyRef.current.length > 0)
+
+    applySnapshot(prev)
+  }, [getSnapshot, applySnapshot])
+
+  const redo = useCallback(() => {
+    const redoStack = redoRef.current
+    if (redoStack.length === 0) {
+      return
+    }
+
+    // Save current state to history stack
+    historyRef.current = [...historyRef.current, getSnapshot()]
+    setCanUndo(true)
+
+    const next = redoStack[redoStack.length - 1]
+    redoRef.current = redoStack.slice(0, -1)
+    setCanRedo(redoRef.current.length > 0)
+
+    applySnapshot(next)
+  }, [getSnapshot, applySnapshot])
+
+  return { push, undo, redo, canUndo, canRedo }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,11 @@
   "workspaces": {
     "": {
       "name": "robopo",
+      "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
+      },
       "devDependencies": {
         "@biomejs/biome": "^2.4.11",
         "@types/bun": "^1.3.12",
@@ -460,6 +465,14 @@
     "@csstools/utilities": ["@csstools/utilities@2.0.0", "", { "peerDependencies": { "postcss": "^8.4" } }, "sha512-5VdOr0Z71u+Yp3ozOx8T11N703wIFGVRgOWbOZMKgglPJsWA54MRIoMNVMa7shUToIhx5J8vX4sOZgD2XiihiQ=="],
 
     "@discoveryjs/json-ext": ["@discoveryjs/json-ext@0.5.7", "", {}, "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw=="],
+
+    "@dnd-kit/accessibility": ["@dnd-kit/accessibility@3.1.1", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw=="],
+
+    "@dnd-kit/core": ["@dnd-kit/core@6.3.1", "", { "dependencies": { "@dnd-kit/accessibility": "^3.1.1", "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ=="],
+
+    "@dnd-kit/sortable": ["@dnd-kit/sortable@10.0.0", "", { "dependencies": { "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.3.0", "react": ">=16.8.0" } }, "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg=="],
+
+    "@dnd-kit/utilities": ["@dnd-kit/utilities@3.2.2", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg=="],
 
     "@docsearch/core": ["@docsearch/core@4.6.2", "", { "peerDependencies": { "@types/react": ">= 16.8.0 < 20.0.0", "react": ">= 16.8.0 < 20.0.0", "react-dom": ">= 16.8.0 < 20.0.0" }, "optionalPeers": ["@types/react", "react", "react-dom"] }, "sha512-/S0e6Dj7Zcm8m9Rru49YEX49dhU11be68c+S/BCyN8zQsTTgkKzXlhRbVL5mV6lOLC2+ZRRryaTdcm070Ug2oA=="],
 

--- a/package.json
+++ b/package.json
@@ -47,5 +47,10 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.11",
     "@types/bun": "^1.3.12"
+  },
+  "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2"
   }
 }


### PR DESCRIPTION
## Summary by Sourcery

ドラッグ＆ドロップによるミッション管理、インラインでのミッション編集、フィールドレイアウトと同期したライブロボットプレビューを備えた、コースミッション編集体験の再設計。

新機能:
- ミッションリスト内で、ドラッグ＆ドロップによるミッションの並べ替えを可能にする。
- ミッションリスト上で、ミッションタイプ・パラメータ・ポイント（段階的なポイント設定を含む）をインライン編集できるようにする。
- フィールドグリッド上にパネル番号を表示し、ミッションをパネルベースの位置ヒントと関連付ける。
- 編集フィールド上で、選択中のミッションステップを反映したロボットプレビューをアニメーション表示し、前後の位置や回転アニメーションを含めて見せる。
- フィールド上に新たにルートパネルが配置された際、自動的に空のミッションを挿入する。

改善:
- Start/Goal ミッションの UI を、より明確なスタイリングとインライン操作を備えた専用行として洗練させる。
- 画面サイズの違いに応じたより良い表示のため、次ステップ矢印とロボットコンポーネントを動的なセルサイズに追従できるようにする。
- 完全に空のミッション状態ではなく、デフォルトで空のミッションペアを持つ状態でコースを初期化する。
- ミッションペアの操作を集約し、UI 用のヒントとしてロボット位置を計算することで、ミッション状態の扱いを改善する。

ビルド:
- ミッションリストのドラッグ＆ドロップのために、依存関係として @dnd-kit core、sortable、utilities パッケージを追加する。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Redesign the course mission editing experience with drag-and-drop mission management, inline mission editing, and a live robot preview synchronized with the field layout.

New Features:
- Allow missions to be reordered via drag-and-drop in the mission list.
- Provide inline editing of mission type, parameters, and points directly in the mission list, including tiered point configurations.
- Show panel numbers on the field grid and associate missions with panel-based position hints.
- Animate a robot preview on the edit field that reflects the selected mission step, including before/after position and turn animation.
- Automatically insert empty missions when route panels are newly placed on the field.

Enhancements:
- Refine the Start/Goal mission UI into dedicated rows with clearer styling and inline controls.
- Make next-step arrows and the robot component responsive to dynamic cell sizes for better display on varying screens.
- Initialize courses with a default empty mission pair instead of an entirely empty mission state.
- Improve mission state handling by centralizing mission pair operations and computing robot positions for UI hints.

Build:
- Add @dnd-kit core, sortable, and utilities packages as dependencies for mission list drag-and-drop.

</details>