### PR TITLE
feat: show total point

### DIFF
--- a/@robopo/web/app/components/course/missionList.tsx
+++ b/@robopo/web/app/components/course/missionList.tsx
@@ -39,6 +39,30 @@ import {
 
 // ─── Types ───────────────────────────────────────────────────────────
 
+export type InsertPreview = {
+  afterIndex: number
+  missionType: MissionValue
+  param: number
+}
+
+export function buildPreviewMission(
+  baseMission: MissionState,
+  { afterIndex, missionType, param }: InsertPreview,
+): { missionWithInsert: MissionState; selectedIndex: number } {
+  const temp = [...baseMission]
+  if (temp.length <= 2) {
+    while (temp.length < 4) {
+      temp.push(null)
+    }
+    temp[2] = missionType
+    temp[3] = param
+    return { missionWithInsert: temp, selectedIndex: 0 }
+  }
+  const insertIndex = 2 + (afterIndex + 1) * 2
+  temp.splice(insertIndex, 0, missionType, param)
+  return { missionWithInsert: temp, selectedIndex: afterIndex + 1 }
+}
+
 type MissionPairItem = {
   id: string
   index: number
@@ -62,6 +86,7 @@ export function MissionList({
   pushMissionHistory,
   missionPanelHints,
   setMissionPanelHints,
+  onInsertPreview,
 }: {
   field: FieldState
   mission: MissionState
@@ -77,6 +102,7 @@ export function MissionList({
   pushMissionHistory: () => void
   missionPanelHints: (number | null)[]
   setMissionPanelHints: React.Dispatch<React.SetStateAction<(number | null)[]>>
+  onInsertPreview?: (preview: InsertPreview | null) => void
 }) {
   const [items, setItems] = useState<MissionPairItem[]>([])
   const [insertingAt, setInsertingAt] = useState<number | null>(null)
@@ -171,47 +197,47 @@ export function MissionList({
   function handleAddMission(afterIndex: number) {
     setInsertingAt(afterIndex)
     setSelectedMissionIndex(-1)
+    onInsertPreview?.(null)
   }
 
   function handleInsertMission(
     missionType: MissionValue,
     param: number,
     pointEntry: PointEntry,
+    panelHint: number | null,
   ) {
     if (insertingAt === null) {
       return
     }
     pushMissionHistory()
 
-    const newMission = [...mission]
-    const newPoint = [...point]
+    const { missionWithInsert, selectedIndex } = buildPreviewMission(mission, {
+      afterIndex: insertingAt,
+      missionType,
+      param,
+    })
 
+    // Insert point entry at the corresponding position
+    const newPoint = [...point]
     if (mission.length <= 2) {
-      // No missions yet — set first pair
-      while (newMission.length < 4) {
-        newMission.push(null)
-      }
-      newMission[2] = missionType
-      newMission[3] = param
       while (newPoint.length < 3) {
         newPoint.push(0)
       }
       newPoint[2] = pointEntry
     } else {
-      const insertIndex = 2 + (insertingAt + 1) * 2
-      newMission.splice(insertIndex, 0, missionType, param)
       newPoint.splice(insertingAt + 3, 0, pointEntry)
     }
 
-    setMission(newMission)
+    setMission(missionWithInsert)
     setPoint(newPoint)
     setInsertingAt(null)
-    setSelectedMissionIndex(null)
-    // Insert null hint at the new position (manually added missions have no hint)
+    setSelectedMissionIndex(selectedIndex)
+    onInsertPreview?.(null)
+    // Insert panel hint at the new position
     if (insertingAt !== null) {
       setMissionPanelHints((prev) => {
         const newHints = [...prev]
-        newHints.splice(insertingAt + 1, 0, null)
+        newHints.splice(insertingAt + 1, 0, panelHint)
         return newHints
       })
     }
@@ -275,9 +301,22 @@ export function MissionList({
 
   return (
     <div className="w-full">
-      {/* Header with Undo/Redo */}
+      {/* Header with Total Points & Undo/Redo */}
       <div className="mb-3 flex items-center justify-between">
         <h3 className="font-bold text-sm">ミッション</h3>
+        <span className="badge badge-sm font-mono">
+          合計{" "}
+          {point.slice(1).reduce<number>((sum, entry) => {
+            if (entry === null) {
+              return sum
+            }
+            if (Array.isArray(entry)) {
+              return sum + Math.max(...entry)
+            }
+            return sum + entry
+          }, 0)}{" "}
+          pt
+        </span>
         <div className="flex gap-1">
           <button
             type="button"
@@ -317,8 +356,16 @@ export function MissionList({
         />
         {insertingAt === -1 && (
           <InsertMissionRow
+            defaultPanelId={panelPositions?.startPanel ?? null}
             onInsert={handleInsertMission}
-            onCancel={() => setInsertingAt(null)}
+            onCancel={() => {
+              setInsertingAt(null)
+              onInsertPreview?.(null)
+            }}
+            onPreviewChange={(mt, p) =>
+              onInsertPreview?.({ afterIndex: -1, missionType: mt, param: p })
+            }
+            onPreviewClear={() => onInsertPreview?.(null)}
           />
         )}
 
@@ -364,8 +411,20 @@ export function MissionList({
                 />
                 {insertingAt === idx && (
                   <InsertMissionRow
+                    defaultPanelId={panelPositions?.positions[idx] ?? null}
                     onInsert={handleInsertMission}
-                    onCancel={() => setInsertingAt(null)}
+                    onCancel={() => {
+                      setInsertingAt(null)
+                      onInsertPreview?.(null)
+                    }}
+                    onPreviewChange={(mt, p) =>
+                      onInsertPreview?.({
+                        afterIndex: idx,
+                        missionType: mt,
+                        param: p,
+                      })
+                    }
+                    onPreviewClear={() => onInsertPreview?.(null)}
                   />
                 )}
               </div>
@@ -927,19 +986,27 @@ function InlineMissionEditor({
 // ─── Insert Mission Row ──────────────────────────────────────────────
 
 function InsertMissionRow({
+  defaultPanelId,
   onInsert,
   onCancel,
+  onPreviewChange,
+  onPreviewClear,
 }: {
+  defaultPanelId: number | null
   onInsert: (
     missionType: MissionValue,
     param: number,
     pointEntry: PointEntry,
+    panelHint: number | null,
   ) => void
   onCancel: () => void
+  onPreviewChange?: (missionType: MissionValue, param: number) => void
+  onPreviewClear?: () => void
 }) {
   const [missionType, setMissionType] = useState<MissionValue | null>(null)
   const [param, setParam] = useState<number | null>(null)
   const [pointEntry, setPointEntry] = useState<PointEntry>(0)
+  const [panelId, setPanelId] = useState<number | null>(defaultPanelId)
 
   const isMove = missionType === "mf" || missionType === "mb"
   const isTurn = missionType === "tr" || missionType === "tl"
@@ -948,20 +1015,55 @@ function InsertMissionRow({
 
   function handleMissionTypeChange(val: MissionValue) {
     setMissionType(val)
+    let newParam: number | null
     if (val === "ps") {
-      setParam(0)
+      newParam = 0
     } else if (val === "mf" || val === "mb") {
-      setParam(1)
+      newParam = 1
     } else if (val === "tr" || val === "tl") {
-      setParam(90)
+      newParam = 90
     } else {
-      setParam(null)
+      newParam = null
+    }
+    setParam(newParam)
+    if (val && newParam !== null) {
+      onPreviewChange?.(val, newParam)
+    } else {
+      onPreviewClear?.()
+    }
+  }
+
+  function handleParamChange(newParam: number) {
+    setParam(newParam)
+    if (missionType) {
+      onPreviewChange?.(missionType, newParam)
     }
   }
 
   return (
     <div className="rounded-lg border-2 border-primary/40 border-dashed bg-primary/5 p-3">
       <div className="flex flex-wrap items-center gap-2">
+        {/* Panel ID */}
+        <div className="flex items-center gap-0.5">
+          <span className="font-mono text-xs">P</span>
+          <input
+            type="number"
+            className="input input-bordered input-xs w-12 font-mono"
+            min={1}
+            max={25}
+            value={panelId ?? ""}
+            onChange={(e) => {
+              const num = Number(e.target.value)
+              if (e.target.value === "") {
+                setPanelId(null)
+              } else if (num >= 1 && num <= 25) {
+                setPanelId(num)
+              }
+            }}
+            placeholder="-"
+          />
+        </div>
+
         <select
           className="select select-bordered select-xs"
           value={(missionType as string) ?? ""}
@@ -982,7 +1084,7 @@ function InsertMissionRow({
             <select
               className="select select-bordered select-xs"
               value={param ?? ""}
-              onChange={(e) => setParam(Number(e.target.value))}
+              onChange={(e) => handleParamChange(Number(e.target.value))}
             >
               {[1, 2, 3, 4].map((n) => (
                 <option key={n} value={n}>
@@ -999,7 +1101,7 @@ function InsertMissionRow({
             <select
               className="select select-bordered select-xs"
               value={param ?? ""}
-              onChange={(e) => setParam(Number(e.target.value))}
+              onChange={(e) => handleParamChange(Number(e.target.value))}
             >
               {[90, 180, 270, 360].map((n) => (
                 <option key={n} value={n}>
@@ -1033,7 +1135,7 @@ function InsertMissionRow({
           disabled={!canInsert}
           onClick={() => {
             if (canInsert) {
-              onInsert(missionType, param ?? 0, pointEntry)
+              onInsert(missionType, param ?? 0, pointEntry, panelId)
             }
           }}
         >

--- a/@robopo/web/app/course/edit/editorPage.tsx
+++ b/@robopo/web/app/course/edit/editorPage.tsx
@@ -2,6 +2,10 @@
 
 import Link from "next/link"
 import { useCallback, useEffect, useMemo, useState } from "react"
+import {
+  buildPreviewMission,
+  type InsertPreview,
+} from "@/app/components/course/missionList"
 import { computeRobotPreview } from "@/app/components/course/robotPreview"
 import {
   deserializeField,
@@ -51,6 +55,7 @@ export function EditorPage({
   const [selectedMissionIndex, setSelectedMissionIndex] = useState<
     number | null
   >(null)
+  const [insertPreview, setInsertPreview] = useState<InsertPreview | null>(null)
 
   useEffect(() => {
     async function fetchCourseData() {
@@ -75,10 +80,16 @@ export function EditorPage({
     fetchCourseData()
   }, [courseData, setField, setMission, setPoint, setName, setCourseOutRule])
 
-  const robotPreview = useMemo(
-    () => computeRobotPreview(field, mission, selectedMissionIndex),
-    [field, mission, selectedMissionIndex],
-  )
+  const robotPreview = useMemo(() => {
+    if (insertPreview) {
+      const { missionWithInsert, selectedIndex } = buildPreviewMission(
+        mission,
+        insertPreview,
+      )
+      return computeRobotPreview(field, missionWithInsert, selectedIndex)
+    }
+    return computeRobotPreview(field, mission, selectedMissionIndex)
+  }, [field, mission, selectedMissionIndex, insertPreview])
 
   // Auto-add an empty mission when a route panel is placed
   // Inserts after the start action (pair 0) + any previously auto-added routes
@@ -172,6 +183,7 @@ export function EditorPage({
             pushMissionHistory={pushMissionHistory}
             missionPanelHints={missionPanelHints}
             setMissionPanelHints={setMissionPanelHints}
+            onInsertPreview={setInsertPreview}
           />
         </div>
       </div>

--- a/@robopo/web/app/course/edit/missionEdit.tsx
+++ b/@robopo/web/app/course/edit/missionEdit.tsx
@@ -1,4 +1,7 @@
-import { MissionList } from "@/app/components/course/missionList"
+import {
+  type InsertPreview,
+  MissionList,
+} from "@/app/components/course/missionList"
 import type {
   FieldState,
   MissionState,
@@ -20,6 +23,7 @@ type MissionEditProps = {
   pushMissionHistory: () => void
   missionPanelHints: (number | null)[]
   setMissionPanelHints: React.Dispatch<React.SetStateAction<(number | null)[]>>
+  onInsertPreview?: (preview: InsertPreview | null) => void
 }
 
 export default function MissionEdit({
@@ -37,6 +41,7 @@ export default function MissionEdit({
   pushMissionHistory,
   missionPanelHints,
   setMissionPanelHints,
+  onInsertPreview,
 }: MissionEditProps) {
   return (
     <div className="container mx-auto">
@@ -57,6 +62,7 @@ export default function MissionEdit({
             pushMissionHistory={pushMissionHistory}
             missionPanelHints={missionPanelHints}
             setMissionPanelHints={setMissionPanelHints}
+            onInsertPreview={onInsertPreview}
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary by Sourcery

ミッションエディタを拡張し、合計ポイント表示、ミッション挿入時のプレビュー、新規挿入ミッションへのパネルヒント関連付けなどを追加します。

新機能:
- ミッション一覧ヘッダーにミッションの合計ポイントを表示。
- コミット前の挿入ミッションについて、ロボットの動きをプレビュー表示。
- 新しいミッションを挿入する際、パネルヒント（パネルID）を指定・保存できるようにする。

改善点:
- 新しく挿入されたミッションを一覧で自動選択し、挿入プレビューが有効な場合は挿入またはキャンセル時にクリアするようにする。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add mission editor enhancements including total point display, mission insertion previews, and panel hint association for newly inserted missions.

New Features:
- Display the total mission points in the mission list header.
- Preview robot movement for missions being inserted before they are committed.
- Allow specifying and storing a panel hint (panel ID) when inserting a new mission.

Enhancements:
- Automatically select the newly inserted mission in the list and clear any active insertion preview on insert or cancel.

</details>