### PR TITLE
feat: polish competition list page

### DIFF
--- a/@robopo/web/app/api/competition/[id]/route.ts
+++ b/@robopo/web/app/api/competition/[id]/route.ts
@@ -1,44 +1,67 @@
-import type { QueryResult } from "pg"
 import { getCompetitionList } from "@/app/components/server/db"
-import {
-  closeCompetitionById,
-  openCompetitionById,
-  returnCompetitionById,
-} from "@/app/lib/db/queries/queries"
+import { updateCompetition } from "@/app/lib/db/queries/update"
 
 export const revalidate = 0
 
-export async function POST(
+function parseOptionalDate(
+  value: string | null | undefined,
+): Date | null | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+  if (!value) {
+    return null
+  }
+  return new Date(value)
+}
+
+export async function PATCH(
   req: Request,
   props: { params: Promise<{ id: string }> },
 ) {
   const { id } = await props.params
-  const { type } = await req.json()
-  let result: QueryResult
+  const body = await req.json()
 
-  switch (type) {
-    case "open":
-      result = await openCompetitionById(Number(id))
-      break
-    case "return":
-      result = await returnCompetitionById(Number(id))
-      break
-    case "close":
-      result = await closeCompetitionById(Number(id))
-      break
-    default:
-      return Response.json(
-        {
-          success: false,
-          message: "An error occurred while updating the course.",
-          error: "Invalid type",
-        },
-        { status: 400 },
-      )
+  const parsedStart = parseOptionalDate(body.startDate)
+  const parsedEnd = parseOptionalDate(body.endDate)
+
+  if (
+    parsedStart instanceof Date &&
+    parsedEnd instanceof Date &&
+    parsedStart > parsedEnd
+  ) {
+    return Response.json(
+      { success: false, message: "開催日は終了日より前でなければなりません。" },
+      { status: 400 },
+    )
   }
-  const newList = await getCompetitionList()
-  return Response.json(
-    { success: true, data: result, newList: newList },
-    { status: 200 },
-  )
+
+  const updateData: Record<string, unknown> = {}
+  if (body.name !== undefined) {
+    updateData.name = body.name
+  }
+  if (body.description !== undefined) {
+    updateData.description = body.description || null
+  }
+  if (parsedStart !== undefined) {
+    updateData.startDate = parsedStart
+  }
+  if (parsedEnd !== undefined) {
+    updateData.endDate = parsedEnd
+  }
+
+  try {
+    await updateCompetition(Number(id), updateData)
+    const newList = await getCompetitionList()
+    return Response.json({ success: true, newList }, { status: 200 })
+  } catch (error) {
+    return Response.json(
+      {
+        success: false,
+        message: "An error occurred while updating the competition.",
+        error: error,
+      },
+      { status: 500 },
+    )
+  }
 }

--- a/@robopo/web/app/api/competition/route.ts
+++ b/@robopo/web/app/api/competition/route.ts
@@ -3,14 +3,28 @@ import { getCompetitionList } from "@/app/components/server/db"
 import { createCompetition } from "@/app/lib/db/queries/insert"
 
 export async function POST(req: Request) {
-  const { name } = await req.json()
+  const { name, description, startDate, endDate } = await req.json()
+
+  if (startDate && endDate && new Date(startDate) > new Date(endDate)) {
+    return Response.json(
+      { success: false, message: "開催日は終了日より前でなければなりません。" },
+      { status: 400 },
+    )
+  }
+
   const competitionData = {
     name: name,
-    step: 0,
+    description: description || null,
+    startDate: startDate ? new Date(startDate) : null,
+    endDate: endDate ? new Date(endDate) : null,
   }
   try {
     const result = await createCompetition(competitionData)
-    return Response.json({ success: true, data: result }, { status: 200 })
+    const newList = await getCompetitionList()
+    return Response.json(
+      { success: true, data: result, newList },
+      { status: 200 },
+    )
   } catch (error) {
     return Response.json(
       {

--- a/@robopo/web/app/components/common/commonList.tsx
+++ b/@robopo/web/app/components/common/commonList.tsx
@@ -117,13 +117,37 @@ function TableComponent({
           <td className="py-3 font-medium">
             {(common as SelectCompetition).name}
           </td>
-          <td className="py-3">
-            {(common as SelectCompetition).step === 0 ? (
-              <span className="badge badge-outline badge-sm">開催前</span>
-            ) : (common as SelectCompetition).step === 1 ? (
-              <span className="badge badge-primary badge-sm">開催中</span>
+          <td className="max-w-48 py-3">
+            {(common as SelectCompetition).description ? (
+              <span className="line-clamp-2 text-base-content/70 text-sm">
+                {(common as SelectCompetition).description}
+              </span>
             ) : (
-              <span className="badge badge-ghost badge-sm">終了済</span>
+              <span className="text-base-content/30 text-sm">-</span>
+            )}
+          </td>
+          <td
+            className="py-3 text-base-content/60 text-sm"
+            suppressHydrationWarning
+          >
+            {(common as SelectCompetition).startDate ? (
+              new Date(
+                (common as SelectCompetition).startDate as Date,
+              ).toLocaleDateString("ja-JP")
+            ) : (
+              <span className="text-base-content/30">-</span>
+            )}
+          </td>
+          <td
+            className="py-3 text-base-content/60 text-sm"
+            suppressHydrationWarning
+          >
+            {(common as SelectCompetition).endDate ? (
+              new Date(
+                (common as SelectCompetition).endDate as Date,
+              ).toLocaleDateString("ja-JP")
+            ) : (
+              <span className="text-base-content/30">-</span>
             )}
           </td>
         </>
@@ -141,7 +165,7 @@ function itemNames(type: CommonListProps["type"]): string[] {
   } else if (type === "course") {
     itemNames.push("ID", "コース名", "使用大会", "説明", "作成日時")
   } else if (type === "competition") {
-    itemNames.push("ID", "名前", "開催状況")
+    itemNames.push("ID", "名前", "説明", "開催日", "終了日")
   }
   return itemNames
 }

--- a/@robopo/web/app/components/home/tabs.tsx
+++ b/@robopo/web/app/components/home/tabs.tsx
@@ -11,6 +11,10 @@ import Link from "next/link"
 import type React from "react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
+import {
+  getCompetitionStatus,
+  isCompetitionActive,
+} from "@/app/lib/competition"
 import { COMPETITION_MANAGEMENT_LIST } from "@/app/lib/const"
 import type {
   SelectCompetition,
@@ -78,7 +82,7 @@ export function ChallengeTab({
   competitionJudgeList,
 }: ChallengeTabProps): React.JSX.Element {
   const activeCompetitions = useMemo(
-    () => competitionList.competitions.filter((c) => c.step === 1),
+    () => competitionList.competitions.filter(isCompetitionActive),
     [competitionList.competitions],
   )
   const singleCompetition =
@@ -260,7 +264,10 @@ export function SummaryTab({
             <option
               key={competition.id}
               value={competition.id}
-              hidden={competition.step === 0}
+              hidden={
+                getCompetitionStatus(competition) === "before" ||
+                getCompetitionStatus(competition) === "unknown"
+              }
             >
               {competition.name}
             </option>

--- a/@robopo/web/app/config/page.tsx
+++ b/@robopo/web/app/config/page.tsx
@@ -1,12 +1,26 @@
 import { getCompetitionList } from "@/app/components/server/db"
-import { View } from "@/app/config/view"
-import type { SelectCompetition } from "@/app/lib/db/schema"
+import { CompetitionView } from "@/app/config/view"
 
 export const revalidate = 0
 
 export default async function Config() {
-  const initialCompetitionList: { competitions: SelectCompetition[] } =
-    await getCompetitionList()
+  const { competitions } = await getCompetitionList()
 
-  return <View initialCompetitionList={initialCompetitionList} />
+  return (
+    <div className="container mx-auto max-w-6xl px-4 py-6">
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="font-bold text-2xl text-base-content tracking-tight">
+            大会一覧
+          </h1>
+          <p className="mt-1 text-base-content/60 text-sm">
+            大会の作成・編集・削除を行います
+          </p>
+        </div>
+      </div>
+      <div className="rounded-2xl border border-base-300 bg-base-100 shadow-sm">
+        <CompetitionView initialCompetitionList={competitions} />
+      </div>
+    </div>
+  )
 }

--- a/@robopo/web/app/config/tabs.tsx
+++ b/@robopo/web/app/config/tabs.tsx
@@ -1,203 +1,314 @@
 "use client"
 
+import {
+  CheckIcon,
+  PlusIcon,
+  TrashIcon,
+  XMarkIcon,
+} from "@heroicons/react/24/outline"
 import { useState } from "react"
-import { CommonRadioList } from "@/app/components/common/commonList"
-import { CommonRegister } from "@/app/components/common/commonRegister"
-import { BackLabelWithIcon } from "@/app/lib/const"
-import type {
-  SelectCompetition,
-  SelectJudge,
-  SelectPlayer,
-} from "@/app/lib/db/schema"
+import type { SelectCompetition } from "@/app/lib/db/schema"
 
-type CompetitionListTabProps = {
-  competitionId: number | null
-  setCompetitionId: React.Dispatch<React.SetStateAction<number | null>>
-  competitionList: SelectCompetition[]
-  setCompetitionList: React.Dispatch<React.SetStateAction<SelectCompetition[]>>
+function formatDateForInput(date: Date | null | undefined): string {
+  if (!date) {
+    return ""
+  }
+  const d = new Date(date)
+  const year = d.getFullYear()
+  const month = String(d.getMonth() + 1).padStart(2, "0")
+  const day = String(d.getDate()).padStart(2, "0")
+  return `${year}-${month}-${day}`
 }
 
-type NewCompetitionTabProps = {
-  setCompetitionList: React.Dispatch<React.SetStateAction<SelectCompetition[]>>
+type CompetitionFormModalProps = {
+  mode: "create" | "edit"
+  competition?: SelectCompetition | null
+  onClose: () => void
+  onSuccess: (newList: SelectCompetition[]) => void
 }
 
-export function CompetitionListTab({
-  competitionId,
-  setCompetitionId,
-  competitionList,
-  setCompetitionList,
-}: CompetitionListTabProps): React.JSX.Element {
+export function CompetitionFormModal({
+  mode,
+  competition,
+  onClose,
+  onSuccess,
+}: CompetitionFormModalProps) {
+  const [name, setName] = useState(competition?.name ?? "")
+  const [description, setDescription] = useState(competition?.description ?? "")
+  const [startDate, setStartDate] = useState(
+    formatDateForInput(competition?.startDate),
+  )
+  const [endDate, setEndDate] = useState(
+    formatDateForInput(competition?.endDate),
+  )
   const [loading, setLoading] = useState(false)
-  const [isSuccess, setIsSuccess] = useState(false)
-  const [message, setMessage] = useState("")
-  const [modalOpen, setModalOpen] = useState<boolean>(false)
+  const [error, setError] = useState<string | null>(null)
 
-  async function handleButtonClick(event: React.MouseEvent<HTMLButtonElement>) {
-    const type = event.currentTarget.value
-    const requestBody =
-      type === "delete"
-        ? {
-            type: type,
-            id: competitionId,
-          }
-        : {
-            type: type,
-          }
+  function validate(): string | null {
+    if (!name.trim()) {
+      return "名前は必須です。"
+    }
+    if (startDate && endDate && startDate > endDate) {
+      return "開催日は終了日より前でなければなりません。"
+    }
+    return null
+  }
 
-    const url =
-      type === "delete"
-        ? "/api/competition/"
-        : `/api/competition/${competitionId}`
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    const validationError = validate()
+    if (validationError) {
+      setError(validationError)
+      return
+    }
+
+    setLoading(true)
+    setError(null)
+
     try {
-      setLoading(true)
-      const response = await fetch(url, {
-        method: type === "delete" ? "DELETE" : "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(requestBody),
-      })
-      const { success, newList } = await response.json()
-
-      if (response.ok && success) {
-        setMessage("更新に成功しました")
-        setIsSuccess(true)
-        setCompetitionList(newList.competitions)
-        setCompetitionId(null)
-        setModalOpen(false)
-      } else {
-        setMessage("更新に失敗しました")
+      const body: Record<string, unknown> = {
+        name: name.trim(),
+        description: description.trim() || null,
+        startDate: startDate || null,
+        endDate: endDate || null,
       }
-    } catch (_error) {
-      setMessage("送信中にエラーが発生しました")
+
+      const url =
+        mode === "create"
+          ? "/api/competition"
+          : `/api/competition/${competition?.id}`
+      const method = mode === "create" ? "POST" : "PATCH"
+
+      const response = await fetch(url, {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      })
+
+      const result = await response.json()
+
+      if (response.ok && result.success) {
+        onSuccess(result.newList.competitions)
+      } else {
+        setError(result.message || "エラーが発生しました。")
+      }
+    } catch {
+      setError("送信中にエラーが発生しました。")
     } finally {
       setLoading(false)
     }
   }
 
   return (
-    <>
-      <CommonRadioList
-        props={{ type: "competition", commonDataList: competitionList }}
-        commonId={competitionId}
-        setCommonId={setCompetitionId}
-      />
-      <button
-        type="button"
-        className="btn btn-primary m-1 max-w-fit text-default"
-        value="open"
-        disabled={
-          competitionId === null ||
-          loading ||
-          competitionList?.find((c) => c.id === competitionId)?.step === 1
-        }
-        onClick={(e) => handleButtonClick(e)}
-      >
-        開催
-      </button>
-      <button
-        type="button"
-        className="btn btn-primary m-1 max-w-fit text-default"
-        value="return"
-        disabled={
-          competitionId === null ||
-          loading ||
-          competitionList?.find((c) => c.id === competitionId)?.step !== 1
-        }
-        onClick={(e) => handleButtonClick(e)}
-      >
-        開催前に戻す
-      </button>
-      <button
-        type="button"
-        className="btn btn-primary m-1 max-w-fit text-default"
-        value="close"
-        disabled={
-          competitionId === null ||
-          loading ||
-          competitionList?.find((c) => c.id === competitionId)?.step !== 1
-        }
-        onClick={(e) => handleButtonClick(e)}
-      >
-        終了
-      </button>
-      <button
-        type="button"
-        className="btn btn-warning m-1 max-w-fit text-default"
-        disabled={competitionId === null || loading}
-        onClick={() => {
-          setIsSuccess(false)
-          setModalOpen(true)
-        }}
-      >
-        削除
-      </button>
-      {isSuccess && <p>{message}</p>}
-      <p>{loading && <span className="loading loading-spinner"></span>}</p>
-      {modalOpen && (
-        <dialog
-          className="modal modal-open"
-          onClose={() => setModalOpen(false)}
-        >
-          <div className="modal-box">
-            {isSuccess ? <p>{message}</p> : <p>選択した大会を削除しますか?</p>}
-
-            {!isSuccess && (
-              <button
-                type="button"
-                className="btn btn-accent m-3"
-                value="delete"
-                onClick={(e) => handleButtonClick(e)}
-                disabled={loading}
-              >
-                はい
-              </button>
-            )}
+    <dialog className="modal modal-open">
+      <div className="modal-box max-w-md">
+        <h3 className="mb-4 font-bold text-lg">
+          {mode === "create" ? "大会を作成" : "大会を編集"}
+        </h3>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <div>
+            <label className="label" htmlFor="comp-name">
+              <span className="label-text">
+                名前 <span className="text-error">*</span>
+              </span>
+            </label>
+            <input
+              id="comp-name"
+              type="text"
+              className="input input-bordered w-full"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="大会名"
+              required
+            />
+          </div>
+          <div>
+            <label className="label" htmlFor="comp-desc">
+              <span className="label-text">説明</span>
+            </label>
+            <textarea
+              id="comp-desc"
+              className="textarea textarea-bordered w-full"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="大会の説明（任意）"
+              rows={3}
+            />
+          </div>
+          <div className="flex gap-4">
+            <div className="flex-1">
+              <label className="label" htmlFor="comp-start">
+                <span className="label-text">開催日</span>
+              </label>
+              <input
+                id="comp-start"
+                type="date"
+                className="input input-bordered w-full"
+                value={startDate}
+                onChange={(e) => setStartDate(e.target.value)}
+              />
+            </div>
+            <div className="flex-1">
+              <label className="label" htmlFor="comp-end">
+                <span className="label-text">終了日</span>
+              </label>
+              <input
+                id="comp-end"
+                type="date"
+                className="input input-bordered w-full"
+                value={endDate}
+                onChange={(e) => setEndDate(e.target.value)}
+              />
+            </div>
+          </div>
+          {startDate && endDate && startDate > endDate && (
+            <p className="text-error text-sm">
+              開催日は終了日より前でなければなりません。
+            </p>
+          )}
+          {error && <p className="text-error text-sm">{error}</p>}
+          <div className="modal-action">
             <button
               type="button"
-              className="btn btn-accent m-3"
-              onClick={() => setModalOpen(false)}
+              className="btn gap-1.5 rounded-lg"
+              onClick={onClose}
               disabled={loading}
             >
-              <BackLabelWithIcon />
+              <XMarkIcon className="size-4" />
+              キャンセル
+            </button>
+            <button
+              type="submit"
+              className="btn btn-primary gap-1.5 rounded-lg shadow-lg shadow-primary/20 transition-all duration-200 hover:shadow-primary/30 hover:shadow-xl"
+              disabled={loading}
+            >
+              {loading ? (
+                <span className="loading loading-spinner loading-sm" />
+              ) : mode === "create" ? (
+                <PlusIcon className="size-4" />
+              ) : (
+                <CheckIcon className="size-4" />
+              )}
+              {mode === "create" ? "作成" : "保存"}
             </button>
           </div>
-          <form
-            method="dialog"
-            className="modal-backdrop"
-            onClick={() => setModalOpen(false)}
-            onKeyDown={(e) => e.key === "Escape" && setModalOpen(false)}
-          >
-            <button type="button" className="cursor-default">
-              close
-            </button>
-          </form>
-        </dialog>
-      )}
-    </>
+        </form>
+      </div>
+      <form
+        method="dialog"
+        className="modal-backdrop"
+        onClick={onClose}
+        onKeyDown={(e) => e.key === "Escape" && onClose()}
+      >
+        <button type="button" className="cursor-default">
+          close
+        </button>
+      </form>
+    </dialog>
   )
 }
 
-export function NewCompetitionTab({
-  setCompetitionList,
-}: NewCompetitionTabProps) {
-  const [successMessage, setSuccessMessage] = useState<string | null>(null)
-  const [errorMessage, setErrorMessage] = useState<string | null>(null)
-  return (
-    <>
-      <p>新しい大会を追加します</p>
-      <CommonRegister
-        type="competition"
-        setSuccessMessage={setSuccessMessage}
-        setErrorMessage={setErrorMessage}
-        setCommonDataList={
-          setCompetitionList as React.Dispatch<
-            React.SetStateAction<
-              SelectPlayer[] | SelectJudge[] | SelectCompetition[]
-            >
-          >
+type DeleteCompetitionModalProps = {
+  selectedIds: number[]
+  competitions: SelectCompetition[]
+  onClose: () => void
+  onSuccess: (newList: SelectCompetition[]) => void
+}
+
+export function DeleteCompetitionModal({
+  selectedIds,
+  competitions,
+  onClose,
+  onSuccess,
+}: DeleteCompetitionModalProps) {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const selectedNames = competitions
+    .filter((c) => selectedIds.includes(c.id))
+    .map((c) => c.name)
+
+  async function handleDelete() {
+    setLoading(true)
+    setError(null)
+
+    try {
+      for (const id of selectedIds) {
+        const response = await fetch("/api/competition/", {
+          method: "DELETE",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ type: "delete", id }),
+        })
+        const result = await response.json()
+
+        if (!response.ok || !result.success) {
+          setError(`ID ${id} の削除に失敗しました。`)
+          setLoading(false)
+          return
         }
-      />
-      {successMessage && <p>{successMessage}</p>}
-      {errorMessage && <p>{errorMessage}</p>}
-    </>
+
+        if (id === selectedIds[selectedIds.length - 1]) {
+          onSuccess(result.newList.competitions)
+        }
+      }
+    } catch {
+      setError("送信中にエラーが発生しました。")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <dialog className="modal modal-open">
+      <div className="modal-box">
+        <h3 className="mb-4 font-bold text-lg">大会を削除</h3>
+        <p className="mb-2">以下の大会を削除しますか？</p>
+        <ul className="mb-4 list-inside list-disc text-sm">
+          {selectedNames.map((name) => (
+            <li key={name} className="font-medium">
+              {name}
+            </li>
+          ))}
+        </ul>
+        <p className="text-sm text-warning">
+          この操作は取り消せません。関連するデータも全て削除されます。
+        </p>
+        {error && <p className="mt-2 text-error text-sm">{error}</p>}
+        <div className="modal-action">
+          <button
+            type="button"
+            className="btn gap-1.5 rounded-lg"
+            onClick={onClose}
+            disabled={loading}
+          >
+            <XMarkIcon className="size-4" />
+            キャンセル
+          </button>
+          <button
+            type="button"
+            className="btn btn-error gap-1.5 rounded-lg shadow-error/20 shadow-lg transition-all duration-200 hover:shadow-error/30 hover:shadow-xl"
+            onClick={handleDelete}
+            disabled={loading}
+          >
+            {loading ? (
+              <span className="loading loading-spinner loading-sm" />
+            ) : (
+              <TrashIcon className="size-4" />
+            )}
+            削除する
+          </button>
+        </div>
+      </div>
+      <form
+        method="dialog"
+        className="modal-backdrop"
+        onClick={onClose}
+        onKeyDown={(e) => e.key === "Escape" && onClose()}
+      >
+        <button type="button" className="cursor-default">
+          close
+        </button>
+      </form>
+    </dialog>
   )
 }

--- a/@robopo/web/app/config/view.tsx
+++ b/@robopo/web/app/config/view.tsx
@@ -1,35 +1,273 @@
 "use client"
 
-import { useState } from "react"
-import { ThreeTabs } from "@/app/components/parts/threeTabs"
-import { CompetitionListTab, NewCompetitionTab } from "@/app/config/tabs"
+import {
+  BarsArrowDownIcon,
+  BarsArrowUpIcon,
+  FunnelIcon,
+  MagnifyingGlassIcon,
+  PencilSquareIcon,
+  PlusIcon,
+  TrashIcon,
+} from "@heroicons/react/24/outline"
+import { useMemo, useState } from "react"
+import { CommonCheckboxList } from "@/app/components/common/commonList"
+import { CompetitionFormModal, DeleteCompetitionModal } from "@/app/config/tabs"
+import {
+  type CompetitionStatus,
+  getCompetitionStatus,
+} from "@/app/lib/competition"
 import type { SelectCompetition } from "@/app/lib/db/schema"
 
-type ViewProps = {
-  initialCompetitionList: { competitions: SelectCompetition[] }
-}
+type SortKey = "name" | "id" | "startDate" | "endDate"
+type StatusFilter = "" | CompetitionStatus
 
-export function View({ initialCompetitionList }: ViewProps) {
-  const [competitionId, setCompetitionId] = useState<number | null>(null)
-  const [competitionList, setCompetitionList] = useState<SelectCompetition[]>(
-    initialCompetitionList.competitions,
-  )
+export function CompetitionView({
+  initialCompetitionList,
+}: {
+  initialCompetitionList: SelectCompetition[]
+}) {
+  const [competitionList, setCompetitionList] = useState(initialCompetitionList)
+  const [selectedIds, setSelectedIds] = useState<number[]>([])
+  const [searchQuery, setSearchQuery] = useState("")
+  const [sortKey, setSortKey] = useState<SortKey>("id")
+  const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc")
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("")
+  const [successMessage, setSuccessMessage] = useState<string | null>(null)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const [createModalOpen, setCreateModalOpen] = useState(false)
+  const [editModalOpen, setEditModalOpen] = useState(false)
+  const [deleteModalOpen, setDeleteModalOpen] = useState(false)
+
+  const selectedCompetition =
+    selectedIds.length === 1
+      ? (competitionList.find((c) => c.id === selectedIds[0]) ?? null)
+      : null
+
+  const filteredAndSortedList = useMemo(() => {
+    let list = competitionList
+
+    if (searchQuery.trim()) {
+      const q = searchQuery.trim().toLowerCase()
+      list = list.filter(
+        (c) =>
+          c.name.toLowerCase().includes(q) ||
+          (c.description?.toLowerCase().includes(q) ?? false),
+      )
+    }
+
+    if (statusFilter) {
+      list = list.filter((c) => getCompetitionStatus(c) === statusFilter)
+    }
+
+    return [...list].sort((a, b) => {
+      let cmp = 0
+      if (sortKey === "name") {
+        cmp = a.name.localeCompare(b.name, "ja")
+      } else if (sortKey === "startDate") {
+        cmp = (a.startDate?.getTime() ?? 0) - (b.startDate?.getTime() ?? 0)
+      } else if (sortKey === "endDate") {
+        cmp = (a.endDate?.getTime() ?? 0) - (b.endDate?.getTime() ?? 0)
+      } else {
+        cmp = a.id - b.id
+      }
+      return sortOrder === "asc" ? cmp : -cmp
+    })
+  }, [competitionList, searchQuery, statusFilter, sortKey, sortOrder])
+
+  function handleSuccess(newList: SelectCompetition[], message: string) {
+    // API JSON responses return dates as strings; convert them back to Date objects
+    const parsed = newList.map((c) => ({
+      ...c,
+      createdAt: c.createdAt ? new Date(c.createdAt) : null,
+      startDate: c.startDate ? new Date(c.startDate) : null,
+      endDate: c.endDate ? new Date(c.endDate) : null,
+    }))
+    setCompetitionList(parsed)
+    setSuccessMessage(message)
+    setErrorMessage(null)
+    setSelectedIds([])
+  }
 
   return (
-    <ThreeTabs
-      tab1Title="大会一覧"
-      tab1={
-        <CompetitionListTab
-          competitionId={competitionId}
-          setCompetitionId={setCompetitionId}
-          competitionList={competitionList}
-          setCompetitionList={setCompetitionList}
+    <>
+      {/* Action bar */}
+      <div className="px-4 pt-4 pb-2">
+        {successMessage && (
+          <div className="mb-3 rounded-lg bg-success/10 px-4 py-2 font-medium text-sm text-success">
+            {successMessage}
+          </div>
+        )}
+        {errorMessage && (
+          <div className="mb-3 rounded-lg bg-error/10 px-4 py-2 font-medium text-error text-sm">
+            {errorMessage}
+          </div>
+        )}
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            className="btn btn-sm btn-primary gap-1.5 rounded-lg shadow-lg shadow-primary/20 transition-all duration-200 hover:shadow-primary/30 hover:shadow-xl"
+            onClick={() => {
+              setSuccessMessage(null)
+              setCreateModalOpen(true)
+            }}
+          >
+            <PlusIcon className="size-4" />
+            新規作成
+          </button>
+          <button
+            type="button"
+            className={`btn btn-sm gap-1.5 rounded-lg ${
+              selectedIds.length !== 1
+                ? "btn-disabled"
+                : "btn-primary btn-outline"
+            }`}
+            disabled={selectedIds.length !== 1}
+            onClick={() => {
+              setSuccessMessage(null)
+              setEditModalOpen(true)
+            }}
+          >
+            <PencilSquareIcon className="size-4" />
+            編集
+          </button>
+          <button
+            type="button"
+            className={`btn btn-sm gap-1.5 rounded-lg ${
+              selectedIds.length === 0
+                ? "btn-disabled"
+                : "btn-error btn-outline"
+            }`}
+            disabled={selectedIds.length === 0}
+            onClick={() => {
+              setSuccessMessage(null)
+              setDeleteModalOpen(true)
+            }}
+          >
+            <TrashIcon className="size-4" />
+            削除
+          </button>
+        </div>
+      </div>
+
+      {/* Filter bar */}
+      <div className="flex flex-col gap-3 px-4 pb-4">
+        <label className="input input-bordered flex items-center gap-2 rounded-xl bg-base-200/40 transition-colors focus-within:bg-base-100">
+          <MagnifyingGlassIcon className="size-4 shrink-0 text-base-content/40" />
+          <input
+            type="text"
+            placeholder="名前・説明で検索"
+            className="grow"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+          />
+        </label>
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="flex shrink-0 items-center gap-1.5 rounded-lg bg-base-200/50 px-2.5 py-1.5">
+            <FunnelIcon className="size-3.5 shrink-0 text-base-content/40" />
+            <span className="shrink-0 text-xs">状態</span>
+            <select
+              className="select select-ghost select-xs bg-transparent pe-0 font-medium focus:outline-none [&>option]:bg-base-100 [&>option]:text-base-content"
+              style={{ backgroundImage: "none" }}
+              value={statusFilter}
+              onChange={(e) => setStatusFilter(e.target.value as StatusFilter)}
+            >
+              <option value="">すべて</option>
+              <option value="before">開催前</option>
+              <option value="active">開催中</option>
+              <option value="ended">終了済</option>
+              <option value="unknown">未設定</option>
+            </select>
+          </div>
+          <div className="flex items-center gap-1.5 rounded-lg bg-base-200/50 px-2.5 py-1.5">
+            <select
+              className="select select-ghost select-xs bg-transparent font-medium focus:outline-none [&>option]:bg-base-100 [&>option]:text-base-content"
+              value={sortKey}
+              onChange={(e) => setSortKey(e.target.value as SortKey)}
+            >
+              <option value="id">ID</option>
+              <option value="name">名前</option>
+              <option value="startDate">開催日</option>
+              <option value="endDate">終了日</option>
+            </select>
+            <button
+              type="button"
+              className="flex shrink-0 items-center gap-1 rounded-md bg-base-100 px-2 py-1 text-xs shadow-sm transition-colors hover:bg-base-300/40"
+              onClick={() =>
+                setSortOrder((prev) => (prev === "asc" ? "desc" : "asc"))
+              }
+            >
+              {sortOrder === "desc" ? (
+                <BarsArrowDownIcon className="size-3.5" />
+              ) : (
+                <BarsArrowUpIcon className="size-3.5" />
+              )}
+              {sortKey === "name"
+                ? sortOrder === "desc"
+                  ? "Z→A"
+                  : "A→Z"
+                : sortKey === "startDate" || sortKey === "endDate"
+                  ? sortOrder === "desc"
+                    ? "新しい順"
+                    : "古い順"
+                  : sortOrder === "desc"
+                    ? "大きい順"
+                    : "小さい順"}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Table */}
+      {(searchQuery || statusFilter) && filteredAndSortedList.length === 0 ? (
+        <div className="py-8 text-center text-base-content/40">
+          条件に一致する大会が見つかりません
+        </div>
+      ) : (
+        <CommonCheckboxList
+          props={{ type: "competition", commonDataList: filteredAndSortedList }}
+          commonId={selectedIds}
+          setCommonId={setSelectedIds}
         />
-      }
-      tab2Title="大会登録"
-      tab2={<NewCompetitionTab setCompetitionList={setCompetitionList} />}
-      tab3Title=""
-      tab3={null}
-    />
+      )}
+
+      {/* Create Modal */}
+      {createModalOpen && (
+        <CompetitionFormModal
+          mode="create"
+          onClose={() => setCreateModalOpen(false)}
+          onSuccess={(newList) => {
+            handleSuccess(newList, "大会を作成しました")
+            setCreateModalOpen(false)
+          }}
+        />
+      )}
+
+      {/* Edit Modal */}
+      {editModalOpen && selectedCompetition && (
+        <CompetitionFormModal
+          mode="edit"
+          competition={selectedCompetition}
+          onClose={() => setEditModalOpen(false)}
+          onSuccess={(newList) => {
+            handleSuccess(newList, "大会を更新しました")
+            setEditModalOpen(false)
+          }}
+        />
+      )}
+
+      {/* Delete Modal */}
+      {deleteModalOpen && (
+        <DeleteCompetitionModal
+          selectedIds={selectedIds}
+          competitions={competitionList}
+          onClose={() => setDeleteModalOpen(false)}
+          onSuccess={(newList) => {
+            handleSuccess(newList, "大会を削除しました")
+            setDeleteModalOpen(false)
+          }}
+        />
+      )}
+    </>
   )
 }

--- a/@robopo/web/app/lib/competition.ts
+++ b/@robopo/web/app/lib/competition.ts
@@ -1,0 +1,36 @@
+import type { SelectCompetition } from "@/app/lib/db/schema"
+
+export type CompetitionStatus = "before" | "active" | "ended" | "unknown"
+
+/**
+ * Determine the current status of a competition based on its date range.
+ * - "before": today is before the start date
+ * - "active": today is within [startDate, endDate]
+ * - "ended": today is after the end date
+ * - "unknown": start or end date is not set
+ */
+export function getCompetitionStatus(c: SelectCompetition): CompetitionStatus {
+  if (!c.startDate || !c.endDate) {
+    return "unknown"
+  }
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  const start = new Date(c.startDate)
+  start.setHours(0, 0, 0, 0)
+  const end = new Date(c.endDate)
+  end.setHours(0, 0, 0, 0)
+  if (today < start) {
+    return "before"
+  }
+  if (today > end) {
+    return "ended"
+  }
+  return "active"
+}
+
+/**
+ * Check if a competition is currently active (today falls within its date range).
+ */
+export function isCompetitionActive(c: SelectCompetition): boolean {
+  return getCompetitionStatus(c) === "active"
+}

--- a/@robopo/web/app/lib/db/queries/queries.ts
+++ b/@robopo/web/app/lib/db/queries/queries.ts
@@ -372,47 +372,6 @@ export async function getChallengeCount(
   return result as { challengeCount: number }[]
 }
 
-// Set competition to open status by ID
-export async function openCompetitionById(id: number) {
-  return await db
-    .update(competition)
-    .set({ step: 1 })
-    .where(eq(competition.id, id))
-}
-
-// Set competition to pre-open status by ID
-export async function returnCompetitionById(id: number) {
-  // 1) Check the current step to enforce valid state transition
-  const existing = await db
-    .select({ step: competition.step })
-    .from(competition)
-    .where(eq(competition.id, id))
-    .limit(1)
-
-  if (!existing) {
-    throw new Error(`Competition with id ${id} not found`)
-  }
-  if (existing[0]?.step !== 1) {
-    throw new Error(
-      `Invalid state transition: cannot return competition from step ${existing[0]?.step} to before state`,
-    )
-  }
-
-  // 2) Perform the permitted update
-  return await db
-    .update(competition)
-    .set({ step: 0 })
-    .where(eq(competition.id, id))
-}
-
-// Set competition to closed status by ID
-export async function closeCompetitionById(id: number) {
-  return await db
-    .update(competition)
-    .set({ step: 2 })
-    .where(eq(competition.id, id))
-}
-
 // Get players with their competitions
 export async function getPlayersWithCompetition() {
   return await db

--- a/@robopo/web/app/lib/db/queries/update.ts
+++ b/@robopo/web/app/lib/db/queries/update.ts
@@ -1,10 +1,17 @@
 import { eq } from "drizzle-orm"
 import { db } from "@/app/lib/db/db"
-import { course } from "@/app/lib/db/schema"
+import { competition, course } from "@/app/lib/db/schema"
 
 export async function updateCourse(
   id: number,
   data: Partial<typeof course.$inferInsert>,
 ) {
   return await db.update(course).set(data).where(eq(course.id, id))
+}
+
+export async function updateCompetition(
+  id: number,
+  data: Partial<typeof competition.$inferInsert>,
+) {
+  return await db.update(competition).set(data).where(eq(competition.id, id))
 }

--- a/@robopo/web/app/lib/db/schema.ts
+++ b/@robopo/web/app/lib/db/schema.ts
@@ -7,11 +7,12 @@ import {
   timestamp,
 } from "drizzle-orm/pg-core"
 
-// step 0:prepare, 1:open, 2:close
 export const competition = pgTable("competition", {
   id: serial("id").primaryKey(),
   name: text("name").notNull(),
-  step: integer("step").default(0).notNull(),
+  description: text("description"),
+  startDate: timestamp("start_date"),
+  endDate: timestamp("end_date"),
   createdAt: timestamp("created_at").defaultNow(),
 })
 

--- a/@robopo/web/app/lib/db/seed.ts
+++ b/@robopo/web/app/lib/db/seed.ts
@@ -68,10 +68,10 @@ async function seed() {
     `)
     const testCourseId = courseResult.rows[0].id
 
-    // Test competition (in progress: step=1)
+    // Test competition (active: start_date in past, end_date in future)
     const compResult = await db.execute<{ id: number }>(sql`
-      INSERT INTO competition (name, step)
-      VALUES ('テスト大会', 1)
+      INSERT INTO competition (name, start_date, end_date)
+      VALUES ('テスト大会', NOW() - INTERVAL '7 days', NOW() + INTERVAL '30 days')
       RETURNING id
     `)
     const competitionId = compResult.rows[0].id
@@ -110,7 +110,7 @@ async function seed() {
       `)
     }
 
-    // --- Second competition (also in progress: step=1) ---
+    // --- Second competition (also active) ---
     const course2Result = await db.execute<{ id: number }>(sql`
       INSERT INTO course (name, field, fieldvalid, mission, missionvalid, point)
       VALUES ('TestCourse2',
@@ -124,8 +124,8 @@ async function seed() {
     const testCourse2Id = course2Result.rows[0].id
 
     const comp2Result = await db.execute<{ id: number }>(sql`
-      INSERT INTO competition (name, step)
-      VALUES ('ロボサバ2026', 1)
+      INSERT INTO competition (name, start_date, end_date)
+      VALUES ('ロボサバ2026', NOW() - INTERVAL '7 days', NOW() + INTERVAL '30 days')
       RETURNING id
     `)
     const competition2Id = comp2Result.rows[0].id

--- a/@robopo/web/test/unit/components/common/commonList.test.tsx
+++ b/@robopo/web/test/unit/components/common/commonList.test.tsx
@@ -28,8 +28,22 @@ const players = [
 ]
 
 const competitions = [
-  { id: 1, name: "大会A", step: 0, createdAt: new Date() },
-  { id: 2, name: "大会B", step: 1, createdAt: new Date() },
+  {
+    id: 1,
+    name: "大会A",
+    description: null,
+    startDate: null,
+    endDate: null,
+    createdAt: new Date(),
+  },
+  {
+    id: 2,
+    name: "大会B",
+    description: null,
+    startDate: null,
+    endDate: null,
+    createdAt: new Date(),
+  },
 ]
 
 describe("CommonSelectionList", () => {
@@ -199,5 +213,78 @@ describe("CommonCheckboxList", () => {
     // The callback should have added id 2
     const lastCall = setCommonId.mock.calls[setCommonId.mock.calls.length - 1]
     expect(lastCall[0]).toEqual([1, 2])
+  })
+})
+
+describe("Competition table columns", () => {
+  test("renders correct header labels for competition type", () => {
+    const onSelect = mock()
+    const { container } = render(
+      <CommonSelectionList
+        props={{ type: "competition", commonDataList: competitions }}
+        selectionMode="checkbox"
+        selectedId={[]}
+        onSelect={onSelect}
+      />,
+    )
+    const headers = container.querySelectorAll("thead th")
+    const headerTexts = Array.from(headers).map((h) => h.textContent?.trim())
+    expect(headerTexts).toContain("ID")
+    expect(headerTexts).toContain("名前")
+    expect(headerTexts).toContain("説明")
+    expect(headerTexts).toContain("開催日")
+    expect(headerTexts).toContain("終了日")
+  })
+
+  test("renders dash for null description, startDate, and endDate", () => {
+    const onSelect = mock()
+    const { container } = render(
+      <CommonSelectionList
+        props={{ type: "competition", commonDataList: competitions }}
+        selectionMode="radio"
+        selectedId={null}
+        onSelect={onSelect}
+      />,
+    )
+    const cells = container.querySelectorAll("tbody tr:first-child td")
+    const cellTexts = Array.from(cells).map((c) => c.textContent?.trim())
+    // description, startDate, endDate should all be "-"
+    expect(cellTexts.filter((t) => t === "-")).toHaveLength(3)
+  })
+
+  test("renders formatted dates for non-null startDate and endDate", () => {
+    const onSelect = mock()
+    const competitionsWithDates = [
+      {
+        id: 1,
+        name: "日付あり大会",
+        description: "テスト説明",
+        startDate: new Date("2026-04-01T00:00:00"),
+        endDate: new Date("2026-04-30T00:00:00"),
+        createdAt: new Date(),
+      },
+    ]
+    const { container } = render(
+      <CommonSelectionList
+        props={{
+          type: "competition",
+          commonDataList: competitionsWithDates,
+        }}
+        selectionMode="radio"
+        selectedId={null}
+        onSelect={onSelect}
+      />,
+    )
+    const cells = container.querySelectorAll("tbody tr:first-child td")
+    const cellTexts = Array.from(cells).map((c) => c.textContent?.trim())
+    // description should render
+    expect(cellTexts).toContain("テスト説明")
+    // dates should not be "-"
+    const dashCount = cellTexts.filter((t) => t === "-").length
+    expect(dashCount).toBe(0)
+    // dates should not contain ISO format "T" separator
+    for (const text of cellTexts) {
+      expect(text).not.toContain("T00:00:00")
+    }
   })
 })

--- a/@robopo/web/test/unit/components/home/dashboard.test.tsx
+++ b/@robopo/web/test/unit/components/home/dashboard.test.tsx
@@ -7,7 +7,14 @@ afterEach(cleanup)
 const defaultProps = {
   competitionList: {
     competitions: [
-      { id: 1, name: "Test Competition", step: 1, createdAt: null },
+      {
+        id: 1,
+        name: "Test Competition",
+        description: null,
+        startDate: null,
+        endDate: null,
+        createdAt: null,
+      },
     ],
   },
   courseList: {

--- a/@robopo/web/test/unit/components/home/tabs.test.tsx
+++ b/@robopo/web/test/unit/components/home/tabs.test.tsx
@@ -6,9 +6,33 @@ afterEach(cleanup)
 
 const competitionList = {
   competitions: [
-    { id: 1, name: "Active Comp", step: 1, createdAt: null },
-    { id: 2, name: "Closed Comp", step: 2, createdAt: null },
-    { id: 3, name: "Prep Comp", step: 0, createdAt: null },
+    {
+      id: 1,
+      name: "Active Comp",
+
+      description: null,
+      startDate: new Date("2025-01-01T00:00:00.000Z"),
+      endDate: new Date("2027-12-31T00:00:00.000Z"),
+      createdAt: null,
+    },
+    {
+      id: 2,
+      name: "Closed Comp",
+
+      description: null,
+      startDate: new Date("2024-01-01T00:00:00.000Z"),
+      endDate: new Date("2024-12-31T00:00:00.000Z"),
+      createdAt: null,
+    },
+    {
+      id: 3,
+      name: "Prep Comp",
+
+      description: null,
+      startDate: new Date("2027-06-01T00:00:00.000Z"),
+      endDate: new Date("2027-12-31T00:00:00.000Z"),
+      createdAt: null,
+    },
   ],
 }
 
@@ -63,7 +87,17 @@ const competitionJudgeList = {
 describe("ChallengeTab", () => {
   test("shows competition name when single active competition", () => {
     const singleCompe = {
-      competitions: [{ id: 1, name: "Only Comp", step: 1, createdAt: null }],
+      competitions: [
+        {
+          id: 1,
+          name: "Only Comp",
+
+          description: null,
+          startDate: new Date("2025-01-01T00:00:00.000Z"),
+          endDate: new Date("2027-12-31T00:00:00.000Z"),
+          createdAt: null,
+        },
+      ],
     }
     render(
       <ChallengeTab
@@ -93,7 +127,17 @@ describe("ChallengeTab", () => {
 
   test("shows warning when course card clicked without judge selected", () => {
     const singleCompe = {
-      competitions: [{ id: 1, name: "Comp", step: 1, createdAt: null }],
+      competitions: [
+        {
+          id: 1,
+          name: "Comp",
+
+          description: null,
+          startDate: new Date("2025-01-01T00:00:00.000Z"),
+          endDate: new Date("2027-12-31T00:00:00.000Z"),
+          createdAt: null,
+        },
+      ],
     }
     const { container } = render(
       <ChallengeTab
@@ -116,7 +160,17 @@ describe("ChallengeTab", () => {
 
   test("renders course cards when competition is selected", () => {
     const singleCompe = {
-      competitions: [{ id: 1, name: "Comp", step: 1, createdAt: null }],
+      competitions: [
+        {
+          id: 1,
+          name: "Comp",
+
+          description: null,
+          startDate: new Date("2025-01-01T00:00:00.000Z"),
+          endDate: new Date("2027-12-31T00:00:00.000Z"),
+          createdAt: null,
+        },
+      ],
     }
     render(
       <ChallengeTab
@@ -134,8 +188,24 @@ describe("ChallengeTab", () => {
   test("shows placeholder when no competition selected", () => {
     const multiActive = {
       competitions: [
-        { id: 1, name: "Comp A", step: 1, createdAt: null },
-        { id: 2, name: "Comp B", step: 1, createdAt: null },
+        {
+          id: 1,
+          name: "Comp A",
+
+          description: null,
+          startDate: new Date("2025-01-01T00:00:00.000Z"),
+          endDate: new Date("2027-12-31T00:00:00.000Z"),
+          createdAt: null,
+        },
+        {
+          id: 2,
+          name: "Comp B",
+
+          description: null,
+          startDate: new Date("2025-01-01T00:00:00.000Z"),
+          endDate: new Date("2027-12-31T00:00:00.000Z"),
+          createdAt: null,
+        },
       ],
     }
     render(
@@ -154,7 +224,17 @@ describe("ChallengeTab", () => {
 
   test("renders course links with judgeId in href when judge is selected", () => {
     const singleCompe = {
-      competitions: [{ id: 1, name: "Comp", step: 1, createdAt: null }],
+      competitions: [
+        {
+          id: 1,
+          name: "Comp",
+
+          description: null,
+          startDate: new Date("2025-01-01T00:00:00.000Z"),
+          endDate: new Date("2027-12-31T00:00:00.000Z"),
+          createdAt: null,
+        },
+      ],
     }
     render(
       <ChallengeTab

--- a/@robopo/web/test/unit/components/server/db.test.ts
+++ b/@robopo/web/test/unit/components/server/db.test.ts
@@ -51,7 +51,9 @@ describe("server/db.ts data fetching functions", () => {
   })
 
   test("getCompetitionList queries competition table and wraps result", async () => {
-    mockResult = [{ id: 1, name: "C1", step: 0 }]
+    mockResult = [
+      { id: 1, name: "C1", description: null, startDate: null, endDate: null },
+    ]
     const result = await getCompetitionList()
     expect(lastFromTable).toBe(competition)
     expect(result.competitions).toHaveLength(1)

--- a/@robopo/web/test/unit/lib/db/queries.test.ts
+++ b/@robopo/web/test/unit/lib/db/queries.test.ts
@@ -52,7 +52,7 @@ async function setupTestData() {
   // Create test competition
   const [comp] = await db
     .insert(competition)
-    .values({ name: "__test_query_competition__", step: 1 })
+    .values({ name: "__test_query_competition__" })
     .returning({ id: competition.id })
   testCompetitionId = comp.id
 


### PR DESCRIPTION
## Summary by Sourcery

大会管理の UI とデータモデルを刷新し、より豊富な大会メタデータとモダンな CRUD ワークフローをサポートします。ステップベースのステータス管理を日付ベースのステータスに置き換え、それに合わせて API ルートとテストを更新します。

New Features:
- 検索・フィルタ・ソートが可能な大会一覧に加え、一括選択やスケジュールによるステータスフィルタリングを備えた大会管理ビューを追加。
- 名前・説明・開始日・終了日を入力し、クライアントサイド検証を行う大会作成および編集モーダルを導入。
- 複数の大会削除に対応し、エラーも表示する削除確認モーダルを追加。

Bug Fixes:
- 作成・更新処理において、API レイヤーと UI レイヤーの両方で「開始日が終了日より後になっていないか」を検証。

Enhancements:
- 旧来のタブ形式の大会一覧／登録 UI を廃止し、カードスタイルの単一の大会管理ページレイアウトに置き換え。
- ステップベースのステータスバッジの代わりに、説明と開始日／終了日を表示するよう大会テーブルのレンダリングを拡張。
- ホームタブにおいて、「アクティブな」大会および選択可能な大会を、ステップフィールドではなく開始日／終了日に基づいて算出。
- DB レイヤーに汎用的な `updateCompetition` ヘルパーを追加し、大会更新 API ルートからそれを利用。

Tests:
- ホームタブ、ダッシュボード、共通リスト、サーバー DB、クエリテスト全体で、ステップではなく説明と日付フィールドを持つ新しい大会スキーマを用いるよう、ユニットテストとフィクスチャを更新。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Revamp the competition management UI and data model to support richer competition metadata and modern CRUD workflows, replacing step-based status handling with date-based status, and updating API routes and tests accordingly.

New Features:
- Add a competition management view with searchable, filterable, and sortable competition list plus bulk selection and status filtering by schedule.
- Introduce create and edit competition modals that capture name, description, and start/end dates with client-side validation.
- Add a delete confirmation modal that supports deleting multiple competitions and surfaces errors.

Bug Fixes:
- Validate that competition start date is not after end date at both API and UI layers for create and update operations.

Enhancements:
- Replace the old tabbed competition list/register UI with a single, card-style competition management page layout.
- Extend competition table rendering to show description and start/end dates instead of step-based status badges.
- Compute "active" competitions and selectable competitions based on start/end dates instead of a step field in home tabs.
- Add a generic updateCompetition helper in the DB layer and use it from the competition update API route.

Tests:
- Update unit tests and fixtures across home tabs, dashboard, common list, server DB, and query tests to use the new competition shape with description and date fields instead of step.

</details>