### PR TITLE
feat: polish course assign method

### DIFF
--- a/@robopo/web/app/api/assign/course/route.ts
+++ b/@robopo/web/app/api/assign/course/route.ts
@@ -1,5 +1,10 @@
+import { eq } from "drizzle-orm"
 import { assignById, unassignById } from "@/app/api/assign/assign"
 import { db } from "@/app/lib/db/db"
+import {
+  getCourseWithCompetition,
+  groupByCourse,
+} from "@/app/lib/db/queries/queries"
 import {
   competitionCourse,
   type SelectCompetitionCourse,
@@ -21,4 +26,42 @@ export async function POST(req: Request) {
 
 export async function DELETE(req: Request) {
   return await unassignById(req, "course")
+}
+
+// Bulk update: replace all competition links for a single course
+export async function PUT(req: Request) {
+  try {
+    const { courseId, competitionIds } = await req.json()
+    if (typeof courseId !== "number") {
+      return Response.json({ error: "Invalid courseId" }, { status: 400 })
+    }
+
+    // Remove all existing links for this course
+    await db
+      .delete(competitionCourse)
+      .where(eq(competitionCourse.courseId, courseId))
+
+    // Insert new links
+    if (Array.isArray(competitionIds) && competitionIds.length > 0) {
+      await db.insert(competitionCourse).values(
+        competitionIds.map((compId: number) => ({
+          competitionId: compId,
+          courseId,
+        })),
+      )
+    }
+
+    // Return updated course list
+    const newList = groupByCourse(await getCourseWithCompetition())
+    return Response.json({ success: true, newList }, { status: 200 })
+  } catch (error) {
+    return Response.json(
+      {
+        success: false,
+        message: "紐付けの更新中にエラーが発生しました。",
+        error,
+      },
+      { status: 500 },
+    )
+  }
 }

--- a/@robopo/web/app/api/competition/[id]/route.ts
+++ b/@robopo/web/app/api/competition/[id]/route.ts
@@ -1,5 +1,8 @@
-import { getCompetitionList } from "@/app/components/server/db"
+import { eq } from "drizzle-orm"
+import { getCompetitionWithCourseList } from "@/app/components/server/db"
+import { db } from "@/app/lib/db/db"
 import { updateCompetition } from "@/app/lib/db/queries/update"
+import { competitionCourse } from "@/app/lib/db/schema"
 
 export const revalidate = 0
 
@@ -52,7 +55,26 @@ export async function PATCH(
 
   try {
     await updateCompetition(Number(id), updateData)
-    const newList = await getCompetitionList()
+
+    // Update course links if provided
+    if (body.courseIds !== undefined) {
+      const competitionId = Number(id)
+      // Remove all existing links
+      await db
+        .delete(competitionCourse)
+        .where(eq(competitionCourse.competitionId, competitionId))
+      // Insert new links
+      if (Array.isArray(body.courseIds) && body.courseIds.length > 0) {
+        await db.insert(competitionCourse).values(
+          body.courseIds.map((courseId: number) => ({
+            competitionId,
+            courseId,
+          })),
+        )
+      }
+    }
+
+    const newList = await getCompetitionWithCourseList()
     return Response.json({ success: true, newList }, { status: 200 })
   } catch (error) {
     return Response.json(

--- a/@robopo/web/app/api/competition/route.ts
+++ b/@robopo/web/app/api/competition/route.ts
@@ -1,9 +1,11 @@
 import { deleteById } from "@/app/api/delete"
-import { getCompetitionList } from "@/app/components/server/db"
+import { getCompetitionWithCourseList } from "@/app/components/server/db"
+import { db } from "@/app/lib/db/db"
 import { createCompetition } from "@/app/lib/db/queries/insert"
+import { competitionCourse } from "@/app/lib/db/schema"
 
 export async function POST(req: Request) {
-  const { name, description, startDate, endDate } = await req.json()
+  const { name, description, startDate, endDate, courseIds } = await req.json()
 
   if (startDate && endDate && new Date(startDate) > new Date(endDate)) {
     return Response.json(
@@ -20,7 +22,19 @@ export async function POST(req: Request) {
   }
   try {
     const result = await createCompetition(competitionData)
-    const newList = await getCompetitionList()
+    const newCompetitionId = result[0].id
+
+    // Insert course links if provided
+    if (Array.isArray(courseIds) && courseIds.length > 0) {
+      await db.insert(competitionCourse).values(
+        courseIds.map((courseId: number) => ({
+          competitionId: newCompetitionId,
+          courseId,
+        })),
+      )
+    }
+
+    const newList = await getCompetitionWithCourseList()
     return Response.json(
       { success: true, data: result, newList },
       { status: 200 },
@@ -39,6 +53,6 @@ export async function POST(req: Request) {
 
 export async function DELETE(req: Request) {
   return await deleteById(req, "competition", async () => ({
-    newList: await getCompetitionList(),
+    newList: await getCompetitionWithCourseList(),
   }))
 }

--- a/@robopo/web/app/api/course/route.ts
+++ b/@robopo/web/app/api/course/route.ts
@@ -1,5 +1,4 @@
 import type { NextRequest } from "next/server"
-import { deleteById } from "@/app/api/delete"
 import {
   checkValidity,
   deserializeField,
@@ -8,7 +7,12 @@ import {
   isStart,
 } from "@/app/components/course/utils"
 import { createCourse } from "@/app/lib/db/queries/insert"
-import { getCourseById, getCourseByName } from "@/app/lib/db/queries/queries"
+import {
+  deleteCourseById,
+  getCourseById,
+  getCourseByName,
+  getLinkedCourseIds,
+} from "@/app/lib/db/queries/queries"
 import { updateCourse } from "@/app/lib/db/queries/update"
 
 export const revalidate = 0
@@ -82,5 +86,36 @@ export async function POST(req: NextRequest) {
 }
 
 export async function DELETE(req: Request) {
-  return await deleteById(req, "course")
+  const { id } = await req.json()
+  const ids: number[] = Array.isArray(id) ? id : [id]
+
+  // Check if any course is linked to competitions (single query)
+  const linkedIds = await getLinkedCourseIds(ids)
+  if (linkedIds.length > 0) {
+    return Response.json(
+      {
+        success: false,
+        message:
+          "使用大会が0でないコースは削除できません。先に紐付けを解除してください。",
+      },
+      { status: 400 },
+    )
+  }
+
+  try {
+    await Promise.all(ids.map((cid) => deleteCourseById(cid)))
+    return Response.json(
+      { success: true, message: "コースを削除しました。" },
+      { status: 200 },
+    )
+  } catch (error) {
+    return Response.json(
+      {
+        success: false,
+        message: "コースの削除中にエラーが発生しました。",
+        error,
+      },
+      { status: 500 },
+    )
+  }
 }

--- a/@robopo/web/app/components/common/commonList.tsx
+++ b/@robopo/web/app/components/common/commonList.tsx
@@ -1,6 +1,6 @@
 import type React from "react"
 import type {
-  SelectCompetition,
+  SelectCompetitionWithCourse,
   SelectCourseWithCompetition,
   SelectJudge,
   SelectJudgeWithCompetition,
@@ -13,7 +13,7 @@ type CommonListProps = {
   commonDataList:
     | SelectPlayer[]
     | SelectJudge[]
-    | SelectCompetition[]
+    | SelectCompetitionWithCourse[]
     | SelectPlayerWithCompetition[]
     | SelectJudgeWithCompetition[]
 }
@@ -21,14 +21,16 @@ type CommonListProps = {
 function TableComponent({
   type,
   common,
+  onCourseCompetitionClick,
 }: {
   type: CommonListProps["type"]
   common:
     | SelectPlayer
     | SelectJudge
-    | SelectCompetition
+    | SelectCompetitionWithCourse
     | SelectPlayerWithCompetition
     | SelectJudgeWithCompetition
+  onCourseCompetitionClick?: (names: string[]) => void
 }) {
   return (
     <>
@@ -82,12 +84,25 @@ function TableComponent({
             {(common as SelectCourseWithCompetition).name}
           </td>
           <td className="py-3">
-            {(common as SelectCourseWithCompetition).competitionName?.map(
-              (name) => (
-                <span key={name} className="badge badge-ghost badge-sm mr-1">
-                  {name}
-                </span>
-              ),
+            {(common as SelectCourseWithCompetition).competitionName?.length ? (
+              <button
+                type="button"
+                className="badge badge-primary badge-outline cursor-pointer transition-colors hover:bg-primary hover:text-primary-content"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onCourseCompetitionClick?.(
+                    (common as SelectCourseWithCompetition).competitionName ??
+                      [],
+                  )
+                }}
+              >
+                {
+                  (common as SelectCourseWithCompetition).competitionName
+                    ?.length
+                }
+              </button>
+            ) : (
+              <span className="text-base-content/30 text-sm">0</span>
             )}
           </td>
           <td className="max-w-48 py-3">
@@ -112,15 +127,28 @@ function TableComponent({
       {type === "competition" && (
         <>
           <td className="py-3 font-mono text-base-content/50 text-xs">
-            {(common as SelectCompetition).id}
+            {(common as SelectCompetitionWithCourse).id}
           </td>
           <td className="py-3 font-medium">
-            {(common as SelectCompetition).name}
+            {(common as SelectCompetitionWithCourse).name}
+          </td>
+          <td className="py-3">
+            {(common as SelectCompetitionWithCourse).courseNames?.length > 0 ? (
+              (common as SelectCompetitionWithCourse).courseNames.map(
+                (name) => (
+                  <span key={name} className="badge badge-ghost badge-sm mr-1">
+                    {name}
+                  </span>
+                ),
+              )
+            ) : (
+              <span className="text-base-content/30 text-sm">-</span>
+            )}
           </td>
           <td className="max-w-48 py-3">
-            {(common as SelectCompetition).description ? (
+            {(common as SelectCompetitionWithCourse).description ? (
               <span className="line-clamp-2 text-base-content/70 text-sm">
-                {(common as SelectCompetition).description}
+                {(common as SelectCompetitionWithCourse).description}
               </span>
             ) : (
               <span className="text-base-content/30 text-sm">-</span>
@@ -130,9 +158,9 @@ function TableComponent({
             className="py-3 text-base-content/60 text-sm"
             suppressHydrationWarning
           >
-            {(common as SelectCompetition).startDate ? (
+            {(common as SelectCompetitionWithCourse).startDate ? (
               new Date(
-                (common as SelectCompetition).startDate as Date,
+                (common as SelectCompetitionWithCourse).startDate as Date,
               ).toLocaleDateString("ja-JP")
             ) : (
               <span className="text-base-content/30">-</span>
@@ -142,9 +170,9 @@ function TableComponent({
             className="py-3 text-base-content/60 text-sm"
             suppressHydrationWarning
           >
-            {(common as SelectCompetition).endDate ? (
+            {(common as SelectCompetitionWithCourse).endDate ? (
               new Date(
-                (common as SelectCompetition).endDate as Date,
+                (common as SelectCompetitionWithCourse).endDate as Date,
               ).toLocaleDateString("ja-JP")
             ) : (
               <span className="text-base-content/30">-</span>
@@ -165,7 +193,7 @@ function itemNames(type: CommonListProps["type"]): string[] {
   } else if (type === "course") {
     itemNames.push("ID", "コース名", "使用大会", "説明", "作成日時")
   } else if (type === "competition") {
-    itemNames.push("ID", "名前", "説明", "開催日", "終了日")
+    itemNames.push("ID", "名前", "コース", "説明", "開催日", "終了日")
   }
   return itemNames
 }
@@ -200,11 +228,13 @@ export function CommonSelectionList({
   selectionMode,
   selectedId,
   onSelect,
+  onCourseCompetitionClick,
 }: {
   props: CommonListProps
   selectionMode: "radio" | "checkbox"
   selectedId: number | null | number[]
   onSelect: (id: number) => void
+  onCourseCompetitionClick?: (names: string[]) => void
 }) {
   function isChecked(id: number): boolean {
     if (selectionMode === "radio") {
@@ -220,8 +250,8 @@ export function CommonSelectionList({
           {typeLabel(type)}一覧
         </h2>
       )}
-      <div className="w-full">
-        <div className="m-3 max-h-[28rem] overflow-x-auto overflow-y-auto rounded-xl border border-base-300/50 sm:h-96">
+      <div className="flex min-h-0 w-full flex-1 flex-col">
+        <div className="m-3 min-h-0 flex-1 overflow-x-auto overflow-y-auto rounded-xl border border-base-300/50">
           <table className="table-pin-rows table-zebra table">
             <thead>
               <tr className="border-base-300/50 border-b bg-base-200/60">
@@ -275,7 +305,11 @@ export function CommonSelectionList({
                         />
                       </label>
                     </th>
-                    <TableComponent type={type} common={common} />
+                    <TableComponent
+                      type={type}
+                      common={common}
+                      onCourseCompetitionClick={onCourseCompetitionClick}
+                    />
                   </tr>
                 ))
               ) : (
@@ -319,10 +353,12 @@ export function CommonCheckboxList({
   props,
   commonId,
   setCommonId,
+  onCourseCompetitionClick,
 }: {
   props: CommonListProps
   commonId: number[]
   setCommonId: React.Dispatch<React.SetStateAction<number[]>>
+  onCourseCompetitionClick?: (names: string[]) => void
 }) {
   function handleToggle(id: number) {
     if (!commonId) {
@@ -340,6 +376,7 @@ export function CommonCheckboxList({
       selectionMode="checkbox"
       selectedId={commonId}
       onSelect={handleToggle}
+      onCourseCompetitionClick={onCourseCompetitionClick}
     />
   )
 }

--- a/@robopo/web/app/components/common/commonModal.tsx
+++ b/@robopo/web/app/components/common/commonModal.tsx
@@ -58,11 +58,16 @@ export function DeleteModal({ type, ids }: { type: InputType; ids: number[] }) {
         body: JSON.stringify({ id: ids }),
       })
 
-      if (response.ok) {
+      const result = await response.json()
+      if (response.ok && result.success) {
         setSuccessMessage(`${commonString}を正常に削除しました`)
       } else {
-        setErrorMessage(`${commonString}を削除できませんでした`)
+        setErrorMessage(
+          result.message || `${commonString}を削除できませんでした`,
+        )
       }
+    } catch {
+      setErrorMessage(`${commonString}を削除できませんでした`)
     } finally {
       setLoading(false)
     }

--- a/@robopo/web/app/components/common/view.tsx
+++ b/@robopo/web/app/components/common/view.tsx
@@ -3,11 +3,15 @@
 import {
   BarsArrowDownIcon,
   BarsArrowUpIcon,
+  CheckCircleIcon,
+  ExclamationTriangleIcon,
   FunnelIcon,
   LinkIcon,
   MagnifyingGlassIcon,
   PencilSquareIcon,
   TrashIcon,
+  XCircleIcon,
+  XMarkIcon,
 } from "@heroicons/react/24/outline"
 import Link from "next/link"
 import type React from "react"
@@ -15,6 +19,7 @@ import { useMemo, useState } from "react"
 import { CommonCheckboxList } from "@/app/components/common/commonList"
 import { CommonRegister } from "@/app/components/common/commonRegister"
 import type {
+  SelectCompetition,
   SelectCourseWithCompetition,
   SelectJudge,
   SelectJudgeWithCompetition,
@@ -27,21 +32,25 @@ type SortKey = "createdAt" | "name" | "id"
 type PlayerProps = {
   type: "player"
   initialCommonDataList: SelectPlayerWithCompetition[]
+  competitionList?: never
 }
 
 type JudgeProps = {
   type: "judge"
   initialCommonDataList: SelectJudgeWithCompetition[]
+  competitionList?: never
 }
 
 type CourseProps = {
   type: "course"
   initialCommonDataList: SelectCourseWithCompetition[]
+  competitionList: SelectCompetition[]
 }
 
 export function View({
   type,
   initialCommonDataList,
+  competitionList,
 }: PlayerProps | JudgeProps | CourseProps) {
   const [successMessage, setSuccessMessage] = useState<string | null>(null)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
@@ -63,7 +72,15 @@ export function View({
   }
 
   // Action options for selected items
-  function ItemManager({ commonId }: { commonId: number[] | null }) {
+  function ItemManager({
+    commonId,
+    onAssignClick,
+    onDeleteClick,
+  }: {
+    commonId: number[] | null
+    onAssignClick?: () => void
+    onDeleteClick?: () => void
+  }) {
     return (
       <div className="px-4 pt-2 pb-4">
         {successMessage && (
@@ -100,50 +117,84 @@ export function View({
               編集
             </Link>
           )}
-          <Link
-            href={
-              type === "player"
-                ? `/player/assign/${createQueryParams(commonId)}`
-                : type === "judge"
-                  ? `/judge/assign/${createQueryParams(commonId)}`
-                  : `/course/assign/${createQueryParams(commonId)}`
-            }
-            className={`btn btn-sm gap-1.5 rounded-lg ${
-              commonId === null || commonId?.length === 0
-                ? "btn-disabled pointer-events-none"
-                : "btn-primary btn-outline"
-            }`}
-            aria-disabled={commonId === null || commonId?.length === 0}
-            tabIndex={
-              commonId === null || commonId?.length === 0 ? -1 : undefined
-            }
-            onClick={() => setSuccessMessage(null)}
-          >
-            <LinkIcon className="size-4" />
-            大会割当
-          </Link>
-          <Link
-            href={
-              type === "player"
-                ? `/player/delete/${createQueryParams(commonId)}`
-                : type === "judge"
-                  ? `/judge/delete/${createQueryParams(commonId)}`
-                  : `/course/delete/${createQueryParams(commonId)}`
-            }
-            className={`btn btn-sm gap-1.5 rounded-lg ${
-              commonId === null || commonId?.length === 0
-                ? "btn-disabled pointer-events-none"
-                : "btn-error btn-outline"
-            }`}
-            aria-disabled={commonId === null || commonId?.length === 0}
-            tabIndex={
-              commonId === null || commonId?.length === 0 ? -1 : undefined
-            }
-            onClick={() => setSuccessMessage(null)}
-          >
-            <TrashIcon className="size-4" />
-            削除
-          </Link>
+          {type === "course" ? (
+            <button
+              type="button"
+              className={`btn btn-sm gap-1.5 rounded-lg ${
+                commonId?.length !== 1
+                  ? "btn-disabled"
+                  : "btn-primary btn-outline"
+              }`}
+              disabled={commonId?.length !== 1}
+              onClick={() => {
+                setSuccessMessage(null)
+                onAssignClick?.()
+              }}
+            >
+              <LinkIcon className="size-4" />
+              大会紐付け
+            </button>
+          ) : (
+            <Link
+              href={
+                type === "player"
+                  ? `/player/assign/${createQueryParams(commonId)}`
+                  : `/judge/assign/${createQueryParams(commonId)}`
+              }
+              className={`btn btn-sm gap-1.5 rounded-lg ${
+                commonId === null || commonId?.length === 0
+                  ? "btn-disabled pointer-events-none"
+                  : "btn-primary btn-outline"
+              }`}
+              aria-disabled={commonId === null || commonId?.length === 0}
+              tabIndex={
+                commonId === null || commonId?.length === 0 ? -1 : undefined
+              }
+              onClick={() => setSuccessMessage(null)}
+            >
+              <LinkIcon className="size-4" />
+              大会割当
+            </Link>
+          )}
+          {type === "course" ? (
+            <button
+              type="button"
+              className={`btn btn-sm gap-1.5 rounded-lg ${
+                commonId === null || commonId?.length === 0
+                  ? "btn-disabled"
+                  : "btn-error btn-outline"
+              }`}
+              disabled={commonId === null || commonId?.length === 0}
+              onClick={() => {
+                setSuccessMessage(null)
+                onDeleteClick?.()
+              }}
+            >
+              <TrashIcon className="size-4" />
+              削除
+            </button>
+          ) : (
+            <Link
+              href={
+                type === "player"
+                  ? `/player/delete/${createQueryParams(commonId)}`
+                  : `/judge/delete/${createQueryParams(commonId)}`
+              }
+              className={`btn btn-sm gap-1.5 rounded-lg ${
+                commonId === null || commonId?.length === 0
+                  ? "btn-disabled pointer-events-none"
+                  : "btn-error btn-outline"
+              }`}
+              aria-disabled={commonId === null || commonId?.length === 0}
+              tabIndex={
+                commonId === null || commonId?.length === 0 ? -1 : undefined
+              }
+              onClick={() => setSuccessMessage(null)}
+            >
+              <TrashIcon className="size-4" />
+              削除
+            </Link>
+          )}
         </div>
       </div>
     )
@@ -276,10 +327,17 @@ export function View({
     const [sortKey, setSortKey] = useState<SortKey>("createdAt")
     const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc")
     const [competitionFilter, setCompetitionFilter] = useState("")
+    const [competitionDetailNames, setCompetitionDetailNames] = useState<
+      string[] | null
+    >(null)
+    const [assignModalOpen, setAssignModalOpen] = useState(false)
+    const [deleteModalOpen, setDeleteModalOpen] = useState(false)
+
+    const courseDataList = commonDataList as SelectCourseWithCompetition[]
 
     const competitionNames = useMemo(() => {
       const names = new Set<string>()
-      for (const c of commonDataList as SelectCourseWithCompetition[]) {
+      for (const c of courseDataList) {
         for (const name of c.competitionName ?? []) {
           names.add(name)
         }
@@ -288,7 +346,7 @@ export function View({
     }, [])
 
     const filteredAndSortedList = useMemo(() => {
-      let list = commonDataList as SelectCourseWithCompetition[]
+      let list = courseDataList
       if (searchQuery.trim()) {
         const q = searchQuery.trim().toLowerCase()
         list = list.filter(
@@ -315,33 +373,148 @@ export function View({
       })
     }, [searchQuery, sortKey, sortOrder, competitionFilter])
 
+    const selectedCourse =
+      commonId.length === 1
+        ? (courseDataList.find((c) => c.id === commonId[0]) ?? null)
+        : null
+
+    const selectedCourses = courseDataList.filter((c) =>
+      commonId.includes(c.id),
+    )
+
+    function handleAssignSuccess(newList: SelectCourseWithCompetition[]) {
+      const parsed = newList.map((c) => ({
+        ...c,
+        createdAt: c.createdAt ? new Date(c.createdAt) : null,
+      }))
+      setCommonDataList(parsed)
+      setSuccessMessage("大会紐付けを更新しました")
+      setErrorMessage(null)
+      setAssignModalOpen(false)
+      setCommonId([])
+    }
+
+    function handleDeleteSuccess() {
+      setSuccessMessage("コースを削除しました")
+      setErrorMessage(null)
+      setDeleteModalOpen(false)
+      setCommonId([])
+      // Reload to get fresh data
+      window.location.href = "/course"
+    }
+
     return (
-      <>
-        <ItemManager commonId={commonId} />
-        <CourseFilterBar
-          searchQuery={searchQuery}
-          setSearchQuery={setSearchQuery}
-          competitionFilter={competitionFilter}
-          setCompetitionFilter={setCompetitionFilter}
-          competitionNames={competitionNames}
-          sortKey={sortKey}
-          setSortKey={setSortKey}
-          sortOrder={sortOrder}
-          setSortOrder={setSortOrder}
-        />
-        {(searchQuery || competitionFilter) &&
-        filteredAndSortedList.length === 0 ? (
-          <div className="py-8 text-center text-base-content/40">
-            条件に一致するコースが見つかりません
-          </div>
-        ) : (
-          <CommonCheckboxList
-            props={{ type: type, commonDataList: filteredAndSortedList }}
+      <div className="flex min-h-0 flex-1 flex-col">
+        <div className="shrink-0">
+          <ItemManager
             commonId={commonId}
-            setCommonId={setCommonId}
+            onAssignClick={() => setAssignModalOpen(true)}
+            onDeleteClick={() => setDeleteModalOpen(true)}
+          />
+          <CourseFilterBar
+            searchQuery={searchQuery}
+            setSearchQuery={setSearchQuery}
+            competitionFilter={competitionFilter}
+            setCompetitionFilter={setCompetitionFilter}
+            competitionNames={competitionNames}
+            sortKey={sortKey}
+            setSortKey={setSortKey}
+            sortOrder={sortOrder}
+            setSortOrder={setSortOrder}
+          />
+        </div>
+        <div className="min-h-0 flex-1">
+          {(searchQuery || competitionFilter) &&
+          filteredAndSortedList.length === 0 ? (
+            <div className="py-8 text-center text-base-content/40">
+              条件に一致するコースが見つかりません
+            </div>
+          ) : (
+            <CommonCheckboxList
+              props={{ type: type, commonDataList: filteredAndSortedList }}
+              commonId={commonId}
+              setCommonId={setCommonId}
+              onCourseCompetitionClick={setCompetitionDetailNames}
+            />
+          )}
+        </div>
+
+        {/* Competition detail modal */}
+        {competitionDetailNames !== null && (
+          <dialog className="modal modal-open">
+            <div className="modal-box max-w-sm">
+              <div className="mb-4 flex items-center justify-between">
+                <h3 className="font-bold text-lg">使用大会一覧</h3>
+                <button
+                  type="button"
+                  className="btn btn-ghost btn-sm btn-circle"
+                  onClick={() => setCompetitionDetailNames(null)}
+                >
+                  <XMarkIcon className="size-5" />
+                </button>
+              </div>
+              <div className="max-h-[60vh] overflow-y-auto">
+                {competitionDetailNames.length > 0 ? (
+                  <ul className="space-y-1.5">
+                    {competitionDetailNames.map((name) => (
+                      <li
+                        key={name}
+                        className="rounded-lg bg-base-200/50 px-3 py-2.5 text-sm"
+                      >
+                        {name}
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="py-4 text-center text-base-content/40 text-sm">
+                    使用大会はありません
+                  </p>
+                )}
+              </div>
+              <div className="modal-action">
+                <button
+                  type="button"
+                  className="btn rounded-lg"
+                  onClick={() => setCompetitionDetailNames(null)}
+                >
+                  閉じる
+                </button>
+              </div>
+            </div>
+            <form
+              method="dialog"
+              className="modal-backdrop"
+              onClick={() => setCompetitionDetailNames(null)}
+              onKeyDown={(e) =>
+                e.key === "Escape" && setCompetitionDetailNames(null)
+              }
+            >
+              <button type="button" className="cursor-default">
+                close
+              </button>
+            </form>
+          </dialog>
+        )}
+
+        {/* Course assign modal */}
+        {assignModalOpen && selectedCourse && competitionList && (
+          <CourseAssignModal
+            course={selectedCourse}
+            competitionList={competitionList}
+            onClose={() => setAssignModalOpen(false)}
+            onSuccess={handleAssignSuccess}
           />
         )}
-      </>
+
+        {/* Course delete modal */}
+        {deleteModalOpen && selectedCourses.length > 0 && (
+          <CourseDeleteModal
+            courses={selectedCourses}
+            onClose={() => setDeleteModalOpen(false)}
+            onSuccess={handleDeleteSuccess}
+          />
+        )}
+      </div>
     )
   }
 
@@ -349,5 +522,262 @@ export function View({
     <ViewWithRegister />
   ) : (
     <ViewNoRegister />
+  )
+}
+
+// Course-specific assign modal with checkbox selection
+function CourseAssignModal({
+  course,
+  competitionList,
+  onClose,
+  onSuccess,
+}: {
+  course: SelectCourseWithCompetition
+  competitionList: SelectCompetition[]
+  onClose: () => void
+  onSuccess: (newList: SelectCourseWithCompetition[]) => void
+}) {
+  const [selectedCompetitionIds, setSelectedCompetitionIds] = useState<
+    number[]
+  >(course.competitionIds ?? [])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  function toggleCompetition(id: number) {
+    setSelectedCompetitionIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
+    )
+  }
+
+  async function handleSave() {
+    setLoading(true)
+    setError(null)
+    try {
+      const response = await fetch("/api/assign/course", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          courseId: course.id,
+          competitionIds: selectedCompetitionIds,
+        }),
+      })
+      const result = await response.json()
+      if (response.ok && result.success) {
+        onSuccess(result.newList)
+      } else {
+        setError(result.message || "エラーが発生しました。")
+      }
+    } catch {
+      setError("送信中にエラーが発生しました。")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <dialog className="modal modal-open">
+      <div className="modal-box max-w-md">
+        <div className="mb-4 flex items-center justify-between">
+          <h3 className="font-bold text-lg">大会紐付け</h3>
+          <button
+            type="button"
+            className="btn btn-ghost btn-sm btn-circle"
+            onClick={onClose}
+          >
+            <XMarkIcon className="size-5" />
+          </button>
+        </div>
+        <p className="mb-3 text-base-content/60 text-sm">
+          <span className="font-medium text-base-content">{course.name}</span>{" "}
+          に紐付ける大会を選択してください
+        </p>
+        {competitionList.length > 0 ? (
+          <div className="max-h-[8.5rem] overflow-y-auto rounded-xl border border-base-300/50 bg-base-200/30">
+            {competitionList.map((c) => (
+              <label
+                key={c.id}
+                className="flex cursor-pointer items-center gap-2.5 rounded-lg px-3 py-2 transition-colors hover:bg-base-200/60"
+              >
+                <input
+                  type="checkbox"
+                  className="checkbox checkbox-primary checkbox-sm"
+                  checked={selectedCompetitionIds.includes(c.id)}
+                  onChange={() => toggleCompetition(c.id)}
+                />
+                <span className="text-sm">{c.name}</span>
+              </label>
+            ))}
+          </div>
+        ) : (
+          <p className="rounded-xl bg-base-200/30 px-3 py-2 text-base-content/40 text-sm">
+            大会が登録されていません
+          </p>
+        )}
+        <p className="mt-1 text-base-content/40 text-xs">
+          紐付けは任意です（0件でも可）
+        </p>
+        {error && <p className="mt-2 text-error text-sm">{error}</p>}
+        <div className="modal-action">
+          <button
+            type="button"
+            className="btn gap-1.5 rounded-lg"
+            onClick={onClose}
+            disabled={loading}
+          >
+            <XMarkIcon className="size-4" />
+            キャンセル
+          </button>
+          <button
+            type="button"
+            className="btn btn-primary gap-1.5 rounded-lg shadow-lg shadow-primary/20 transition-all duration-200 hover:shadow-primary/30 hover:shadow-xl"
+            onClick={handleSave}
+            disabled={loading}
+          >
+            {loading ? (
+              <span className="loading loading-spinner loading-sm" />
+            ) : (
+              <LinkIcon className="size-4" />
+            )}
+            保存
+          </button>
+        </div>
+      </div>
+      <form
+        method="dialog"
+        className="modal-backdrop"
+        onClick={onClose}
+        onKeyDown={(e) => e.key === "Escape" && onClose()}
+      >
+        <button type="button" className="cursor-default">
+          close
+        </button>
+      </form>
+    </dialog>
+  )
+}
+
+// Course delete modal with competition link protection
+function CourseDeleteModal({
+  courses,
+  onClose,
+  onSuccess,
+}: {
+  courses: SelectCourseWithCompetition[]
+  onClose: () => void
+  onSuccess: () => void
+}) {
+  const [loading, setLoading] = useState(false)
+  const [successMessage, setSuccessMessage] = useState<string | null>(null)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const hasLinkedCourses = courses.some(
+    (c) => (c.competitionName?.length ?? 0) > 0,
+  )
+
+  async function handleDelete() {
+    setLoading(true)
+    setErrorMessage(null)
+    try {
+      const response = await fetch("/api/course", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id: courses.map((c) => c.id) }),
+      })
+      const result = await response.json()
+      if (response.ok && result.success) {
+        setSuccessMessage("コースを正常に削除しました")
+      } else {
+        setErrorMessage(result.message || "コースを削除できませんでした")
+      }
+    } catch {
+      setErrorMessage("コースを削除できませんでした")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <dialog className="modal modal-open">
+      <div className="modal-box max-w-md">
+        <div className="flex flex-col items-center px-2 py-2">
+          {successMessage ? (
+            <div className="flex flex-col items-center gap-3">
+              <CheckCircleIcon className="size-12 text-success" />
+              <p className="text-center font-medium">{successMessage}</p>
+            </div>
+          ) : hasLinkedCourses ? (
+            <div className="flex flex-col items-center gap-3">
+              <ExclamationTriangleIcon className="size-12 text-warning" />
+              <p className="text-center font-medium">
+                使用大会が0でないコースは削除できません。
+                <br />
+                先に紐付けを解除してください。
+              </p>
+            </div>
+          ) : (
+            <div className="flex flex-col items-center gap-3">
+              <ExclamationTriangleIcon className="size-12 text-warning" />
+              <p className="text-center font-medium">
+                選択したコースを削除しますか?
+              </p>
+              <ul className="w-full list-inside list-disc text-sm">
+                {courses.map((c) => (
+                  <li key={c.id} className="font-medium">
+                    {c.name}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {errorMessage && (
+            <div className="mt-4 flex w-full items-center gap-2 rounded-lg bg-error/10 px-4 py-2.5 text-error text-sm">
+              <XCircleIcon className="size-5 shrink-0" />
+              {errorMessage}
+            </div>
+          )}
+
+          <div className="mt-6 flex w-full flex-col gap-2">
+            {!hasLinkedCourses && !successMessage && (
+              <button
+                type="button"
+                className="btn btn-error w-full rounded-xl shadow-error/20 shadow-lg transition-all duration-200 hover:shadow-error/30 hover:shadow-xl"
+                onClick={handleDelete}
+                disabled={loading}
+              >
+                {loading ? (
+                  <>
+                    削除中
+                    <span className="loading loading-spinner loading-sm" />
+                  </>
+                ) : (
+                  "削除する"
+                )}
+              </button>
+            )}
+            <button
+              type="button"
+              className="btn w-full rounded-xl"
+              onClick={successMessage ? onSuccess : onClose}
+              disabled={loading}
+            >
+              戻る
+            </button>
+          </div>
+        </div>
+      </div>
+      <form
+        method="dialog"
+        className="modal-backdrop"
+        onClick={successMessage ? onSuccess : onClose}
+        onKeyDown={(e) =>
+          e.key === "Escape" && (successMessage ? onSuccess() : onClose())
+        }
+      >
+        <button type="button" className="cursor-default">
+          close
+        </button>
+      </form>
+    </dialog>
   )
 }

--- a/@robopo/web/app/components/server/db.ts
+++ b/@robopo/web/app/components/server/db.ts
@@ -3,6 +3,10 @@
 import { eq } from "drizzle-orm"
 import { db } from "@/app/lib/db/db"
 import {
+  getCompetitionWithCourse,
+  groupByCompetition,
+} from "@/app/lib/db/queries/queries"
+import {
   competition,
   competitionCourse,
   competitionJudge,
@@ -13,6 +17,7 @@ import {
   type SelectCompetition,
   type SelectCompetitionCourse,
   type SelectCompetitionJudge,
+  type SelectCompetitionWithCourse,
   type SelectCourse,
   type SelectJudge,
   type SelectPlayer,
@@ -33,6 +38,14 @@ export async function getCompetitionList(): Promise<{
   competitions: SelectCompetition[]
 }> {
   const competitions: SelectCompetition[] = await db.select().from(competition)
+  return { competitions }
+}
+
+// Get competition list with course info
+export async function getCompetitionWithCourseList(): Promise<{
+  competitions: SelectCompetitionWithCourse[]
+}> {
+  const competitions = groupByCompetition(await getCompetitionWithCourse())
   return { competitions }
 }
 

--- a/@robopo/web/app/config/page.tsx
+++ b/@robopo/web/app/config/page.tsx
@@ -1,25 +1,32 @@
-import { getCompetitionList } from "@/app/components/server/db"
+import {
+  getCompetitionWithCourseList,
+  getCourseList,
+} from "@/app/components/server/db"
 import { CompetitionView } from "@/app/config/view"
 
 export const revalidate = 0
 
 export default async function Config() {
-  const { competitions } = await getCompetitionList()
+  const [{ competitions }, { courses }] = await Promise.all([
+    getCompetitionWithCourseList(),
+    getCourseList(),
+  ])
 
   return (
-    <div className="container mx-auto max-w-6xl px-4 py-6">
-      <div className="mb-6 flex items-center justify-between">
-        <div>
-          <h1 className="font-bold text-2xl text-base-content tracking-tight">
-            大会一覧
-          </h1>
-          <p className="mt-1 text-base-content/60 text-sm">
-            大会の作成・編集・削除を行います
-          </p>
-        </div>
+    <div className="flex h-[calc(100dvh-3.5rem)] flex-col overflow-hidden px-4 py-6 sm:px-10 lg:px-16">
+      <div className="mb-4 shrink-0">
+        <h1 className="font-bold text-2xl text-base-content tracking-tight">
+          大会一覧
+        </h1>
+        <p className="mt-1 text-base-content/60 text-sm">
+          大会の作成・編集・削除を行います
+        </p>
       </div>
-      <div className="rounded-2xl border border-base-300 bg-base-100 shadow-sm">
-        <CompetitionView initialCompetitionList={competitions} />
+      <div className="flex min-h-0 flex-1 flex-col rounded-2xl border border-base-300 bg-base-100 shadow-sm">
+        <CompetitionView
+          initialCompetitionList={competitions}
+          courseList={courses}
+        />
       </div>
     </div>
   )

--- a/@robopo/web/app/config/tabs.tsx
+++ b/@robopo/web/app/config/tabs.tsx
@@ -7,7 +7,12 @@ import {
   XMarkIcon,
 } from "@heroicons/react/24/outline"
 import { useState } from "react"
-import type { SelectCompetition } from "@/app/lib/db/schema"
+import type {
+  SelectCompetitionWithCourse,
+  SelectCourse,
+} from "@/app/lib/db/schema"
+
+const DEFAULT_COURSE_NAMES = ["THE一本橋", "センサーコース"]
 
 function formatDateForInput(date: Date | null | undefined): string {
   if (!date) {
@@ -22,14 +27,16 @@ function formatDateForInput(date: Date | null | undefined): string {
 
 type CompetitionFormModalProps = {
   mode: "create" | "edit"
-  competition?: SelectCompetition | null
+  competition?: SelectCompetitionWithCourse | null
+  courseList: SelectCourse[]
   onClose: () => void
-  onSuccess: (newList: SelectCompetition[]) => void
+  onSuccess: (newList: SelectCompetitionWithCourse[]) => void
 }
 
 export function CompetitionFormModal({
   mode,
   competition,
+  courseList,
   onClose,
   onSuccess,
 }: CompetitionFormModalProps) {
@@ -41,8 +48,23 @@ export function CompetitionFormModal({
   const [endDate, setEndDate] = useState(
     formatDateForInput(competition?.endDate),
   )
+  const [selectedCourseIds, setSelectedCourseIds] = useState<number[]>(
+    mode === "create"
+      ? courseList
+          .filter((c) => DEFAULT_COURSE_NAMES.includes(c.name))
+          .map((c) => c.id)
+      : (competition?.courseIds ?? []),
+  )
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+
+  function toggleCourse(courseId: number) {
+    setSelectedCourseIds((prev) =>
+      prev.includes(courseId)
+        ? prev.filter((id) => id !== courseId)
+        : [...prev, courseId],
+    )
+  }
 
   function validate(): string | null {
     if (!name.trim()) {
@@ -71,6 +93,7 @@ export function CompetitionFormModal({
         description: description.trim() || null,
         startDate: startDate || null,
         endDate: endDate || null,
+        courseIds: selectedCourseIds,
       }
 
       const url =
@@ -166,6 +189,39 @@ export function CompetitionFormModal({
               開催日は終了日より前でなければなりません。
             </p>
           )}
+
+          {/* Course selection */}
+          <div>
+            <span className="label">
+              <span className="label-text">コース</span>
+            </span>
+            {courseList.length > 0 ? (
+              <div className="max-h-[8.5rem] overflow-y-auto rounded-xl border border-base-300/50 bg-base-200/30">
+                {courseList.map((c) => (
+                  <label
+                    key={c.id}
+                    className="flex cursor-pointer items-center gap-2.5 rounded-lg px-3 py-2 transition-colors hover:bg-base-200/60"
+                  >
+                    <input
+                      type="checkbox"
+                      className="checkbox checkbox-primary checkbox-sm"
+                      checked={selectedCourseIds.includes(c.id)}
+                      onChange={() => toggleCourse(c.id)}
+                    />
+                    <span className="text-sm">{c.name}</span>
+                  </label>
+                ))}
+              </div>
+            ) : (
+              <p className="rounded-xl bg-base-200/30 px-3 py-2 text-base-content/40 text-sm">
+                コースが登録されていません
+              </p>
+            )}
+            <p className="mt-1 text-base-content/40 text-xs">
+              コースの選択は任意です
+            </p>
+          </div>
+
           {error && <p className="text-error text-sm">{error}</p>}
           <div className="modal-action">
             <button
@@ -210,9 +266,9 @@ export function CompetitionFormModal({
 
 type DeleteCompetitionModalProps = {
   selectedIds: number[]
-  competitions: SelectCompetition[]
+  competitions: SelectCompetitionWithCourse[]
   onClose: () => void
-  onSuccess: (newList: SelectCompetition[]) => void
+  onSuccess: (newList: SelectCompetitionWithCourse[]) => void
 }
 
 export function DeleteCompetitionModal({

--- a/@robopo/web/app/config/view.tsx
+++ b/@robopo/web/app/config/view.tsx
@@ -16,15 +16,20 @@ import {
   type CompetitionStatus,
   getCompetitionStatus,
 } from "@/app/lib/competition"
-import type { SelectCompetition } from "@/app/lib/db/schema"
+import type {
+  SelectCompetitionWithCourse,
+  SelectCourse,
+} from "@/app/lib/db/schema"
 
 type SortKey = "name" | "id" | "startDate" | "endDate"
 type StatusFilter = "" | CompetitionStatus
 
 export function CompetitionView({
   initialCompetitionList,
+  courseList,
 }: {
-  initialCompetitionList: SelectCompetition[]
+  initialCompetitionList: SelectCompetitionWithCourse[]
+  courseList: SelectCourse[]
 }) {
   const [competitionList, setCompetitionList] = useState(initialCompetitionList)
   const [selectedIds, setSelectedIds] = useState<number[]>([])
@@ -75,7 +80,10 @@ export function CompetitionView({
     })
   }, [competitionList, searchQuery, statusFilter, sortKey, sortOrder])
 
-  function handleSuccess(newList: SelectCompetition[], message: string) {
+  function handleSuccess(
+    newList: SelectCompetitionWithCourse[],
+    message: string,
+  ) {
     // API JSON responses return dates as strings; convert them back to Date objects
     const parsed = newList.map((c) => ({
       ...c,
@@ -90,9 +98,9 @@ export function CompetitionView({
   }
 
   return (
-    <>
+    <div className="flex min-h-0 flex-1 flex-col">
       {/* Action bar */}
-      <div className="px-4 pt-4 pb-2">
+      <div className="shrink-0 px-4 pt-4 pb-2">
         {successMessage && (
           <div className="mb-3 rounded-lg bg-success/10 px-4 py-2 font-medium text-sm text-success">
             {successMessage}
@@ -151,7 +159,7 @@ export function CompetitionView({
       </div>
 
       {/* Filter bar */}
-      <div className="flex flex-col gap-3 px-4 pb-4">
+      <div className="flex shrink-0 flex-col gap-3 px-4 pb-4">
         <label className="input input-bordered flex items-center gap-2 rounded-xl bg-base-200/40 transition-colors focus-within:bg-base-100">
           <MagnifyingGlassIcon className="size-4 shrink-0 text-base-content/40" />
           <input
@@ -219,22 +227,28 @@ export function CompetitionView({
       </div>
 
       {/* Table */}
-      {(searchQuery || statusFilter) && filteredAndSortedList.length === 0 ? (
-        <div className="py-8 text-center text-base-content/40">
-          条件に一致する大会が見つかりません
-        </div>
-      ) : (
-        <CommonCheckboxList
-          props={{ type: "competition", commonDataList: filteredAndSortedList }}
-          commonId={selectedIds}
-          setCommonId={setSelectedIds}
-        />
-      )}
+      <div className="min-h-0 flex-1">
+        {(searchQuery || statusFilter) && filteredAndSortedList.length === 0 ? (
+          <div className="py-8 text-center text-base-content/40">
+            条件に一致する大会が見つかりません
+          </div>
+        ) : (
+          <CommonCheckboxList
+            props={{
+              type: "competition",
+              commonDataList: filteredAndSortedList,
+            }}
+            commonId={selectedIds}
+            setCommonId={setSelectedIds}
+          />
+        )}
+      </div>
 
       {/* Create Modal */}
       {createModalOpen && (
         <CompetitionFormModal
           mode="create"
+          courseList={courseList}
           onClose={() => setCreateModalOpen(false)}
           onSuccess={(newList) => {
             handleSuccess(newList, "大会を作成しました")
@@ -248,6 +262,7 @@ export function CompetitionView({
         <CompetitionFormModal
           mode="edit"
           competition={selectedCompetition}
+          courseList={courseList}
           onClose={() => setEditModalOpen(false)}
           onSuccess={(newList) => {
             handleSuccess(newList, "大会を更新しました")
@@ -268,6 +283,6 @@ export function CompetitionView({
           }}
         />
       )}
-    </>
+    </div>
   )
 }

--- a/@robopo/web/app/course/page.tsx
+++ b/@robopo/web/app/course/page.tsx
@@ -1,20 +1,23 @@
 import { PlusIcon } from "@heroicons/react/24/outline"
 import Link from "next/link"
 import { View } from "@/app/components/common/view"
+import { getCompetitionList } from "@/app/components/server/db"
 import {
   getCourseWithCompetition,
   groupByCourse,
 } from "@/app/lib/db/queries/queries"
-import type { SelectCourseWithCompetition } from "@/app/lib/db/schema"
 
 export const revalidate = 0
 
 export default async function Course() {
-  const initialCourseDataList: SelectCourseWithCompetition[] =
-    await groupByCourse(await getCourseWithCompetition())
+  const [courseRows, { competitions }] = await Promise.all([
+    getCourseWithCompetition(),
+    getCompetitionList(),
+  ])
+  const initialCourseDataList = groupByCourse(courseRows)
   return (
-    <div className="container mx-auto max-w-6xl px-4 py-6">
-      <div className="mb-6 flex items-center justify-between">
+    <div className="flex h-[calc(100dvh-3.5rem)] flex-col overflow-hidden px-4 py-6 sm:px-10 lg:px-16">
+      <div className="mb-4 flex shrink-0 items-center justify-between">
         <div>
           <h1 className="font-bold text-2xl text-base-content tracking-tight">
             コース一覧
@@ -31,8 +34,12 @@ export default async function Course() {
           新規作成
         </Link>
       </div>
-      <div className="rounded-2xl border border-base-300 bg-base-100 shadow-sm">
-        <View type="course" initialCommonDataList={initialCourseDataList} />
+      <div className="flex min-h-0 flex-1 flex-col rounded-2xl border border-base-300 bg-base-100 shadow-sm">
+        <View
+          type="course"
+          initialCommonDataList={initialCourseDataList}
+          competitionList={competitions}
+        />
       </div>
     </div>
   )

--- a/@robopo/web/app/lib/competition.ts
+++ b/@robopo/web/app/lib/competition.ts
@@ -1,5 +1,3 @@
-import type { SelectCompetition } from "@/app/lib/db/schema"
-
 export type CompetitionStatus = "before" | "active" | "ended" | "unknown"
 
 /**
@@ -9,7 +7,10 @@ export type CompetitionStatus = "before" | "active" | "ended" | "unknown"
  * - "ended": today is after the end date
  * - "unknown": start or end date is not set
  */
-export function getCompetitionStatus(c: SelectCompetition): CompetitionStatus {
+export function getCompetitionStatus(c: {
+  startDate: Date | null
+  endDate: Date | null
+}): CompetitionStatus {
   if (!c.startDate || !c.endDate) {
     return "unknown"
   }
@@ -31,6 +32,9 @@ export function getCompetitionStatus(c: SelectCompetition): CompetitionStatus {
 /**
  * Check if a competition is currently active (today falls within its date range).
  */
-export function isCompetitionActive(c: SelectCompetition): boolean {
+export function isCompetitionActive(c: {
+  startDate: Date | null
+  endDate: Date | null
+}): boolean {
   return getCompetitionStatus(c) === "active"
 }

--- a/@robopo/web/app/lib/db/queries/insert.ts
+++ b/@robopo/web/app/lib/db/queries/insert.ts
@@ -19,7 +19,10 @@ import {
 } from "@/app/lib/db/schema"
 
 export async function createCompetition(data: Omit<InsertCompetition, "id">) {
-  return await db.insert(competition).values(data)
+  return await db
+    .insert(competition)
+    .values(data)
+    .returning({ id: competition.id })
 }
 
 export async function createCourse(data: Omit<InsertCourse, "id">) {

--- a/@robopo/web/app/lib/db/queries/queries.ts
+++ b/@robopo/web/app/lib/db/queries/queries.ts
@@ -10,6 +10,7 @@ import {
   course,
   judge,
   player,
+  type SelectCompetitionWithCourse,
   type SelectCourse,
   type SelectCourseWithCompetition,
   type SelectJudgeWithCompetition,
@@ -410,7 +411,10 @@ function groupByIdWithCompetitions<
       map.set(row.id, existing)
     }
 
-    if (row.competitionName) {
+    if (
+      row.competitionName &&
+      !existing.competitionName.includes(row.competitionName)
+    ) {
       existing.competitionName.push(row.competitionName)
     }
   }
@@ -488,7 +492,7 @@ export async function getCourseWithCompetition() {
     .orderBy(course.id)
 }
 
-// Group flat rows by course
+// Group flat rows by course, collecting competition IDs and names
 export function groupByCourse(
   flatRows: {
     id: number
@@ -499,12 +503,127 @@ export function groupByCourse(
     competitionName: string | null
   }[],
 ): SelectCourseWithCompetition[] {
-  return groupByIdWithCompetitions(flatRows, (row) => ({
-    id: row.id,
-    name: row.name,
-    description: row.description,
-    createdAt: row.createdAt,
-    competitionId: row.competitionId,
-    competitionName: [],
-  }))
+  const map = new Map<number, SelectCourseWithCompetition>()
+
+  for (const row of flatRows) {
+    let existing = map.get(row.id)
+    if (!existing) {
+      existing = {
+        id: row.id,
+        name: row.name,
+        description: row.description,
+        createdAt: row.createdAt,
+        competitionId: row.competitionId,
+        competitionIds: [],
+        competitionName: [],
+      }
+      map.set(row.id, existing)
+    }
+    if (
+      row.competitionId &&
+      row.competitionName &&
+      !existing.competitionIds.includes(row.competitionId)
+    ) {
+      existing.competitionIds.push(row.competitionId)
+      existing.competitionName?.push(row.competitionName)
+    }
+  }
+
+  return Array.from(map.values())
+}
+
+// Get competitions with their courses
+export async function getCompetitionWithCourse() {
+  return await db
+    .select({
+      id: competition.id,
+      name: competition.name,
+      description: competition.description,
+      startDate: competition.startDate,
+      endDate: competition.endDate,
+      createdAt: competition.createdAt,
+      courseId: course.id,
+      courseName: course.name,
+    })
+    .from(competition)
+    .leftJoin(
+      competitionCourse,
+      eq(competition.id, competitionCourse.competitionId),
+    )
+    .leftJoin(course, eq(competitionCourse.courseId, course.id))
+    .orderBy(competition.id)
+}
+
+// Group flat rows by competition, collecting course IDs and names
+export function groupByCompetition(
+  flatRows: {
+    id: number
+    name: string
+    description: string | null
+    startDate: Date | null
+    endDate: Date | null
+    createdAt: Date | null
+    courseId: number | null
+    courseName: string | null
+  }[],
+): SelectCompetitionWithCourse[] {
+  const map = new Map<number, SelectCompetitionWithCourse>()
+
+  for (const row of flatRows) {
+    let existing = map.get(row.id)
+    if (!existing) {
+      existing = {
+        id: row.id,
+        name: row.name,
+        description: row.description,
+        startDate: row.startDate,
+        endDate: row.endDate,
+        createdAt: row.createdAt,
+        courseIds: [],
+        courseNames: [],
+      }
+      map.set(row.id, existing)
+    }
+    if (
+      row.courseId &&
+      row.courseName &&
+      !existing.courseIds.includes(row.courseId)
+    ) {
+      existing.courseIds.push(row.courseId)
+      existing.courseNames.push(row.courseName)
+    }
+  }
+
+  return Array.from(map.values())
+}
+
+// Count how many competitions a course is linked to
+export async function getCourseCompetitionCount(
+  courseId: number,
+): Promise<number> {
+  const result = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(competitionCourse)
+    .where(eq(competitionCourse.courseId, courseId))
+  return result[0]?.count ?? 0
+}
+
+// Batch: check if any of the given course IDs have competition links
+export async function getLinkedCourseIds(
+  courseIds: number[],
+): Promise<number[]> {
+  if (courseIds.length === 0) {
+    return []
+  }
+  const result = await db
+    .select({ courseId: competitionCourse.courseId })
+    .from(competitionCourse)
+    .where(
+      sql`${competitionCourse.courseId} IN (${sql.join(
+        courseIds.map((id) => sql`${id}`),
+        sql`, `,
+      )})`,
+    )
+    .groupBy(competitionCourse.courseId)
+  return result.map((r) => r.courseId)
 }

--- a/@robopo/web/app/lib/db/schema.ts
+++ b/@robopo/web/app/lib/db/schema.ts
@@ -194,5 +194,17 @@ export type SelectCourseWithCompetition = {
   description: string | null
   createdAt: Date | null
   competitionId: number | null
+  competitionIds: number[]
   competitionName: string[] | null
+}
+
+export type SelectCompetitionWithCourse = {
+  id: number
+  name: string
+  description: string | null
+  startDate: Date | null
+  endDate: Date | null
+  createdAt: Date | null
+  courseIds: number[]
+  courseNames: string[]
 }

--- a/@robopo/web/test/unit/components/common/commonList.test.tsx
+++ b/@robopo/web/test/unit/components/common/commonList.test.tsx
@@ -35,6 +35,8 @@ const competitions = [
     startDate: null,
     endDate: null,
     createdAt: new Date(),
+    courseIds: [],
+    courseNames: [],
   },
   {
     id: 2,
@@ -43,6 +45,8 @@ const competitions = [
     startDate: null,
     endDate: null,
     createdAt: new Date(),
+    courseIds: [],
+    courseNames: [],
   },
 ]
 
@@ -231,6 +235,7 @@ describe("Competition table columns", () => {
     const headerTexts = Array.from(headers).map((h) => h.textContent?.trim())
     expect(headerTexts).toContain("ID")
     expect(headerTexts).toContain("名前")
+    expect(headerTexts).toContain("コース")
     expect(headerTexts).toContain("説明")
     expect(headerTexts).toContain("開催日")
     expect(headerTexts).toContain("終了日")
@@ -248,8 +253,8 @@ describe("Competition table columns", () => {
     )
     const cells = container.querySelectorAll("tbody tr:first-child td")
     const cellTexts = Array.from(cells).map((c) => c.textContent?.trim())
-    // description, startDate, endDate should all be "-"
-    expect(cellTexts.filter((t) => t === "-")).toHaveLength(3)
+    // courses, description, startDate, endDate should all be "-"
+    expect(cellTexts.filter((t) => t === "-")).toHaveLength(4)
   })
 
   test("renders formatted dates for non-null startDate and endDate", () => {
@@ -262,6 +267,8 @@ describe("Competition table columns", () => {
         startDate: new Date("2026-04-01T00:00:00"),
         endDate: new Date("2026-04-30T00:00:00"),
         createdAt: new Date(),
+        courseIds: [1],
+        courseNames: ["テストコース"],
       },
     ]
     const { container } = render(


### PR DESCRIPTION
## Summary by Sourcery

モーダルベースのUI、より豊富な連携メタデータ、削除ガードを用いて、コースとコンペティションの紐づけおよび削除フローを強化し、あわせてコンペティション管理機能を拡張してコースとの関連付けに対応し、テーブルレイアウトを改善します。

New Features:
- チェックボックス選択によるコンペティションのコースへの割り当て用モーダルUIを追加し、専用のAPIエンドポイント経由でリンクを更新できるようにします。
- コンペティションとコースの関係モデルを導入し、新しい種別やグルーピング用クエリを追加して、双方向にリンクされたIDと名前を参照できるようにします。
- 設定ビューから、関連付けるコースを指定してコンペティションの新規作成および編集ができるようにし、任意で複数コース選択も可能にします。

Bug Fixes:
- コンペティションとまだリンクされているコースを削除できないようにし、共有削除モーダル内で削除APIからの意味のあるエラーメッセージを表示します。

Enhancements:
- コースとコンペティションの一覧レイアウトを、Flexベースのスクロール可能なパネルに刷新し、利用回数やリンク済みアイテムを示すバッジをより分かりやすくします。
- コース側にはコンペティションの利用回数を、コンペティション側には紐づくコース一覧をテーブルに表示し、特定のコースを利用しているすべてのコンペティションを確認できる詳細モーダルを追加します。
- コンペティション作成時にIDを返却するようにし、その後に行う紐づけレコードの追加を確実に実行できるようにします。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance course–competition assignment and deletion flows with modal-based UI, richer linkage metadata, and guarded deletions, while extending competition management to handle course associations and improving table layouts.

New Features:
- Add modal UI for assigning competitions to a course with checkbox selection and updating links via a dedicated API endpoint.
- Introduce a competition–course relationship model, including new types and grouping queries that expose linked IDs and names in both directions.
- Allow competitions to be created and edited with associated courses via the configuration view, including optional multi-course selection.

Bug Fixes:
- Prevent deletion of courses that are still linked to competitions and surface meaningful error messages from delete APIs in the shared delete modal.

Enhancements:
- Refine course and competition list layouts to be flex-based, scrollable panels with clearer badges for usage counts and linked items.
- Show competition usage counts for courses and course lists for competitions in tables, including a detail modal for viewing all competitions using a course.
- Return IDs when creating competitions so subsequent linkage inserts can be performed reliably.

</details>