### PR TITLE
feat: add navigation drawer

### DIFF
--- a/@robopo/web/app/components/header/header.tsx
+++ b/@robopo/web/app/components/header/header.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image"
 import Link from "next/link"
 import { useState } from "react"
+import { NavigationDrawer } from "@/app/components/header/navigationDrawer"
 import { useNavigationGuard } from "@/app/hooks/useNavigationGuard"
 import { SIGN_IN_CONST, SIGN_OUT_CONST } from "@/app/lib/const"
 import { signOut } from "@/lib/auth-client"
@@ -77,6 +78,9 @@ export function Header({ session }: Props) {
               </>
             )}
           </button>
+        ) : null}
+        {session?.user ? (
+          <NavigationDrawer />
         ) : (
           <Link
             href={SIGN_IN_CONST.href}

--- a/@robopo/web/app/components/header/navigationDrawer.tsx
+++ b/@robopo/web/app/components/header/navigationDrawer.tsx
@@ -1,0 +1,247 @@
+"use client"
+
+import { Bars3Icon, XMarkIcon } from "@heroicons/react/24/outline"
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { useCallback, useEffect, useRef, useState } from "react"
+import { createPortal } from "react-dom"
+import type { NavItem } from "@/app/lib/const"
+import {
+  COMPETITION_MANAGEMENT_LIST,
+  NAVIGATION_GENERAL_LIST,
+} from "@/app/lib/const"
+
+function NavLink({
+  item,
+  active,
+  index,
+  isOpen,
+  onClick,
+}: {
+  item: NavItem
+  active: boolean
+  index: number
+  isOpen: boolean
+  onClick: () => void
+}) {
+  return (
+    <Link
+      href={item.href}
+      onClick={onClick}
+      className={`drawer-item group flex items-center gap-3 rounded-lg px-3 py-2.5 font-medium text-sm transition-all duration-200 ${
+        active
+          ? "border-primary border-l-4 bg-primary/10 text-primary"
+          : "border-transparent border-l-4 text-base-content/70 hover:bg-base-200 hover:text-base-content active:scale-[0.98]"
+      } ${isOpen ? "drawer-item-visible" : ""}`}
+      style={{ "--drawer-item-index": index } as React.CSSProperties}
+    >
+      <span
+        className={`flex size-6 shrink-0 items-center justify-center transition-transform duration-200 ${
+          active ? "" : "group-hover:scale-110"
+        }`}
+      >
+        {item.icon}
+      </span>
+      {item.label}
+    </Link>
+  )
+}
+
+export function NavigationDrawer() {
+  const [isOpen, setIsOpen] = useState(false)
+  const [mounted, setMounted] = useState(false)
+  const [hasBeenOpened, setHasBeenOpened] = useState(false)
+  const pathname = usePathname()
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const drawerRef = useRef<HTMLDivElement>(null)
+
+  const close = useCallback(() => {
+    setIsOpen(false)
+    // Return focus to trigger button
+    requestAnimationFrame(() => {
+      triggerRef.current?.focus()
+    })
+  }, [])
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  // Escape key handler
+  useEffect(() => {
+    if (!isOpen) {
+      return
+    }
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        close()
+      }
+    }
+    document.addEventListener("keydown", onKeyDown)
+    return () => document.removeEventListener("keydown", onKeyDown)
+  }, [isOpen, close])
+
+  // Focus trap
+  useEffect(() => {
+    if (!isOpen || !drawerRef.current) {
+      return
+    }
+    const drawer = drawerRef.current
+    const focusableSelector =
+      'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])'
+
+    // Focus the close button after the drawer slide-in animation starts
+    const rafId = requestAnimationFrame(() => {
+      const firstFocusable =
+        drawer.querySelector<HTMLElement>(focusableSelector)
+      firstFocusable?.focus()
+    })
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== "Tab") {
+        return
+      }
+      const focusables = drawer.querySelectorAll<HTMLElement>(focusableSelector)
+      const first = focusables[0]
+      const last = focusables[focusables.length - 1]
+
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault()
+        last?.focus()
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault()
+        first?.focus()
+      }
+    }
+
+    document.addEventListener("keydown", onKeyDown)
+    return () => {
+      cancelAnimationFrame(rafId)
+      document.removeEventListener("keydown", onKeyDown)
+    }
+  }, [isOpen])
+
+  // Prevent body scroll
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = "hidden"
+    } else {
+      document.body.style.overflow = ""
+    }
+    return () => {
+      document.body.style.overflow = ""
+    }
+  }, [isOpen])
+
+  const isActive = (href: string) => {
+    if (href === "/") {
+      return pathname === "/"
+    }
+    return pathname.startsWith(href)
+  }
+
+  const allItems = [...NAVIGATION_GENERAL_LIST, ...COMPETITION_MANAGEMENT_LIST]
+  const dividerIndex = NAVIGATION_GENERAL_LIST.length
+
+  const drawerOverlay = (
+    <div
+      className={`fixed inset-0 z-50 transition-opacity duration-300 ${
+        isOpen
+          ? "pointer-events-auto opacity-100"
+          : "pointer-events-none opacity-0"
+      }`}
+    >
+      {/* Backdrop */}
+      <button
+        type="button"
+        className="absolute inset-0 bg-black/40 backdrop-blur-sm"
+        onClick={close}
+        tabIndex={-1}
+        aria-label="メニューを閉じる"
+      />
+
+      {/* Drawer panel */}
+      <div
+        ref={drawerRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="ナビゲーションメニュー"
+        className={`absolute top-0 right-0 h-full w-72 bg-base-100 shadow-2xl ${
+          isOpen
+            ? "drawer-slide-in"
+            : hasBeenOpened
+              ? "drawer-slide-out"
+              : "translate-x-full"
+        }`}
+      >
+        {/* Header */}
+        <div className="flex h-14 items-center justify-between border-base-300 border-b px-4">
+          <span
+            className={`drawer-title font-bold text-base text-base-content/80 ${isOpen ? "drawer-title-visible" : ""}`}
+          >
+            メニュー
+          </span>
+          <button
+            type="button"
+            onClick={close}
+            className="btn btn-ghost btn-sm btn-square rounded-full transition-transform duration-200 hover:rotate-90 active:scale-90"
+            aria-label="メニューを閉じる"
+          >
+            <XMarkIcon className="size-5" />
+          </button>
+        </div>
+
+        {/* Navigation links */}
+        <nav
+          aria-label="メインナビゲーション"
+          className="flex flex-col gap-1 p-3"
+        >
+          {allItems.map((item, i) => (
+            <div key={item.href}>
+              {i === dividerIndex && (
+                <>
+                  <div
+                    className={`drawer-divider my-2 border-base-300 border-t ${isOpen ? "drawer-divider-visible" : ""}`}
+                    style={{ "--drawer-item-index": i } as React.CSSProperties}
+                  />
+                  <span
+                    className={`drawer-item mb-1 block px-3 font-semibold text-base-content/40 text-xs uppercase tracking-wider ${isOpen ? "drawer-item-visible" : ""}`}
+                    style={{ "--drawer-item-index": i } as React.CSSProperties}
+                  >
+                    大会管理
+                  </span>
+                </>
+              )}
+              <NavLink
+                item={item}
+                active={isActive(item.href)}
+                index={i}
+                isOpen={isOpen}
+                onClick={close}
+              />
+            </div>
+          ))}
+        </nav>
+      </div>
+    </div>
+  )
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => {
+          setIsOpen(true)
+          setHasBeenOpened(true)
+        }}
+        className="btn btn-ghost btn-sm btn-square rounded-full transition-transform duration-200 active:scale-90"
+        aria-label="メニューを開く"
+      >
+        <Bars3Icon className="size-5" />
+      </button>
+
+      {mounted && createPortal(drawerOverlay, document.body)}
+    </>
+  )
+}

--- a/@robopo/web/app/globals.css
+++ b/@robopo/web/app/globals.css
@@ -71,6 +71,100 @@
   }
 }
 
+/* Drawer animations */
+.drawer-slide-in {
+  animation: drawerIn 350ms cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+.drawer-slide-out {
+  animation: drawerOut 250ms cubic-bezier(0.4, 0, 1, 1) forwards;
+}
+
+@keyframes drawerIn {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes drawerOut {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(100%);
+  }
+}
+
+/* Drawer staggered item entrance */
+.drawer-item {
+  opacity: 0;
+  transform: translateX(20px);
+  transition:
+    opacity 300ms cubic-bezier(0.16, 1, 0.3, 1)
+    calc(var(--drawer-item-index, 0) * 40ms + 100ms),
+    transform 300ms cubic-bezier(0.16, 1, 0.3, 1)
+    calc(var(--drawer-item-index, 0) * 40ms + 100ms);
+}
+
+.drawer-item-visible {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.drawer-divider {
+  opacity: 0;
+  transition: opacity 300ms cubic-bezier(0.16, 1, 0.3, 1)
+    calc(var(--drawer-item-index, 0) * 40ms + 80ms);
+}
+
+.drawer-divider-visible {
+  opacity: 1;
+}
+
+.drawer-title {
+  opacity: 0;
+  transform: translateY(-8px);
+  transition:
+    opacity 250ms cubic-bezier(0.16, 1, 0.3, 1) 80ms,
+    transform 250ms cubic-bezier(0.16, 1, 0.3, 1) 80ms;
+}
+
+.drawer-title-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .drawer-slide-in,
+  .drawer-slide-out {
+    animation: none;
+  }
+
+  .drawer-slide-in {
+    transform: translateX(0);
+  }
+
+  .drawer-slide-out {
+    transform: translateX(100%);
+  }
+
+  .drawer-item,
+  .drawer-divider,
+  .drawer-title {
+    transition: none;
+  }
+
+  .drawer-item-visible,
+  .drawer-divider-visible,
+  .drawer-title-visible {
+    opacity: 1;
+    transform: none;
+  }
+}
+
 /* Modern table styling */
 .table th {
   font-weight: 600;

--- a/@robopo/web/app/lib/const.tsx
+++ b/@robopo/web/app/lib/const.tsx
@@ -3,6 +3,7 @@ import {
   ArrowRightStartOnRectangleIcon,
   ArrowUpCircleIcon,
   ArrowUturnLeftIcon,
+  CalculatorIcon,
   HomeIcon,
   PlayIcon,
   TrophyIcon,
@@ -57,6 +58,19 @@ export const COMPETITION_MANAGEMENT_LIST: NavItem[] = [
     label: "採点者一覧",
     href: "/judge",
     icon: <UserCircleIcon className="size-6" />,
+  },
+]
+
+export const NAVIGATION_GENERAL_LIST: NavItem[] = [
+  {
+    label: "ホーム",
+    href: "/",
+    icon: <HomeIcon className="size-6" />,
+  },
+  {
+    label: "集計結果",
+    href: "/summary" as Route,
+    icon: <CalculatorIcon className="size-6" />,
   },
 ]
 


### PR DESCRIPTION
## Summary by Sourcery

認証済みユーザー向けに、アニメーション付きのスライドイン／スライドアウト動作と更新されたナビゲーション構造を備えたモバイル用ナビゲーションドロワーを追加します。

New Features:
- サインイン済みユーザー向けに、カテゴリ別に整理されたナビゲーションリンクを持つオーバーレイメニューを提供する `NavigationDrawer` コンポーネントを導入。
- ヘッダーナビゲーションで使用するため、ホームおよびサマリーへのリンクとアイコンを含む汎用ナビゲーションリストを追加。

Enhancements:
- ドロワーのスライドイン／スライドアウト遷移用に、CSS のキーフレームアニメーションと、低速アニメーション（低動作環境）への対応を追加。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a mobile navigation drawer for authenticated users with animated slide-in/out behavior and updated navigation structure.

New Features:
- Introduce a NavigationDrawer component that provides an overlay menu with categorized navigation links for signed-in users.
- Add a general navigation list including home and summary links with icons for use in header navigation.

Enhancements:
- Add CSS keyframe animations and reduced-motion handling for the drawer slide-in/out transitions.

</details>