### PR TITLE
feat: extend overall preview course

### DIFF
--- a/@robopo/web/app/components/course/field.tsx
+++ b/@robopo/web/app/components/course/field.tsx
@@ -18,6 +18,7 @@ type FieldProps = {
   botDirection?: MissionValue
   botAfterPosition?: { row: number; col: number }
   botAfterAngle?: number
+  isPlaying?: boolean
   nextMission?: MissionValue[]
   onPanelClick: (row: number, col: number) => void
   onPanelPointerDown?: (row: number, col: number) => void
@@ -34,6 +35,7 @@ export function Field({
   botDirection,
   botAfterPosition,
   botAfterAngle,
+  isPlaying = false,
   nextMission,
   onPanelClick,
   onPanelPointerDown,
@@ -135,7 +137,7 @@ export function Field({
           afterCol={botAfterPosition?.col}
           afterAngle={botAfterAngle}
           responsive
-          opacity={0.6}
+          opacity={isPlaying ? 1 : 0.6}
         />
       )}
     </div>

--- a/@robopo/web/app/components/course/missionList.tsx
+++ b/@robopo/web/app/components/course/missionList.tsx
@@ -22,7 +22,8 @@ import {
   PlusIcon,
   TrashIcon,
 } from "@heroicons/react/24/outline"
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { PlayIcon, StopIcon } from "@heroicons/react/24/solid"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
   type FieldState,
   findGoal,
@@ -89,6 +90,9 @@ export function MissionList({
   setMissionPanelHints,
   onInsertPreview,
   invalidMissionMap,
+  isPlaying = false,
+  onTogglePlay,
+  canPlay = false,
 }: {
   field: FieldState
   mission: MissionState
@@ -106,6 +110,9 @@ export function MissionList({
   setMissionPanelHints: React.Dispatch<React.SetStateAction<(number | null)[]>>
   onInsertPreview?: (preview: InsertPreview | null) => void
   invalidMissionMap?: Map<number, string>
+  isPlaying?: boolean
+  onTogglePlay?: () => void
+  canPlay?: boolean
 }) {
   const [items, setItems] = useState<MissionPairItem[]>([])
   const [insertingAt, setInsertingAt] = useState<number | null>(null)
@@ -321,11 +328,34 @@ export function MissionList({
           pt
         </span>
         <div className="flex gap-1">
+          {onTogglePlay && (
+            <div
+              className="tooltip tooltip-bottom"
+              data-tip={isPlaying ? "停止" : "全体プレビュー"}
+            >
+              <button
+                type="button"
+                className={`btn btn-xs ${
+                  isPlaying
+                    ? "btn-error text-white"
+                    : "bg-gradient-to-r from-primary to-secondary text-white shadow-sm hover:shadow-md"
+                } transition-all duration-200`}
+                onClick={onTogglePlay}
+                disabled={!canPlay && !isPlaying}
+              >
+                {isPlaying ? (
+                  <StopIcon className="size-3.5" />
+                ) : (
+                  <PlayIcon className="size-3.5" />
+                )}
+              </button>
+            </div>
+          )}
           <button
             type="button"
             className="btn btn-ghost btn-xs"
             onClick={undoMission}
-            disabled={!canUndoMission}
+            disabled={!canUndoMission || isPlaying}
             title="元に戻す"
           >
             <ArrowUturnLeftIcon className="size-4" />
@@ -334,7 +364,7 @@ export function MissionList({
             type="button"
             className="btn btn-ghost btn-xs"
             onClick={redoMission}
-            disabled={!canRedoMission}
+            disabled={!canRedoMission || isPlaying}
             title="やり直す"
           >
             <ArrowUturnRightIcon className="size-4" />
@@ -396,6 +426,7 @@ export function MissionList({
                   isSelected={selectedMissionIndex === idx}
                   isInvalid={invalidMissionMap?.has(idx) ?? false}
                   invalidReason={invalidMissionMap?.get(idx)}
+                  isPlaying={isPlaying}
                   onSelect={() => setSelectedMissionIndex(idx)}
                   onDelete={() => handleDeleteMission(idx)}
                   onUpdate={(mt, p, pt) => handleUpdateMission(idx, mt, p, pt)}
@@ -416,7 +447,11 @@ export function MissionList({
                 />
                 {insertingAt === idx && (
                   <InsertMissionRow
-                    defaultPanelId={panelPositions?.positions[idx] ?? null}
+                    defaultPanelId={
+                      panelPositions?.positions[idx + 1] ??
+                      panelPositions?.positions[idx] ??
+                      null
+                    }
                     onInsert={handleInsertMission}
                     onCancel={() => {
                       setInsertingAt(null)
@@ -625,6 +660,7 @@ function SortableMissionRow({
   isSelected,
   isInvalid,
   invalidReason,
+  isPlaying = false,
   onSelect,
   onDelete,
   onUpdate,
@@ -637,6 +673,7 @@ function SortableMissionRow({
   isSelected: boolean
   isInvalid?: boolean
   invalidReason?: string
+  isPlaying?: boolean
   onSelect: () => void
   onDelete: () => void
   onUpdate: (
@@ -664,7 +701,15 @@ function SortableMissionRow({
   const missionType = item.mission[0]
   const missionParam = item.mission[1]
 
+  const rowRef = useRef<HTMLDivElement>(null)
   const [showMobileError, setShowMobileError] = useState(false)
+
+  useEffect(() => {
+    // Skip auto-scroll on mobile to keep the course field visible during playback
+    if (isSelected && isPlaying && rowRef.current && window.innerWidth >= 640) {
+      rowRef.current.scrollIntoView({ behavior: "smooth", block: "nearest" })
+    }
+  }, [isSelected, isPlaying])
 
   useEffect(() => {
     if (!isInvalid) {
@@ -685,7 +730,11 @@ function SortableMissionRow({
   return (
     // biome-ignore lint/a11y/useSemanticElements: sortable container with drag handle
     <div
-      ref={setNodeRef}
+      ref={(node) => {
+        setNodeRef(node)
+        ;(rowRef as React.MutableRefObject<HTMLDivElement | null>).current =
+          node
+      }}
       role="button"
       tabIndex={0}
       style={style}
@@ -736,6 +785,7 @@ function SortableMissionRow({
               className="input input-bordered input-xs w-12 font-mono"
               min={1}
               max={25}
+              disabled={isPlaying}
               value={panelNumber ?? ""}
               onChange={(e) => {
                 const num = Number(e.target.value)
@@ -761,6 +811,7 @@ function SortableMissionRow({
               missionParam={missionParam}
               pointEntry={point ?? 0}
               onUpdate={onUpdate}
+              disabled={isPlaying}
             />
           ) : (
             <span>
@@ -829,6 +880,7 @@ function InlineMissionEditor({
   missionParam,
   pointEntry,
   onUpdate,
+  disabled = false,
 }: {
   missionType: MissionValue
   missionParam: MissionValue
@@ -838,6 +890,7 @@ function InlineMissionEditor({
     param: MissionValue,
     pointEntry: PointEntry,
   ) => void
+  disabled?: boolean
 }) {
   const isMove = missionType === "mf" || missionType === "mb"
   const isTurn = missionType === "tr" || missionType === "tl"
@@ -848,9 +901,8 @@ function InlineMissionEditor({
     pointEntry !== null && !Array.isArray(pointEntry) ? pointEntry : 0
 
   return (
-    // biome-ignore lint/a11y/useSemanticElements: inline editor form group
-    <div
-      role="group"
+    <fieldset
+      disabled={disabled}
       className="space-y-2"
       onClick={(e) => e.stopPropagation()}
       onKeyDown={(e) => e.stopPropagation()}
@@ -1033,7 +1085,7 @@ function InlineMissionEditor({
           )}
         </div>
       )}
-    </div>
+    </fieldset>
   )
 }
 

--- a/@robopo/web/app/course/edit/courseEdit.tsx
+++ b/@robopo/web/app/course/edit/courseEdit.tsx
@@ -28,6 +28,7 @@ type CourseEditProps = {
   botAfterAngle?: number
   onRouteAdded?: (row: number, col: number) => void
   isolatedPanels?: Set<string>
+  isPlaying?: boolean
 }
 
 export default function CourseEdit({
@@ -46,6 +47,7 @@ export default function CourseEdit({
   botAfterAngle,
   onRouteAdded,
   isolatedPanels,
+  isPlaying = false,
 }: CourseEditProps) {
   const [isDragging, setIsDragging] = useState(false)
   const lastCellRef = useRef<{ r: number; c: number } | null>(null)
@@ -85,6 +87,9 @@ export default function CourseEdit({
   )
 
   function handlePanelClick(row: number, col: number) {
+    if (isPlaying) {
+      return
+    }
     // Skip if already handled by pointerDown (prevents double-fire on touch)
     if (pointerHandledRef.current) {
       pointerHandledRef.current = false
@@ -95,6 +100,9 @@ export default function CourseEdit({
   }
 
   function handlePointerDown(row: number, col: number) {
+    if (isPlaying) {
+      return
+    }
     pointerHandledRef.current = true
     pushHistory()
     setIsDragging(true)
@@ -149,6 +157,7 @@ export default function CourseEdit({
               botDirection={botDirection}
               botAfterPosition={botAfterPosition}
               botAfterAngle={botAfterAngle}
+              isPlaying={isPlaying}
               onPanelClick={handlePanelClick}
               onPanelPointerDown={handlePointerDown}
               onPanelPointerEnter={handlePointerEnter}

--- a/@robopo/web/app/course/edit/courseEditContext.tsx
+++ b/@robopo/web/app/course/edit/courseEditContext.tsx
@@ -49,6 +49,7 @@ export type CourseEditState = {
   canRedoMission: boolean
   pushMissionHistory: () => void
   markInitialized: () => void
+  resetInitialized: () => void
   nameError: string
   setNameError: React.Dispatch<React.SetStateAction<string>>
 }
@@ -82,6 +83,7 @@ const dummy: CourseEditState = {
   canRedoMission: false,
   pushMissionHistory: () => {},
   markInitialized: () => {},
+  resetInitialized: () => {},
   nameError: "",
   setNameError: () => {},
 }
@@ -106,6 +108,10 @@ export function CourseEditProvider({
 
   const markInitialized = useCallback(() => {
     initializedRef.current = true
+  }, [])
+
+  const resetInitialized = useCallback(() => {
+    initializedRef.current = false
   }, [])
 
   const [nameError, setNameError] = useState("")
@@ -259,6 +265,7 @@ export function CourseEditProvider({
         canRedoMission,
         pushMissionHistory,
         markInitialized,
+        resetInitialized,
         nameError,
         setNameError,
       }}

--- a/@robopo/web/app/course/edit/editorPage.tsx
+++ b/@robopo/web/app/course/edit/editorPage.tsx
@@ -5,7 +5,7 @@ import {
   CheckCircleIcon,
   ExclamationTriangleIcon,
 } from "@heroicons/react/24/outline"
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
   buildPreviewMission,
   type InsertPreview,
@@ -15,6 +15,8 @@ import {
   deserializeField,
   deserializeMission,
   deserializePoint,
+  findStart,
+  missionStatePair,
   serializeField,
   serializeMission,
   serializePoint,
@@ -64,6 +66,7 @@ export function EditorPage({
     missionPanelHints,
     setMissionPanelHints,
     markInitialized,
+    resetInitialized,
     nameError,
   } = useCourseEdit()
 
@@ -77,6 +80,66 @@ export function EditorPage({
   const [saveState, setSaveState] = useState<SaveState>("idle")
   const [showSaveWarning, setShowSaveWarning] = useState(false)
   const [mounted, setMounted] = useState(false)
+  const [isPlaying, setIsPlaying] = useState(false)
+  const [playbackIndex, setPlaybackIndex] = useState<number | null>(null)
+  const playbackTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  const playbackCount = useMemo(
+    () => missionStatePair(mission).length,
+    [mission],
+  )
+
+  const canPlay =
+    playbackCount > 0 && mission[0] !== null && findStart(field) !== null
+
+  const clearPlaybackTimer = useCallback(() => {
+    if (playbackTimerRef.current) {
+      clearInterval(playbackTimerRef.current)
+      playbackTimerRef.current = null
+    }
+  }, [])
+
+  // Auto-advance playback timer
+  useEffect(() => {
+    if (!isPlaying) {
+      setPlaybackIndex(null)
+      clearPlaybackTimer()
+      return
+    }
+
+    setPlaybackIndex(0)
+
+    playbackTimerRef.current = setInterval(() => {
+      setPlaybackIndex((prev) => {
+        if (prev === null || prev + 1 >= playbackCount) {
+          setIsPlaying(false)
+          return null
+        }
+        return prev + 1
+      })
+    }, 2400)
+
+    return clearPlaybackTimer
+  }, [isPlaying, playbackCount, clearPlaybackTimer])
+
+  const wasPlayingRef = useRef(false)
+
+  // Sync selectedMissionIndex from playback index
+  useEffect(() => {
+    if (isPlaying) {
+      wasPlayingRef.current = true
+      setSelectedMissionIndex(playbackIndex)
+      setInsertPreview(null)
+    } else if (wasPlayingRef.current) {
+      // Playback just stopped — clear selection
+      wasPlayingRef.current = false
+      setSelectedMissionIndex(null)
+    }
+  }, [isPlaying, playbackIndex])
+
+  const handleTogglePlay = useCallback(() => {
+    setIsPlaying((prev) => !prev)
+  }, [])
 
   const validation = useCourseValidation({ field, mission, name, nameError })
   const saveBlockMessage = mounted ? validation.saveBlockMessage : null
@@ -92,6 +155,8 @@ export function EditorPage({
   }, [saveBlockMessage])
 
   useEffect(() => {
+    // Reset before loading so re-runs (e.g. React strict mode) don't falsely mark dirty
+    resetInitialized()
     if (courseData) {
       if (courseData.field) {
         setField(deserializeField(courseData.field))
@@ -111,6 +176,8 @@ export function EditorPage({
       if (courseData.courseOutRule) {
         setCourseOutRule(courseData.courseOutRule)
       }
+      // Default to route tool when editing an existing course
+      setSelectedTool("route")
     }
     // Mark initialized after initial data load so dirty tracking starts
     markInitialized()
@@ -122,7 +189,9 @@ export function EditorPage({
     setName,
     setDescription,
     setCourseOutRule,
+    setSelectedTool,
     markInitialized,
+    resetInitialized,
   ])
 
   const robotPreview = useMemo(() => {
@@ -250,6 +319,7 @@ export function EditorPage({
             botAfterAngle={robotPreview?.afterAngle}
             onRouteAdded={handleRouteAdded}
             isolatedPanels={validation.isolatedPanels}
+            isPlaying={isPlaying}
           />
         </div>
         <div className="sm:mx-4 sm:min-h-0 sm:w-full sm:justify-self-start sm:overflow-y-auto">
@@ -272,8 +342,11 @@ export function EditorPage({
             setMissionPanelHints={setMissionPanelHints}
             onInsertPreview={setInsertPreview}
             invalidMissionMap={validation.invalidMissionMap}
-            disabled={isBusy}
+            disabled={isBusy || isPlaying}
             courseId={courseId}
+            isPlaying={isPlaying}
+            onTogglePlay={handleTogglePlay}
+            canPlay={canPlay}
           />
         </div>
       </div>

--- a/@robopo/web/app/course/edit/missionEdit.tsx
+++ b/@robopo/web/app/course/edit/missionEdit.tsx
@@ -30,6 +30,9 @@ type MissionEditProps = {
   invalidMissionMap?: Map<number, string>
   disabled?: boolean
   courseId?: number | null
+  isPlaying?: boolean
+  onTogglePlay?: () => void
+  canPlay?: boolean
 }
 
 export default function MissionEdit({
@@ -53,6 +56,9 @@ export default function MissionEdit({
   invalidMissionMap,
   disabled = false,
   courseId,
+  isPlaying,
+  onTogglePlay,
+  canPlay,
 }: MissionEditProps) {
   const {
     name,
@@ -107,6 +113,9 @@ export default function MissionEdit({
             setMissionPanelHints={setMissionPanelHints}
             onInsertPreview={onInsertPreview}
             invalidMissionMap={invalidMissionMap}
+            isPlaying={isPlaying}
+            onTogglePlay={onTogglePlay}
+            canPlay={canPlay}
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary by Sourcery

コースエディタにフルコース再生モードを追加し、初期化処理および変更検知（dirty tracking）の挙動をより厳密にしました。

新機能:
- 条件が有効な場合に、コース内のすべてのミッションを順番にプレビューできる全体ミッション再生コントロールを追加。

バグ修正:
- データ読み込み前にコース編集の初期化状態をリセットし、コンポーネントの再マウント時に誤って変更あり（dirty）と判定される問題を防止。
- 再生中のフィールドロボットのプレビュー不透明度を調整し、視認性を向上。

改善:
- 再生中は、ミッション編集、取り消し/やり直し、およびフィールド上での操作を無効化して、競合する変更が発生しないように制御。
- デスクトップ環境では再生中に選択中のミッション行へ自動スクロールし、インラインのミッションエディタを `fieldset` によりフォームフィールドに適した形に調整。
- 既存コースを読み込む際、エディタのデフォルトツールをルートツールに設定し、ミッション挿入時のデフォルトパネル選択を修正。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a full-course playback mode to the course editor and tighten initialization/dirty tracking behavior.

New Features:
- Introduce an overall mission playback control that sequentially previews all missions in a course when conditions are valid.

Bug Fixes:
- Reset course edit initialization state before loading data to avoid false dirty-state detection under repeated mounts.
- Adjust field robot preview opacity during playback for clearer visualization.

Enhancements:
- Disable mission editing, undo/redo, and field interactions while playback is running to prevent conflicting changes.
- Auto-scroll the selected mission row on desktop during playback and adjust inline mission editor to be form-field friendly via fieldset.
- Default the editor to the route tool when loading an existing course and correct default panel selection when inserting missions.

</details>