### PR TITLE
feat: enable react compiler

### DIFF
--- a/.mise/prepare-state.toml
+++ b/.mise/prepare-state.toml
@@ -1,3 +1,3 @@
 [providers.bun]
-"bun.lock" = "4070f0f9e65c48b6c8e5e72faf6a139bf18a1a1e7fb6cda20032b20890c1a408"
+"bun.lock" = "ac93e62fe6600cbe221fea0d01acaaf3145d128dc379521df2fd69c5144b4e42"
 "package.json" = "7fb2193f773ad401981ab6e757ccdd3c79e0ace156fe984a0b9413f22140a6b2"

--- a/@robopo/web/app/challenge/[competitionId]/[courseId]/[playerId]/audioContext.tsx
+++ b/@robopo/web/app/challenge/[competitionId]/[courseId]/[playerId]/audioContext.tsx
@@ -2,14 +2,7 @@
 
 import { SpeakerWaveIcon, SpeakerXMarkIcon } from "@heroicons/react/24/outline"
 import type React from "react"
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from "react"
+import { createContext, useContext, useEffect, useRef, useState } from "react"
 
 export type AudioContextType = {
   muted: boolean
@@ -50,7 +43,7 @@ export function SoundController() {
   const { muted, setMuted } = useAudioContext()
   const previewRef = useRef<HTMLAudioElement | null>(null)
 
-  const handleToggle = useCallback(() => {
+  const handleToggle = () => {
     if (muted) {
       // OFF → ON: プレビュー音を鳴らして音量を確認させる
       if (!previewRef.current) {
@@ -63,8 +56,8 @@ export function SoundController() {
         // Ignore play errors (e.g. autoplay policies or rapid toggling)
       })
     }
-    setMuted(!muted)
-  }, [muted, setMuted])
+    setMuted((prev) => !prev)
+  }
 
   // Cleanup: アンマウント時にAudioインスタンスを解放
   useEffect(() => {

--- a/@robopo/web/app/challenge/[competitionId]/[courseId]/view.tsx
+++ b/@robopo/web/app/challenge/[competitionId]/[courseId]/view.tsx
@@ -3,7 +3,7 @@
 import { MagnifyingGlassIcon, PlayIcon } from "@heroicons/react/24/outline"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
-import { useMemo, useState } from "react"
+import { useState } from "react"
 import { BackButton } from "@/app/components/parts/buttons"
 import type { SelectCourse, SelectPlayer } from "@/app/lib/db/schema"
 
@@ -24,7 +24,7 @@ export function View({
   const [searchQuery, setSearchQuery] = useState("")
   const playerDataList = initialPlayerDataList.players
 
-  const filteredPlayers = useMemo(() => {
+  const filteredPlayers = (() => {
     if (!searchQuery) {
       return playerDataList
     }
@@ -35,7 +35,7 @@ export function View({
         p.furigana?.toLowerCase().includes(q) ||
         p.bibNumber?.toLowerCase().includes(q),
     )
-  }, [playerDataList, searchQuery])
+  })()
 
   return (
     <div className="mx-auto flex w-full max-w-2xl flex-col px-4 py-6">

--- a/@robopo/web/app/challenge/challenge.tsx
+++ b/@robopo/web/app/challenge/challenge.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from "next/navigation"
 import type React from "react"
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import {
   SoundController,
   useAudioContext,
@@ -227,16 +227,10 @@ export function Challenge({
   setIsEnabled,
 }: ChallengeProps): React.JSX.Element {
   const router = useRouter()
-  const fieldState = useMemo(() => deserializeField(field ?? ""), [field])
-  const missionState = useMemo(
-    () => deserializeMission(mission ?? ""),
-    [mission],
-  )
-  const missionPair = useMemo(
-    () => missionStatePair(missionState),
-    [missionState],
-  )
-  const pointState: PointState = useMemo(() => deserializePoint(point), [point])
+  const fieldState = deserializeField(field ?? "")
+  const missionState = deserializeMission(mission ?? "")
+  const missionPair = missionStatePair(missionState)
+  const pointState: PointState = deserializePoint(point)
   const [isRetry, setIsRetry] = useState(false)
   const [isGoal, setIsGoal] = useState(false)
   const [nowMission, setNowMission] = useState(0)
@@ -247,7 +241,7 @@ export function Challenge({
   const [isSuccess, setIsSuccess] = useState(false)
   const [message, setMessage] = useState("")
   const [modalOpen, setModalOpen] = useState(0)
-  const start = useMemo(() => findStart(fieldState), [fieldState])
+  const start = findStart(fieldState)
   const [botPosition, setBotPosition] = useState({
     row: start?.[0] || 0,
     col: start?.[1] || 0,
@@ -269,59 +263,42 @@ export function Challenge({
     }
   }, [nextSound, backSound])
 
-  const handleNext = useCallback(
-    (row: number, col: number) => {
-      if (
-        nowMission < missionPair.length &&
-        pointState[nowMission + 2] !== null
-      ) {
-        const [newRow, newCol, direction] = getRobotPosition(
-          start?.[0] || 0,
-          start?.[1] || 0,
-          missionState,
-          nowMission + 1,
-        )
-        if ((strictMode && newRow === row && newCol === col) || !strictMode) {
-          const point = calcPoint(pointState, nowMission + 1)
-          setPointCount(point)
-          if (nowMission === missionPair.length - 1) {
-            setIsGoal(true)
-            setModalOpen(1)
-            !muted && goalSound?.play()
-          } else if (nowMission < missionPair.length - 1) {
-            setNowMission(nowMission + 1)
-            !muted && nextSound?.play()
-          }
-          if (!isRetry && !isGoal) {
-            setFirstResult(firstResult + 1)
-          } else if (retryResult !== null && !isGoal) {
-            setRetryResult(retryResult + 1)
-          }
-          setBotPosition({ row: newRow, col: newCol })
-          setBotDirection(direction)
+  const handleNext = (row: number, col: number) => {
+    if (
+      nowMission < missionPair.length &&
+      pointState[nowMission + 2] !== null
+    ) {
+      const [newRow, newCol, direction] = getRobotPosition(
+        start?.[0] || 0,
+        start?.[1] || 0,
+        missionState,
+        nowMission + 1,
+      )
+      if ((strictMode && newRow === row && newCol === col) || !strictMode) {
+        const point = calcPoint(pointState, nowMission + 1)
+        setPointCount(point)
+        if (nowMission === missionPair.length - 1) {
+          setIsGoal(true)
+          setModalOpen(1)
+          !muted && goalSound?.play()
+        } else if (nowMission < missionPair.length - 1) {
+          setNowMission(nowMission + 1)
+          !muted && nextSound?.play()
         }
-      } else {
-        setNowMission(0)
+        if (!isRetry && !isGoal) {
+          setFirstResult(firstResult + 1)
+        } else if (retryResult !== null && !isGoal) {
+          setRetryResult(retryResult + 1)
+        }
+        setBotPosition({ row: newRow, col: newCol })
+        setBotDirection(direction)
       }
-    },
-    [
-      nowMission,
-      missionPair.length,
-      pointState,
-      start,
-      missionState,
-      strictMode,
-      isRetry,
-      isGoal,
-      firstResult,
-      retryResult,
-      muted,
-      goalSound,
-      nextSound,
-    ],
-  )
+    } else {
+      setNowMission(0)
+    }
+  }
 
-  const handleBack = useCallback(() => {
+  const handleBack = () => {
     if (nowMission > 0) {
       if (!isRetry) {
         setFirstResult(firstResult - 1)
@@ -345,20 +322,9 @@ export function Challenge({
       }
       !muted && backSound?.play()
     }
-  }, [
-    nowMission,
-    isRetry,
-    firstResult,
-    retryResult,
-    isGoal,
-    pointState,
-    start,
-    missionState,
-    muted,
-    backSound,
-  ])
+  }
 
-  const handleRetry = useCallback(() => {
+  const handleRetry = () => {
     setIsRetry(true)
     setRetryResult(0)
     setPointCount(0)
@@ -366,68 +332,50 @@ export function Challenge({
     setIsGoal(false)
     setBotPosition({ row: start?.[0] || 0, col: start?.[1] || 0 })
     setBotDirection(missionState[0])
-  }, [start, missionState])
+  }
 
   // Handle tier point selection (for graded scoring missions)
-  const handleTierSelect = useCallback(
-    (tierIndex: number) => {
-      const currentEntry = pointState[nowMission + 2]
-      if (!Array.isArray(currentEntry)) {
-        return
-      }
+  const handleTierSelect = (tierIndex: number) => {
+    const currentEntry = pointState[nowMission + 2]
+    if (!Array.isArray(currentEntry)) {
+      return
+    }
 
-      const tierPoint = currentEntry[tierIndex] ?? 0
-      // Calculate point manually: base + tier point for this mission
-      const basePoint = calcPoint(pointState, nowMission)
-      const newPoint = basePoint + tierPoint
-      // Add goal bonus if this is the last mission
-      if (nowMission === missionPair.length - 1) {
-        const goalEntry = pointState[1]
-        const goalPt =
-          goalEntry !== null && !Array.isArray(goalEntry)
-            ? Number(goalEntry)
-            : 0
-        setPointCount(newPoint + goalPt)
-        setIsGoal(true)
-        setModalOpen(1)
-        !muted && goalSound?.play()
-      } else {
-        setPointCount(newPoint)
-        setNowMission(nowMission + 1)
-        !muted && nextSound?.play()
-      }
+    const tierPoint = currentEntry[tierIndex] ?? 0
+    // Calculate point manually: base + tier point for this mission
+    const basePoint = calcPoint(pointState, nowMission)
+    const newPoint = basePoint + tierPoint
+    // Add goal bonus if this is the last mission
+    if (nowMission === missionPair.length - 1) {
+      const goalEntry = pointState[1]
+      const goalPt =
+        goalEntry !== null && !Array.isArray(goalEntry) ? Number(goalEntry) : 0
+      setPointCount(newPoint + goalPt)
+      setIsGoal(true)
+      setModalOpen(1)
+      !muted && goalSound?.play()
+    } else {
+      setPointCount(newPoint)
+      setNowMission(nowMission + 1)
+      !muted && nextSound?.play()
+    }
 
-      // Update robot position
-      const [newRow, newCol, direction] = getRobotPosition(
-        start?.[0] || 0,
-        start?.[1] || 0,
-        missionState,
-        nowMission + 1,
-      )
-      setBotPosition({ row: newRow, col: newCol })
-      setBotDirection(direction)
-
-      if (!isRetry && !isGoal) {
-        setFirstResult(firstResult + 1)
-      } else if (retryResult !== null && !isGoal) {
-        setRetryResult(retryResult + 1)
-      }
-    },
-    [
-      nowMission,
-      missionPair.length,
-      pointState,
-      start,
+    // Update robot position
+    const [newRow, newCol, direction] = getRobotPosition(
+      start?.[0] || 0,
+      start?.[1] || 0,
       missionState,
-      isRetry,
-      isGoal,
-      firstResult,
-      retryResult,
-      muted,
-      goalSound,
-      nextSound,
-    ],
-  )
+      nowMission + 1,
+    )
+    setBotPosition({ row: newRow, col: newCol })
+    setBotDirection(direction)
+
+    if (!isRetry && !isGoal) {
+      setFirstResult(firstResult + 1)
+    } else if (retryResult !== null && !isGoal) {
+      setRetryResult(retryResult + 1)
+    }
+  }
 
   const FieldProps = {
     type: "challenge" as FieldPropsType["type"],

--- a/@robopo/web/app/components/common/view.tsx
+++ b/@robopo/web/app/components/common/view.tsx
@@ -16,7 +16,7 @@ import {
 } from "@heroicons/react/24/outline"
 import Link from "next/link"
 import type React from "react"
-import { useMemo, useState } from "react"
+import { useState } from "react"
 import { CommonCheckboxList } from "@/app/components/common/commonList"
 import { CourseFormModal } from "@/app/course/modals"
 import type {
@@ -231,7 +231,7 @@ export function View({
 
   const courseDataList = commonDataList
 
-  const competitionNames = useMemo(() => {
+  const competitionNames = (() => {
     const names = new Set<string>()
     for (const c of courseDataList) {
       for (const name of c.competitionName ?? []) {
@@ -239,9 +239,9 @@ export function View({
       }
     }
     return [...names].sort((a, b) => a.localeCompare(b, "ja"))
-  }, [courseDataList])
+  })()
 
-  const filteredAndSortedList = useMemo(() => {
+  const filteredAndSortedList = (() => {
     let list = courseDataList
     if (searchQuery.trim()) {
       const q = searchQuery.trim().toLowerCase()
@@ -265,7 +265,7 @@ export function View({
       }
       return sortOrder === "asc" ? cmp : -cmp
     })
-  }, [courseDataList, searchQuery, sortKey, sortOrder, competitionFilter])
+  })()
 
   const selectedCourse =
     commonId.length === 1

--- a/@robopo/web/app/components/course/missionList.tsx
+++ b/@robopo/web/app/components/course/missionList.tsx
@@ -23,7 +23,7 @@ import {
   TrashIcon,
 } from "@heroicons/react/24/outline"
 import { PlayIcon, StopIcon } from "@heroicons/react/24/solid"
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import {
   type FieldState,
   findGoal,
@@ -130,7 +130,7 @@ export function MissionList({
   }, [mission])
 
   // Compute panel positions for each mission
-  const panelPositions = useMemo(() => {
+  const panelPositions = (() => {
     const start = findStart(field)
     if (!start) {
       return null
@@ -150,7 +150,7 @@ export function MissionList({
       positions,
       goalPanel,
     }
-  }, [field, mission])
+  })()
 
   // ─── DnD ─────────────────────────────────────────────────
 
@@ -722,10 +722,10 @@ function SortableMissionRow({
       ? "最終ミッションがゴールに到達していません"
       : "コース外の移動です"
 
-  const handleErrorTap = useCallback((e: React.MouseEvent) => {
+  const handleErrorTap = (e: React.MouseEvent) => {
     e.stopPropagation()
     setShowMobileError((prev) => !prev)
-  }, [])
+  }
 
   return (
     // biome-ignore lint/a11y/useSemanticElements: sortable container with drag handle

--- a/@robopo/web/app/components/header/navigationDrawer.tsx
+++ b/@robopo/web/app/components/header/navigationDrawer.tsx
@@ -3,7 +3,7 @@
 import { Bars3Icon, XMarkIcon } from "@heroicons/react/24/outline"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { createPortal } from "react-dom"
 import type { NavItem } from "@/app/lib/const"
 import {
@@ -55,19 +55,20 @@ export function NavigationDrawer() {
   const triggerRef = useRef<HTMLButtonElement>(null)
   const drawerRef = useRef<HTMLDivElement>(null)
 
-  const close = useCallback(() => {
+  const close = () => {
     setIsOpen(false)
     // Return focus to trigger button
     requestAnimationFrame(() => {
       triggerRef.current?.focus()
     })
-  }, [])
+  }
 
   useEffect(() => {
     setMounted(true)
   }, [])
 
   // Escape key handler
+  // biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler handles memoization of close
   useEffect(() => {
     if (!isOpen) {
       return
@@ -79,7 +80,7 @@ export function NavigationDrawer() {
     }
     document.addEventListener("keydown", onKeyDown)
     return () => document.removeEventListener("keydown", onKeyDown)
-  }, [isOpen, close])
+  }, [isOpen])
 
   // Focus trap
   useEffect(() => {

--- a/@robopo/web/app/components/home/tabs.tsx
+++ b/@robopo/web/app/components/home/tabs.tsx
@@ -8,7 +8,7 @@ import {
 import type { Route } from "next"
 import Link from "next/link"
 import type React from "react"
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 
 import { isCompetitionActive } from "@/app/lib/competition"
 import { COMPETITION_MANAGEMENT_LIST } from "@/app/lib/const"
@@ -73,10 +73,8 @@ export function ChallengeTab({
   judgeList,
   competitionJudgeList,
 }: ChallengeTabProps): React.JSX.Element {
-  const activeCompetitions = useMemo(
-    () => competitionList.competitions.filter(isCompetitionActive),
-    [competitionList.competitions],
-  )
+  const activeCompetitions =
+    competitionList.competitions.filter(isCompetitionActive)
   const singleCompetition =
     activeCompetitions.length === 1 ? activeCompetitions[0] : null
 
@@ -86,7 +84,7 @@ export function ChallengeTab({
   const judgeSelectRef = useRef<HTMLSelectElement>(null)
   const disableCondition = competitionId === 0 || judgeId === 0
 
-  const handleDisabledClick = useCallback(() => {
+  const handleDisabledClick = () => {
     if (judgeId === 0) {
       setShowAlert(true)
       judgeSelectRef.current?.scrollIntoView({
@@ -94,7 +92,7 @@ export function ChallengeTab({
         block: "center",
       })
     }
-  }, [judgeId])
+  }
 
   useEffect(() => {
     if (showAlert) {
@@ -103,7 +101,7 @@ export function ChallengeTab({
     }
   }, [showAlert])
 
-  const filteredCourses = useMemo(() => {
+  const filteredCourses = (() => {
     if (competitionId === 0) {
       return []
     }
@@ -111,9 +109,9 @@ export function ChallengeTab({
       .filter((cc) => cc.competitionId === competitionId)
       .map((cc) => cc.courseId)
     return courseList.courses.filter((c) => assigned.includes(c.id))
-  }, [competitionId, competitionCourseList, courseList.courses])
+  })()
 
-  const filteredJudges = useMemo(() => {
+  const filteredJudges = (() => {
     if (competitionId === 0) {
       return judgeList
     }
@@ -121,7 +119,7 @@ export function ChallengeTab({
       .filter((cu) => cu.competitionId === competitionId)
       .map((cu) => cu.judgeId)
     return judgeList.filter((u) => assignedIds.includes(u.id))
-  }, [competitionId, competitionJudgeList, judgeList])
+  })()
 
   return (
     <div className="space-y-4">

--- a/@robopo/web/app/config/view.tsx
+++ b/@robopo/web/app/config/view.tsx
@@ -9,7 +9,7 @@ import {
   PlusIcon,
   TrashIcon,
 } from "@heroicons/react/24/outline"
-import { useMemo, useState } from "react"
+import { useState } from "react"
 import { CommonCheckboxList } from "@/app/components/common/commonList"
 import { CompetitionFormModal, DeleteCompetitionModal } from "@/app/config/tabs"
 import {
@@ -49,7 +49,7 @@ export function CompetitionView({
       ? (competitionList.find((c) => c.id === selectedIds[0]) ?? null)
       : null
 
-  const filteredAndSortedList = useMemo(() => {
+  const filteredAndSortedList = (() => {
     let list = competitionList
 
     if (searchQuery.trim()) {
@@ -78,7 +78,7 @@ export function CompetitionView({
       }
       return sortOrder === "asc" ? cmp : -cmp
     })
-  }, [competitionList, searchQuery, statusFilter, sortKey, sortOrder])
+  })()
 
   function handleSuccess(
     newList: SelectCompetitionWithCourse[],

--- a/@robopo/web/app/course/edit/courseEdit.tsx
+++ b/@robopo/web/app/course/edit/courseEdit.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react"
+import { useRef, useState } from "react"
 import { Field } from "@/app/components/course/field"
 import { Toolbar } from "@/app/components/course/toolbar"
 import {
@@ -54,37 +54,34 @@ export default function CourseEdit({
   const pointerHandledRef = useRef(false)
 
   // Apply tool to a cell
-  const applyTool = useCallback(
-    (row: number, col: number) => {
-      if (selectedTool === "eraser") {
-        if (field[row][col] !== null) {
-          const newField = field.map((r) => [...r])
-          newField[row][col] = null
-          setField(newField)
-        }
-        return
-      }
-      const mode = selectedTool as PanelValue
-      const wasEmpty = field[row][col] === null
-      const newField = putPanel(field, row, col, mode)
-      if (newField) {
+  const applyTool = (row: number, col: number) => {
+    if (selectedTool === "eraser") {
+      if (field[row][col] !== null) {
+        const newField = field.map((r) => [...r])
+        newField[row][col] = null
         setField(newField)
-        // Auto-switch to route after placing start
-        if (mode === "start" && !isStart(field)) {
-          setSelectedTool("route")
-        }
-        // Auto-switch to route after placing goal
-        if (mode === "goal" && !isGoal(field)) {
-          setSelectedTool("route")
-        }
-        // Auto-add empty mission when a route panel is newly placed
-        if (mode === "route" && wasEmpty && onRouteAdded) {
-          onRouteAdded(row, col)
-        }
       }
-    },
-    [field, setField, selectedTool, setSelectedTool, onRouteAdded],
-  )
+      return
+    }
+    const mode = selectedTool as PanelValue
+    const wasEmpty = field[row][col] === null
+    const newField = putPanel(field, row, col, mode)
+    if (newField) {
+      setField(newField)
+      // Auto-switch to route after placing start
+      if (mode === "start" && !isStart(field)) {
+        setSelectedTool("route")
+      }
+      // Auto-switch to route after placing goal
+      if (mode === "goal" && !isGoal(field)) {
+        setSelectedTool("route")
+      }
+      // Auto-add empty mission when a route panel is newly placed
+      if (mode === "route" && wasEmpty && onRouteAdded) {
+        onRouteAdded(row, col)
+      }
+    }
+  }
 
   function handlePanelClick(row: number, col: number) {
     if (isPlaying) {

--- a/@robopo/web/app/course/edit/courseEditContext.tsx
+++ b/@robopo/web/app/course/edit/courseEditContext.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import type React from "react"
-import { createContext, useCallback, useContext, useRef, useState } from "react"
+import { createContext, useContext, useRef, useState } from "react"
 import {
   type FieldState,
   initializeField,
@@ -100,19 +100,19 @@ export function CourseEditProvider({
   const { setDirty } = useNavigationGuard()
   const initializedRef = useRef(false)
 
-  const markDirty = useCallback(() => {
+  const markDirty = () => {
     if (initializedRef.current) {
       setDirty(true)
     }
-  }, [setDirty])
+  }
 
-  const markInitialized = useCallback(() => {
+  const markInitialized = () => {
     initializedRef.current = true
-  }, [])
+  }
 
-  const resetInitialized = useCallback(() => {
+  const resetInitialized = () => {
     initializedRef.current = false
-  }, [])
+  }
 
   const [nameError, setNameError] = useState("")
 
@@ -133,62 +133,40 @@ export function CourseEditProvider({
   const [courseOutRule, setCourseOutRuleRaw] = useState<string>("keep")
   const [selectedTool, setSelectedTool] = useState<ToolType>("start")
 
-  const setName: React.Dispatch<React.SetStateAction<string>> = useCallback(
-    (v) => {
-      setNameRaw(v)
-      markDirty()
-    },
-    [markDirty],
-  )
-  const setDescription: React.Dispatch<React.SetStateAction<string>> =
-    useCallback(
-      (v) => {
-        setDescriptionRaw(v)
-        markDirty()
-      },
-      [markDirty],
-    )
-  const setField: React.Dispatch<React.SetStateAction<FieldState>> =
-    useCallback(
-      (v) => {
-        setFieldRaw(v)
-        markDirty()
-      },
-      [markDirty],
-    )
-  const setMission: React.Dispatch<React.SetStateAction<MissionState>> =
-    useCallback(
-      (v) => {
-        setMissionRaw(v)
-        markDirty()
-      },
-      [markDirty],
-    )
-  const setPoint: React.Dispatch<React.SetStateAction<PointState>> =
-    useCallback(
-      (v) => {
-        setPointRaw(v)
-        markDirty()
-      },
-      [markDirty],
-    )
+  const setName: React.Dispatch<React.SetStateAction<string>> = (v) => {
+    setNameRaw(v)
+    markDirty()
+  }
+  const setDescription: React.Dispatch<React.SetStateAction<string>> = (v) => {
+    setDescriptionRaw(v)
+    markDirty()
+  }
+  const setField: React.Dispatch<React.SetStateAction<FieldState>> = (v) => {
+    setFieldRaw(v)
+    markDirty()
+  }
+  const setMission: React.Dispatch<React.SetStateAction<MissionState>> = (
+    v,
+  ) => {
+    setMissionRaw(v)
+    markDirty()
+  }
+  const setPoint: React.Dispatch<React.SetStateAction<PointState>> = (v) => {
+    setPointRaw(v)
+    markDirty()
+  }
   const setMissionPanelHints: React.Dispatch<
     React.SetStateAction<(number | null)[]>
-  > = useCallback(
-    (v) => {
-      setMissionPanelHintsRaw(v)
-      markDirty()
-    },
-    [markDirty],
-  )
-  const setCourseOutRule: React.Dispatch<React.SetStateAction<string>> =
-    useCallback(
-      (v) => {
-        setCourseOutRuleRaw(v)
-        markDirty()
-      },
-      [markDirty],
-    )
+  > = (v) => {
+    setMissionPanelHintsRaw(v)
+    markDirty()
+  }
+  const setCourseOutRule: React.Dispatch<React.SetStateAction<string>> = (
+    v,
+  ) => {
+    setCourseOutRuleRaw(v)
+    markDirty()
+  }
 
   // Field undo/redo
   const {
@@ -198,14 +176,11 @@ export function CourseEditProvider({
     canUndo,
     canRedo,
   } = useUndoRedo<FieldState>({
-    getSnapshot: useCallback(() => field.map((row) => [...row]), [field]),
-    applySnapshot: useCallback(
-      (snap: FieldState) => {
-        setFieldRaw(snap)
-        markDirty()
-      },
-      [markDirty],
-    ),
+    getSnapshot: () => field.map((row) => [...row]),
+    applySnapshot: (snap: FieldState) => {
+      setFieldRaw(snap)
+      markDirty()
+    },
   })
 
   // Mission undo/redo (includes panelHints for sync - Comment 1 fix)
@@ -216,23 +191,17 @@ export function CourseEditProvider({
     canUndo: canUndoMission,
     canRedo: canRedoMission,
   } = useUndoRedo<MissionSnapshot>({
-    getSnapshot: useCallback(
-      () => ({
-        mission: [...mission],
-        point: [...point],
-        panelHints: [...missionPanelHints],
-      }),
-      [mission, point, missionPanelHints],
-    ),
-    applySnapshot: useCallback(
-      (snap: MissionSnapshot) => {
-        setMissionRaw(snap.mission)
-        setPointRaw(snap.point)
-        setMissionPanelHintsRaw(snap.panelHints)
-        markDirty()
-      },
-      [markDirty],
-    ),
+    getSnapshot: () => ({
+      mission: [...mission],
+      point: [...point],
+      panelHints: [...missionPanelHints],
+    }),
+    applySnapshot: (snap: MissionSnapshot) => {
+      setMissionRaw(snap.mission)
+      setPointRaw(snap.point)
+      setMissionPanelHintsRaw(snap.panelHints)
+      markDirty()
+    },
   })
 
   return (

--- a/@robopo/web/app/hooks/useNavigationGuard.tsx
+++ b/@robopo/web/app/hooks/useNavigationGuard.tsx
@@ -3,7 +3,6 @@
 import {
   createContext,
   type ReactNode,
-  useCallback,
   useContext,
   useEffect,
   useState,
@@ -24,9 +23,9 @@ export const useNavigationGuard = () => useContext(NavigationGuardContext)
 export function NavigationGuardProvider({ children }: { children: ReactNode }) {
   const [isDirty, setIsDirty] = useState(false)
 
-  const setDirty = useCallback((dirty: boolean) => {
+  const setDirty = (dirty: boolean) => {
     setIsDirty(dirty)
-  }, [])
+  }
 
   useEffect(() => {
     if (!isDirty) {

--- a/@robopo/web/app/hooks/useUndoRedo.ts
+++ b/@robopo/web/app/hooks/useUndoRedo.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react"
+import { useRef, useState } from "react"
 
 const DEFAULT_MAX_HISTORY = 50
 
@@ -20,14 +20,14 @@ export function useUndoRedo<T>({
   const [canUndo, setCanUndo] = useState(false)
   const [canRedo, setCanRedo] = useState(false)
 
-  const push = useCallback(() => {
+  const push = () => {
     historyRef.current = [...historyRef.current.slice(-max + 1), getSnapshot()]
     redoRef.current = []
     setCanUndo(true)
     setCanRedo(false)
-  }, [getSnapshot, max])
+  }
 
-  const undo = useCallback(() => {
+  const undo = () => {
     const history = historyRef.current
     if (history.length === 0) {
       return
@@ -42,9 +42,9 @@ export function useUndoRedo<T>({
     setCanUndo(historyRef.current.length > 0)
 
     applySnapshot(prev)
-  }, [getSnapshot, applySnapshot])
+  }
 
-  const redo = useCallback(() => {
+  const redo = () => {
     const redoStack = redoRef.current
     if (redoStack.length === 0) {
       return
@@ -59,7 +59,7 @@ export function useUndoRedo<T>({
     setCanRedo(redoRef.current.length > 0)
 
     applySnapshot(next)
-  }, [getSnapshot, applySnapshot])
+  }
 
   return { push, undo, redo, canUndo, canRedo }
 }

--- a/@robopo/web/app/judge/view.tsx
+++ b/@robopo/web/app/judge/view.tsx
@@ -9,7 +9,7 @@ import {
   PlusIcon,
   TrashIcon,
 } from "@heroicons/react/24/outline"
-import { useMemo, useState } from "react"
+import { useState } from "react"
 import { CommonCheckboxList } from "@/app/components/common/commonList"
 import { JudgeDeleteModal, JudgeFormModal } from "@/app/judge/modals"
 import type {
@@ -46,7 +46,7 @@ export function JudgeView({
 
   const selectedJudges = judgeList.filter((j) => selectedIds.includes(j.id))
 
-  const competitionNames = useMemo(() => {
+  const competitionNames = (() => {
     const names = new Set<string>()
     for (const j of judgeList) {
       for (const name of j.competitionName ?? []) {
@@ -54,9 +54,9 @@ export function JudgeView({
       }
     }
     return [...names].sort((a, b) => a.localeCompare(b, "ja"))
-  }, [judgeList])
+  })()
 
-  const filteredAndSortedList = useMemo(() => {
+  const filteredAndSortedList = (() => {
     let list = judgeList
     if (searchQuery.trim()) {
       const q = searchQuery.trim().toLowerCase()
@@ -78,7 +78,7 @@ export function JudgeView({
       }
       return sortOrder === "asc" ? cmp : -cmp
     })
-  }, [judgeList, searchQuery, competitionFilter, sortKey, sortOrder])
+  })()
 
   function handleSuccess(
     newList: SelectJudgeWithCompetition[],

--- a/@robopo/web/app/lib/db/queries/queries.ts
+++ b/@robopo/web/app/lib/db/queries/queries.ts
@@ -1,4 +1,4 @@
-import { and, eq, type SQLWrapper, sql } from "drizzle-orm"
+import { and, count, eq, inArray, ne, type SQLWrapper, sql } from "drizzle-orm"
 import type { CourseSummary } from "@/app/components/summary/utils"
 import { db } from "@/app/lib/db/db"
 import {
@@ -24,7 +24,7 @@ export async function getCourseByName(
 ): Promise<{ id: number } | null> {
   const conditions = [eq(course.name, name)]
   if (excludeId) {
-    conditions.push(sql`${course.id} != ${excludeId}`)
+    conditions.push(ne(course.id, excludeId))
   }
   const result = await db
     .select({ id: course.id })
@@ -462,7 +462,7 @@ export async function getPlayerByName(
 ): Promise<{ id: number } | null> {
   const conditions = [eq(player.name, name)]
   if (excludeId) {
-    conditions.push(sql`${player.id} != ${excludeId}`)
+    conditions.push(ne(player.id, excludeId))
   }
   const result = await db
     .select({ id: player.id })
@@ -479,7 +479,7 @@ export async function getJudgeByName(
 ): Promise<{ id: number } | null> {
   const conditions = [eq(judge.name, name)]
   if (excludeId) {
-    conditions.push(sql`${judge.id} != ${excludeId}`)
+    conditions.push(ne(judge.id, excludeId))
   }
   const result = await db
     .select({ id: judge.id })
@@ -736,7 +736,7 @@ export async function getCourseCompetitionCount(
   courseId: number,
 ): Promise<number> {
   const result = await db
-    .select({ count: sql<number>`count(*)::int` })
+    .select({ count: count() })
     .from(competitionCourse)
     .where(eq(competitionCourse.courseId, courseId))
   return result[0]?.count ?? 0
@@ -752,12 +752,7 @@ export async function getLinkedCourseIds(
   const result = await db
     .select({ courseId: competitionCourse.courseId })
     .from(competitionCourse)
-    .where(
-      sql`${competitionCourse.courseId} IN (${sql.join(
-        courseIds.map((id) => sql`${id}`),
-        sql`, `,
-      )})`,
-    )
+    .where(inArray(competitionCourse.courseId, courseIds))
     .groupBy(competitionCourse.courseId)
   return result.map((r) => r.courseId)
 }

--- a/@robopo/web/app/player/view.tsx
+++ b/@robopo/web/app/player/view.tsx
@@ -9,7 +9,7 @@ import {
   PlusIcon,
   TrashIcon,
 } from "@heroicons/react/24/outline"
-import { useMemo, useState } from "react"
+import { useState } from "react"
 import { CommonCheckboxList } from "@/app/components/common/commonList"
 import type {
   SelectCompetition,
@@ -46,7 +46,7 @@ export function PlayerView({
 
   const selectedPlayers = playerList.filter((p) => selectedIds.includes(p.id))
 
-  const competitionNames = useMemo(() => {
+  const competitionNames = (() => {
     const names = new Set<string>()
     for (const p of playerList) {
       for (const name of p.competitionName ?? []) {
@@ -54,9 +54,9 @@ export function PlayerView({
       }
     }
     return [...names].sort((a, b) => a.localeCompare(b, "ja"))
-  }, [playerList])
+  })()
 
-  const filteredAndSortedList = useMemo(() => {
+  const filteredAndSortedList = (() => {
     let list = playerList
     if (searchQuery.trim()) {
       const q = searchQuery.trim().toLowerCase()
@@ -86,7 +86,7 @@ export function PlayerView({
       }
       return sortOrder === "asc" ? cmp : -cmp
     })
-  }, [playerList, searchQuery, competitionFilter, sortKey, sortOrder])
+  })()
 
   function handleSuccess(
     newList: SelectPlayerWithCompetition[],

--- a/@robopo/web/app/summary/summaryView.tsx
+++ b/@robopo/web/app/summary/summaryView.tsx
@@ -8,7 +8,7 @@ import {
   XMarkIcon,
 } from "@heroicons/react/24/outline"
 import Link from "next/link"
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { useEffect, useState } from "react"
 import { calcPoint } from "@/app/components/challenge/utils"
 import {
   deserializePoint,
@@ -165,29 +165,22 @@ export function SummaryView({ competitions, defaultCompetitionId }: Props) {
   ])
 
   // Available keys not yet used in sort conditions
-  const availableKeys = useMemo(
-    () =>
-      SORT_OPTIONS.filter(
-        (opt) => !sortConditions.some((sc) => sc.key === opt.value),
-      ),
-    [sortConditions],
+  const availableKeys = SORT_OPTIONS.filter(
+    (opt) => !sortConditions.some((sc) => sc.key === opt.value),
   )
 
-  const addSort = useCallback(
-    (key: SortKey) => {
-      if (sortConditions.some((sc) => sc.key === key)) {
-        return
-      }
-      setSortConditions((prev) => [...prev, { key, order: "desc" }])
-    },
-    [sortConditions],
-  )
+  const addSort = (key: SortKey) => {
+    if (sortConditions.some((sc) => sc.key === key)) {
+      return
+    }
+    setSortConditions((prev) => [...prev, { key, order: "desc" }])
+  }
 
-  const removeSort = useCallback((index: number) => {
+  const removeSort = (index: number) => {
     setSortConditions((prev) => prev.filter((_, i) => i !== index))
-  }, [])
+  }
 
-  const toggleOrder = useCallback((index: number) => {
+  const toggleOrder = (index: number) => {
     setSortConditions((prev) =>
       prev.map((sc, i) =>
         i === index
@@ -195,7 +188,7 @@ export function SummaryView({ competitions, defaultCompetitionId }: Props) {
           : sc,
       ),
     )
-  }, [])
+  }
 
   // Fetch courses when competition changes
   useEffect(() => {
@@ -255,7 +248,7 @@ export function SummaryView({ competitions, defaultCompetitionId }: Props) {
     fetchData()
   }, [competitionId, courseId, courses])
 
-  const filteredAndSorted = useMemo(() => {
+  const filteredAndSorted = (() => {
     let list = rawSummary
 
     // Keyword search
@@ -279,7 +272,7 @@ export function SummaryView({ competitions, defaultCompetitionId }: Props) {
       }
       return 0
     })
-  }, [rawSummary, searchQuery, sortConditions, pointData])
+  })()
 
   const columns = [
     "名前",

--- a/@robopo/web/next.config.ts
+++ b/@robopo/web/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next"
 
 const nextConfig: NextConfig = {
+  reactCompiler: true,
   typedRoutes: true,
 }
 

--- a/@robopo/web/package.json
+++ b/@robopo/web/package.json
@@ -61,6 +61,7 @@
     "@types/pg": "^8.20.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "babel-plugin-react-compiler": "^1.0.0",
     "daisyui": "^5.5.19",
     "drizzle-kit": "^0.31.10",
     "postcss": "^8.5.9",

--- a/@robopo/web/test/unit/player/view.test.tsx
+++ b/@robopo/web/test/unit/player/view.test.tsx
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import type { SelectPlayerWithCompetition } from "@/app/lib/db/schema"
+import { PlayerView } from "@/app/player/view"
+
+afterEach(cleanup)
+
+const players: SelectPlayerWithCompetition[] = [
+  {
+    id: 1,
+    name: "田中太郎",
+    furigana: "たなかたろう",
+    bibNumber: "001",
+    note: null,
+    createdAt: null,
+    competitionId: null,
+    competitionIds: [1],
+    competitionName: ["大会A"],
+  },
+  {
+    id: 2,
+    name: "山田花子",
+    furigana: "やまだはなこ",
+    bibNumber: "002",
+    note: "テスト備考",
+    createdAt: null,
+    competitionId: null,
+    competitionIds: [1, 2],
+    competitionName: ["大会A", "大会B"],
+  },
+  {
+    id: 3,
+    name: "佐藤次郎",
+    furigana: "さとうじろう",
+    bibNumber: "003",
+    note: null,
+    createdAt: null,
+    competitionId: null,
+    competitionIds: [2],
+    competitionName: ["大会B"],
+  },
+]
+
+describe("PlayerView", () => {
+  test("renders all players initially", () => {
+    render(<PlayerView initialPlayerList={players} competitionList={[]} />)
+    expect(screen.getByText("田中太郎")).toBeTruthy()
+    expect(screen.getByText("山田花子")).toBeTruthy()
+    expect(screen.getByText("佐藤次郎")).toBeTruthy()
+  })
+
+  test("filters players by name search", () => {
+    render(<PlayerView initialPlayerList={players} competitionList={[]} />)
+    const searchInput = screen.getByPlaceholderText(
+      "名前・ふりがな・ゼッケン番号・備考で検索",
+    )
+    fireEvent.change(searchInput, { target: { value: "田中" } })
+    expect(screen.getByText("田中太郎")).toBeTruthy()
+    expect(screen.queryByText("山田花子")).toBeNull()
+    expect(screen.queryByText("佐藤次郎")).toBeNull()
+  })
+
+  test("filters players by furigana search", () => {
+    render(<PlayerView initialPlayerList={players} competitionList={[]} />)
+    const searchInput = screen.getByPlaceholderText(
+      "名前・ふりがな・ゼッケン番号・備考で検索",
+    )
+    fireEvent.change(searchInput, { target: { value: "やまだ" } })
+    expect(screen.queryByText("田中太郎")).toBeNull()
+    expect(screen.getByText("山田花子")).toBeTruthy()
+  })
+
+  test("filters players by bib number search", () => {
+    render(<PlayerView initialPlayerList={players} competitionList={[]} />)
+    const searchInput = screen.getByPlaceholderText(
+      "名前・ふりがな・ゼッケン番号・備考で検索",
+    )
+    fireEvent.change(searchInput, { target: { value: "003" } })
+    expect(screen.queryByText("田中太郎")).toBeNull()
+    expect(screen.getByText("佐藤次郎")).toBeTruthy()
+  })
+
+  test("shows empty state when search has no results", () => {
+    render(<PlayerView initialPlayerList={players} competitionList={[]} />)
+    const searchInput = screen.getByPlaceholderText(
+      "名前・ふりがな・ゼッケン番号・備考で検索",
+    )
+    fireEvent.change(searchInput, { target: { value: "存在しない" } })
+    expect(screen.getByText("条件に一致する選手が見つかりません")).toBeTruthy()
+  })
+
+  test("renders competition names in filter dropdown", () => {
+    render(<PlayerView initialPlayerList={players} competitionList={[]} />)
+    expect(screen.getAllByText("大会A").length).toBeGreaterThan(0)
+    expect(screen.getAllByText("大会B").length).toBeGreaterThan(0)
+  })
+})

--- a/@robopo/web/test/unit/summary/summaryView.test.tsx
+++ b/@robopo/web/test/unit/summary/summaryView.test.tsx
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import type { SelectCompetition } from "@/app/lib/db/schema"
+import { SummaryView } from "@/app/summary/summaryView"
+
+afterEach(cleanup)
+
+const competitions: SelectCompetition[] = [
+  {
+    id: 1,
+    name: "大会A",
+    description: null,
+    startDate: new Date("2025-01-01"),
+    endDate: new Date("2027-12-31"),
+    createdAt: null,
+  },
+  {
+    id: 2,
+    name: "大会B",
+    description: null,
+    startDate: new Date("2025-06-01"),
+    endDate: new Date("2027-12-31"),
+    createdAt: null,
+  },
+]
+
+describe("SummaryView", () => {
+  test("renders competition selector with options", () => {
+    render(
+      <SummaryView competitions={competitions} defaultCompetitionId={null} />,
+    )
+    expect(screen.getByText("大会A")).toBeTruthy()
+    expect(screen.getByText("大会B")).toBeTruthy()
+  })
+
+  test("shows placeholder when no competition selected", () => {
+    render(
+      <SummaryView competitions={competitions} defaultCompetitionId={null} />,
+    )
+    expect(screen.getByText("大会を選択してください")).toBeTruthy()
+  })
+
+  test("renders default sort condition (totalPoint desc)", () => {
+    render(
+      <SummaryView competitions={competitions} defaultCompetitionId={null} />,
+    )
+    expect(screen.getByText("総得点")).toBeTruthy()
+    expect(screen.getByText("大きい順")).toBeTruthy()
+  })
+
+  test("toggles sort order on click", () => {
+    render(
+      <SummaryView competitions={competitions} defaultCompetitionId={null} />,
+    )
+    const orderButton = screen.getByText("大きい順")
+    fireEvent.click(orderButton)
+    expect(screen.getByText("小さい順")).toBeTruthy()
+  })
+
+  test("removes sort condition on X click", () => {
+    render(
+      <SummaryView competitions={competitions} defaultCompetitionId={null} />,
+    )
+    // The sort chip should have a remove button
+    const removeButton = screen.getByLabelText("総得点のソートを削除")
+    fireEvent.click(removeButton)
+    // After removal, the sort chip label should be gone (text may still appear in dropdown options)
+    expect(screen.queryByLabelText("総得点のソートを削除")).toBeNull()
+  })
+
+  test("adds new sort condition from dropdown", () => {
+    render(
+      <SummaryView competitions={competitions} defaultCompetitionId={null} />,
+    )
+    // Find the add-sort select
+    const _addSelect = screen.getByRole("combobox", { name: "" })
+    // The last combobox is the sort adder (after competition + course selects)
+    const selects = screen
+      .getAllByRole("combobox")
+      .filter(
+        (s) =>
+          s.querySelector('option[value="playerFurigana"]') !== null ||
+          (s as HTMLSelectElement).querySelector(
+            'option[value="playerFurigana"]',
+          ),
+      )
+    if (selects.length > 0) {
+      fireEvent.change(selects[0], { target: { value: "maxResult" } })
+      expect(screen.getByText("最高得点")).toBeTruthy()
+    }
+  })
+
+  test("renders search input", () => {
+    render(
+      <SummaryView competitions={competitions} defaultCompetitionId={null} />,
+    )
+    expect(
+      screen.getByPlaceholderText("名前・ふりがな・ゼッケン番号で検索"),
+    ).toBeTruthy()
+  })
+})

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Bun workspace monorepo with two packages:
 
 - Runtime: Bun
 - Language: TypeScript (strict mode)
-- Framework: Next.js 16 (App Router, `typedRoutes: true`)
+- Framework: Next.js 16 (App Router, `typedRoutes: true`, `reactCompiler: true`)
 - UI: React 19, Tailwind CSS 4, daisyUI 5
 - Database: PostgreSQL (node-postgres Pool) via Drizzle ORM
 - Authentication: Better Auth with username plugin
@@ -32,6 +32,13 @@ Bun workspace monorepo with two packages:
 - Indent with spaces, no semicolons (ASI), sorted Tailwind classes (`useSortedClasses`).
 - All comments in English. UI-facing strings (labels, messages) are in Japanese.
 - Use `@/` path alias for imports within `@robopo/web` (maps to project root).
+
+### React Compiler
+
+- `reactCompiler: true` is enabled in `next.config.ts`.
+- The React Compiler automatically memoizes components and computations.
+- Do NOT use `useMemo`, `useCallback`, or `React.memo` — they are redundant.
+- Write plain inline expressions for derived state and regular functions for handlers.
 
 ### Database
 

--- a/bun.lock
+++ b/bun.lock
@@ -59,6 +59,7 @@
         "@types/pg": "^8.20.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "babel-plugin-react-compiler": "^1.0.0",
         "daisyui": "^5.5.19",
         "drizzle-kit": "^0.31.10",
         "postcss": "^8.5.9",
@@ -1223,6 +1224,8 @@
     "babel-plugin-polyfill-corejs3": ["babel-plugin-polyfill-corejs3@0.13.0", "", { "dependencies": { "@babel/helper-define-polyfill-provider": "^0.6.5", "core-js-compat": "^3.43.0" }, "peerDependencies": { "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0" } }, "sha512-U+GNwMdSFgzVmfhNm8GJUX88AadB3uo9KpJqS3FaqNIPKgySuvMb+bHPsOmmuWyIcuqZj/pzt1RUIUZns4y2+A=="],
 
     "babel-plugin-polyfill-regenerator": ["babel-plugin-polyfill-regenerator@0.6.8", "", { "dependencies": { "@babel/helper-define-polyfill-provider": "^0.6.8" }, "peerDependencies": { "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0" } }, "sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg=="],
+
+    "babel-plugin-react-compiler": ["babel-plugin-react-compiler@1.0.0", "", { "dependencies": { "@babel/types": "^7.26.0" } }, "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw=="],
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 


### PR DESCRIPTION
## Summary by Sourcery

Next.js アプリで React Compiler を有効化し、既存のコンポーネントやフックをその推奨パターンに合わせて調整します。

新機能:
- Next.js の設定で React Compiler を有効にし、その利用ガイドラインをドキュメント化。

改善:
- React Compiler によって扱われるようになった `useMemo` / `useCallback` / `React.memo` 形式の冗長なパターンを削除し、多数の React コンポーネントを簡素化。
- `ne`、`count`、`inArray` などの Drizzle ORM ヘルパーを利用して、より明瞭でイディオマティックな条件になるようにデータベースクエリ用ユーティリティを洗練。
- ナビゲーションおよびオーディオ関連ハンドラーを、既存の動作を維持しつつ、より単純な関数実装に変更。

ビルド:
- `babel-plugin-react-compiler` 依存関係を追加し、新しいツーリング統合のために Bun のロックファイルを更新。

ドキュメント:
- `AGENTS.md` を更新し、React Compiler の設定とコーディングガイドラインを追記。

テスト:
- サマリービューのソートおよびフィルタリング動作のユニットテストを追加。
- プレーヤービューの検索およびフィルタリング動作のユニットテストを追加。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable React Compiler in the Next.js app and adapt existing components and hooks to its recommended patterns.

New Features:
- Turn on React Compiler in the Next.js configuration and document its usage guidelines.

Enhancements:
- Simplify numerous React components by removing redundant useMemo/useCallback/React.memo-style patterns now handled by the React Compiler.
- Refine database query utilities to use Drizzle ORM helpers like ne, count, and inArray for clearer, more idiomatic conditions.
- Adjust navigation and audio-related handlers to use simple functions while retaining existing behavior.

Build:
- Add babel-plugin-react-compiler dependency and update Bun lockfile for the new tooling integration.

Documentation:
- Update AGENTS.md with React Compiler configuration and coding guidelines.

Tests:
- Add unit tests for the summary view sorting and filtering behavior.
- Add unit tests for the player view search and filtering behavior.

</details>