### PR TITLE
feat: enable cache components

### DIFF
--- a/@robopo/web/app/api/assign/course/route.ts
+++ b/@robopo/web/app/api/assign/course/route.ts
@@ -10,8 +10,6 @@ import {
   type SelectCompetitionCourse,
 } from "@/app/lib/db/schema"
 
-export const revalidate = 0
-
 // Get assigned competition and course list
 export async function GET() {
   const assigns: SelectCompetitionCourse[] = await db

--- a/@robopo/web/app/api/assign/judge/route.ts
+++ b/@robopo/web/app/api/assign/judge/route.ts
@@ -10,8 +10,6 @@ import {
   type SelectCompetitionJudge,
 } from "@/app/lib/db/schema"
 
-export const revalidate = 0
-
 // Get assigned competition and judge list
 export async function GET() {
   const assigns: SelectCompetitionJudge[] = await db

--- a/@robopo/web/app/api/assign/player/route.ts
+++ b/@robopo/web/app/api/assign/player/route.ts
@@ -10,8 +10,6 @@ import {
   type SelectCompetitionPlayer,
 } from "@/app/lib/db/schema"
 
-export const revalidate = 0
-
 // Get assigned competition and player list
 export async function GET() {
   const assigns: SelectCompetitionPlayer[] = await db

--- a/@robopo/web/app/api/challenge/route.ts
+++ b/@robopo/web/app/api/challenge/route.ts
@@ -1,7 +1,5 @@
 import { createChallenge } from "@/app/lib/db/queries/insert"
 
-export const revalidate = 0
-
 export async function POST(req: Request) {
   const {
     firstResult,

--- a/@robopo/web/app/api/competition/[id]/route.ts
+++ b/@robopo/web/app/api/competition/[id]/route.ts
@@ -4,8 +4,6 @@ import { db } from "@/app/lib/db/db"
 import { updateCompetition } from "@/app/lib/db/queries/update"
 import { competitionCourse } from "@/app/lib/db/schema"
 
-export const revalidate = 0
-
 function parseOptionalDate(
   value: string | null | undefined,
 ): Date | null | undefined {

--- a/@robopo/web/app/api/course/route.ts
+++ b/@robopo/web/app/api/course/route.ts
@@ -15,8 +15,6 @@ import {
 } from "@/app/lib/db/queries/queries"
 import { updateCourse } from "@/app/lib/db/queries/update"
 
-export const revalidate = 0
-
 export async function GET(req: NextRequest) {
   const searchParams = req.nextUrl.searchParams
   const rawId = searchParams.get("id")

--- a/@robopo/web/app/api/summary/[competitionId]/[courseId]/route.ts
+++ b/@robopo/web/app/api/summary/[competitionId]/[courseId]/route.ts
@@ -6,8 +6,6 @@ import {
 import type { CourseSummary } from "@/app/components/summary/utils"
 import { getCourseSummary } from "@/app/lib/db/queries/queries"
 
-export const revalidate = 0
-
 function calcElapsedSeconds(
   startTime: string | null,
   endTime: string | null,

--- a/@robopo/web/app/components/common/pageLoadingShell.tsx
+++ b/@robopo/web/app/components/common/pageLoadingShell.tsx
@@ -1,0 +1,21 @@
+export function PageLoadingShell({
+  title,
+  description,
+}: {
+  title: string
+  description: string
+}) {
+  return (
+    <div className="flex h-full flex-col overflow-hidden px-4 py-6 sm:px-10 lg:px-16">
+      <div className="mb-4 shrink-0">
+        <h1 className="font-bold text-2xl text-base-content tracking-tight">
+          {title}
+        </h1>
+        <p className="mt-1 text-base-content/60 text-sm">{description}</p>
+      </div>
+      <div className="flex min-h-0 flex-1 items-center justify-center rounded-2xl border border-base-300 bg-base-100 shadow-sm">
+        <span className="loading loading-spinner loading-lg text-primary" />
+      </div>
+    </div>
+  )
+}

--- a/@robopo/web/app/config/loading.tsx
+++ b/@robopo/web/app/config/loading.tsx
@@ -1,0 +1,10 @@
+import { PageLoadingShell } from "@/app/components/common/pageLoadingShell"
+
+export default function Loading() {
+  return (
+    <PageLoadingShell
+      title="大会一覧"
+      description="大会の作成・編集・削除を行います"
+    />
+  )
+}

--- a/@robopo/web/app/config/page.tsx
+++ b/@robopo/web/app/config/page.tsx
@@ -4,8 +4,6 @@ import {
 } from "@/app/components/server/db"
 import { CompetitionView } from "@/app/config/view"
 
-export const revalidate = 0
-
 export default async function Config() {
   const [{ competitions }, { courses }] = await Promise.all([
     getCompetitionWithCourseList(),

--- a/@robopo/web/app/course/loading.tsx
+++ b/@robopo/web/app/course/loading.tsx
@@ -1,0 +1,10 @@
+import { PageLoadingShell } from "@/app/components/common/pageLoadingShell"
+
+export default function Loading() {
+  return (
+    <PageLoadingShell
+      title="コース一覧"
+      description="コースの作成・編集・削除を行います"
+    />
+  )
+}

--- a/@robopo/web/app/course/page.tsx
+++ b/@robopo/web/app/course/page.tsx
@@ -5,8 +5,6 @@ import {
   groupByCourse,
 } from "@/app/lib/db/queries/queries"
 
-export const revalidate = 0
-
 export default async function Course() {
   const [courseRows, { competitions }] = await Promise.all([
     getCourseWithCompetition(),

--- a/@robopo/web/app/judge/loading.tsx
+++ b/@robopo/web/app/judge/loading.tsx
@@ -1,0 +1,10 @@
+import { PageLoadingShell } from "@/app/components/common/pageLoadingShell"
+
+export default function Loading() {
+  return (
+    <PageLoadingShell
+      title="採点者一覧"
+      description="採点者の登録・編集・削除を行います"
+    />
+  )
+}

--- a/@robopo/web/app/judge/page.tsx
+++ b/@robopo/web/app/judge/page.tsx
@@ -5,8 +5,6 @@ import {
   groupByJudge,
 } from "@/app/lib/db/queries/queries"
 
-export const revalidate = 0
-
 export default async function JudgePage() {
   const [judgeRows, { competitions }] = await Promise.all([
     getJudgeWithCompetition(),

--- a/@robopo/web/app/layout.tsx
+++ b/@robopo/web/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next"
 import { Inter, Noto_Sans_JP } from "next/font/google"
+import { Suspense } from "react"
 import Header from "@/app/components/header/header"
 import HeaderServer from "@/app/components/header/headerServer"
 import { NavigationGuardProvider } from "@/app/hooks/useNavigationGuard"
@@ -23,14 +24,31 @@ export const metadata: Metadata = {
   description: "ロボサバ大会集計アプリ",
 }
 
-export default async function RootLayout(props: LayoutProps<"/">) {
+async function HeaderWithSession() {
   const { session } = await HeaderServer()
+  return <Header session={session} />
+}
+
+function HeaderFallback() {
+  return (
+    <header className="sticky top-0 z-40 flex h-14 items-center justify-between border-base-300 border-b bg-base-100/95 px-4 backdrop-blur-sm sm:px-0">
+      <div className="flex items-center gap-2">
+        <div className="h-9 w-9 animate-pulse rounded bg-base-300" />
+        <span className="font-bold text-lg text-primary">ROBOPO</span>
+      </div>
+    </header>
+  )
+}
+
+export default function RootLayout(props: LayoutProps<"/">) {
   return (
     <html lang="ja" className={`${notoSansJP.variable} ${inter.variable}`}>
       <body className="font-[family-name:var(--font-noto-sans-jp)] antialiased">
         <NavigationGuardProvider>
           <main className="mx-auto min-h-dvh w-full text-sm sm:px-6 lg:px-12 lg:text-base">
-            <Header session={session} />
+            <Suspense fallback={<HeaderFallback />}>
+              <HeaderWithSession />
+            </Suspense>
             {props.children}
             {props.auth}
           </main>

--- a/@robopo/web/app/loading.tsx
+++ b/@robopo/web/app/loading.tsx
@@ -1,0 +1,7 @@
+export default function Loading() {
+  return (
+    <div className="flex h-full items-center justify-center">
+      <span className="loading loading-spinner loading-lg text-primary" />
+    </div>
+  )
+}

--- a/@robopo/web/app/page.tsx
+++ b/@robopo/web/app/page.tsx
@@ -17,9 +17,6 @@ import type {
 } from "@/app/lib/db/schema"
 import { auth } from "@/lib/auth"
 
-export const dynamic = "force-dynamic"
-export const revalidate = 0
-
 export default async function Home() {
   const session = await auth.api.getSession({
     headers: await headers(),

--- a/@robopo/web/app/player/loading.tsx
+++ b/@robopo/web/app/player/loading.tsx
@@ -1,0 +1,10 @@
+import { PageLoadingShell } from "@/app/components/common/pageLoadingShell"
+
+export default function Loading() {
+  return (
+    <PageLoadingShell
+      title="選手一覧"
+      description="選手の登録・編集・削除を行います"
+    />
+  )
+}

--- a/@robopo/web/app/player/page.tsx
+++ b/@robopo/web/app/player/page.tsx
@@ -5,8 +5,6 @@ import {
 } from "@/app/lib/db/queries/queries"
 import { PlayerView } from "@/app/player/view"
 
-export const revalidate = 0
-
 export default async function Player() {
   const [playerRows, { competitions }] = await Promise.all([
     getPlayersWithCompetition(),

--- a/@robopo/web/app/summary/[...ids]/page.tsx
+++ b/@robopo/web/app/summary/[...ids]/page.tsx
@@ -20,8 +20,6 @@ import {
 } from "@/app/lib/db/queries/queries"
 import { CourseDetailTable } from "@/app/summary/[...ids]/courseDetailTable"
 
-export const revalidate = 0
-
 export default async function SummaryPlayer({
   params,
 }: {

--- a/@robopo/web/app/summary/loading.tsx
+++ b/@robopo/web/app/summary/loading.tsx
@@ -1,0 +1,10 @@
+import { PageLoadingShell } from "@/app/components/common/pageLoadingShell"
+
+export default function Loading() {
+  return (
+    <PageLoadingShell
+      title="集計結果"
+      description="大会を選択して集計結果を確認します"
+    />
+  )
+}

--- a/@robopo/web/app/summary/page.tsx
+++ b/@robopo/web/app/summary/page.tsx
@@ -3,8 +3,6 @@ import { getCompetitionStatus } from "@/app/lib/competition"
 import type { SelectCompetition } from "@/app/lib/db/schema"
 import { SummaryView } from "@/app/summary/summaryView"
 
-export const revalidate = 0
-
 function getDefaultCompetitionId(
   competitions: SelectCompetition[],
 ): number | null {

--- a/@robopo/web/next.config.ts
+++ b/@robopo/web/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next"
 
 const nextConfig: NextConfig = {
+  cacheComponents: true,
   reactCompiler: true,
   typedRoutes: true,
 }


### PR DESCRIPTION
## Summary by Sourcery

Next.js のコンポーネントキャッシュを有効化し、`no-revalidate` 設定を整理しながらローディング状態を追加します。

New Features:
- セッション読み込み中にスケルトンフォールバックを表示する、Suspense でラップされたヘッダーを追加。
- データ読み込み中にスピナーを表示するため、config、course、judge、player、summary、root ページ向けにルート単位のローディング UI を追加。

Enhancements:
- `next.config` で `cacheComponents` オプションを有効にし、フレームワークのキャッシュに依存するようにルートごとの `revalidate` 上書き設定を削除。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable Next.js component caching and add loading states while cleaning up no-revalidate settings.

New Features:
- Add Suspense-wrapped header with a skeleton fallback during session loading.
- Introduce route-level loading UIs for config, course, judge, player, summary, and root pages to show spinners while data loads.

Enhancements:
- Enable Next.js cacheComponents option in next.config and remove per-route revalidate overrides to rely on framework caching.

</details>