### PR TITLE
feat: add more skelton loading

### DIFF
--- a/@robopo/web/app/components/common/pageLoadingShell.tsx
+++ b/@robopo/web/app/components/common/pageLoadingShell.tsx
@@ -1,21 +1,68 @@
+import type React from "react"
+import { Skeleton } from "@/app/components/common/skeleton"
+
+const listRows = ["r0", "r1", "r2", "r3", "r4", "r5"]
+
 export function PageLoadingShell({
   title,
   description,
+  children,
 }: {
   title: string
   description: string
+  children?: React.ReactNode
 }) {
   return (
-    <div className="flex h-full flex-col overflow-hidden px-4 py-6 sm:px-10 lg:px-16">
+    <div className="flex h-[calc(100dvh-3.5rem)] flex-col overflow-hidden px-4 py-6 sm:px-10 lg:px-16">
       <div className="mb-4 shrink-0">
         <h1 className="font-bold text-2xl text-base-content tracking-tight">
           {title}
         </h1>
         <p className="mt-1 text-base-content/60 text-sm">{description}</p>
       </div>
-      <div className="flex min-h-0 flex-1 items-center justify-center rounded-2xl border border-base-300 bg-base-100 shadow-sm">
-        <span className="loading loading-spinner loading-lg text-primary" />
+      <div className="flex min-h-0 flex-1 animate-[skeletonFadeIn_0.3s_ease-out] flex-col rounded-2xl border border-base-300 bg-base-100 shadow-sm">
+        {children ?? <ListPageSkeleton />}
       </div>
     </div>
+  )
+}
+
+function ListPageSkeleton() {
+  return (
+    <>
+      {/* Action buttons skeleton */}
+      <div className="shrink-0 px-4 pt-4 pb-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <Skeleton className="h-8 w-20 rounded-lg" />
+          <Skeleton className="h-8 w-16 rounded-lg" />
+          <Skeleton className="h-8 w-16 rounded-lg" />
+        </div>
+      </div>
+
+      {/* Search bar skeleton */}
+      <div className="flex shrink-0 flex-col gap-3 px-4 pb-4">
+        <Skeleton className="h-10 w-full rounded-xl" />
+        {/* Filter / sort bar */}
+        <div className="flex flex-wrap items-center gap-2">
+          <Skeleton className="h-7 w-24 rounded-lg" />
+          <Skeleton className="h-7 w-32 rounded-lg" />
+        </div>
+      </div>
+
+      {/* List rows skeleton */}
+      <div className="min-h-0 flex-1 space-y-0 px-4">
+        {listRows.map((id, i) => (
+          <div
+            key={id}
+            className="flex items-center gap-3 border-base-200/60 border-b py-3"
+            style={{ animationDelay: `${i * 60}ms` }}
+          >
+            <Skeleton className="size-5 shrink-0 rounded" />
+            <Skeleton className="h-4 w-2/5" />
+            <Skeleton className="ml-auto h-3 w-1/5" />
+          </div>
+        ))}
+      </div>
+    </>
   )
 }

--- a/@robopo/web/app/components/common/skeleton.tsx
+++ b/@robopo/web/app/components/common/skeleton.tsx
@@ -1,0 +1,3 @@
+export function Skeleton({ className }: { className?: string }) {
+  return <div className={`skeleton-shimmer rounded-xl ${className ?? ""}`} />
+}

--- a/@robopo/web/app/loading.tsx
+++ b/@robopo/web/app/loading.tsx
@@ -1,7 +1,72 @@
+import { Skeleton } from "@/app/components/common/skeleton"
+
+const courseCards = ["cc0", "cc1", "cc2", "cc3"]
+const manageItems = ["m0", "m1", "m2", "m3", "m4"]
+
 export default function Loading() {
   return (
-    <div className="flex h-full items-center justify-center">
-      <span className="loading loading-spinner loading-lg text-primary" />
+    <div className="mx-auto max-w-4xl animate-[skeletonFadeIn_0.3s_ease-out] px-4 py-6">
+      <div className="grid gap-5 md:grid-cols-2">
+        {/* Scoring card skeleton */}
+        <div className="md:col-span-2">
+          <div className="rounded-box border border-primary/20 bg-base-100 p-5 shadow-sm ring-1 ring-primary/10">
+            {/* Card header */}
+            <div className="mb-4 flex items-center gap-2">
+              <Skeleton className="h-9 w-9 rounded-lg" />
+              <Skeleton className="h-5 w-14" />
+            </div>
+            {/* Competition selector */}
+            <div className="space-y-4">
+              <div>
+                <Skeleton className="mb-1 h-3.5 w-20" />
+                <Skeleton className="h-10 w-full rounded-lg" />
+              </div>
+              {/* Judge selector */}
+              <div>
+                <Skeleton className="mb-1 h-3.5 w-24" />
+                <Skeleton className="h-10 w-full rounded-lg" />
+              </div>
+              {/* Course cards grid */}
+              <div className="grid gap-3 sm:grid-cols-2">
+                {courseCards.map((id, i) => (
+                  <div
+                    key={id}
+                    className="flex min-h-[72px] items-center gap-3 rounded-xl border border-base-300 px-4 py-3"
+                    style={{ animationDelay: `${i * 60}ms` }}
+                  >
+                    <Skeleton className="h-10 w-10 shrink-0 rounded-lg" />
+                    <Skeleton className="h-4 w-3/5" />
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Management card skeleton */}
+        <div className="md:col-span-2">
+          <div className="rounded-box border border-base-300 bg-base-100 p-5 shadow-sm">
+            {/* Card header */}
+            <div className="mb-4 flex items-center gap-2">
+              <Skeleton className="h-9 w-9 rounded-lg" />
+              <Skeleton className="h-5 w-20" />
+            </div>
+            {/* Nav links */}
+            <div className="grid gap-2">
+              {manageItems.map((id, i) => (
+                <div
+                  key={id}
+                  className="flex items-center gap-3 rounded-lg border border-base-300 px-4 py-3"
+                  style={{ animationDelay: `${i * 60}ms` }}
+                >
+                  <Skeleton className="h-6 w-6 shrink-0 rounded" />
+                  <Skeleton className="h-4 w-24" />
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   )
 }

--- a/@robopo/web/app/summary/loading.tsx
+++ b/@robopo/web/app/summary/loading.tsx
@@ -1,10 +1,59 @@
 import { PageLoadingShell } from "@/app/components/common/pageLoadingShell"
+import { Skeleton } from "@/app/components/common/skeleton"
+
+const tableRows = ["t0", "t1", "t2", "t3", "t4", "t5"]
+const tableCols = ["c0", "c1", "c2", "c3", "c4", "c5", "c6"]
 
 export default function Loading() {
   return (
     <PageLoadingShell
       title="集計結果"
       description="大会を選択して集計結果を確認します"
-    />
+    >
+      {/* Competition & Course selectors skeleton */}
+      <div className="shrink-0 px-4 pt-4 pb-2">
+        <div className="flex flex-wrap items-center gap-3">
+          <div className="min-w-[200px] flex-1">
+            <Skeleton className="mb-1.5 h-3 w-10" />
+            <Skeleton className="h-10 w-full rounded-lg" />
+          </div>
+          <div className="min-w-[200px] flex-1">
+            <Skeleton className="mb-1.5 h-3 w-12" />
+            <Skeleton className="h-10 w-full rounded-lg" />
+          </div>
+        </div>
+      </div>
+
+      {/* Search bar skeleton */}
+      <div className="flex shrink-0 flex-col gap-3 px-4 pb-4">
+        <Skeleton className="h-10 w-full rounded-xl" />
+        <div className="flex flex-wrap items-center gap-2">
+          <Skeleton className="h-7 w-28 rounded-lg" />
+          <Skeleton className="h-7 w-20 rounded-full" />
+        </div>
+      </div>
+
+      {/* Table skeleton */}
+      <div className="min-h-0 flex-1 overflow-hidden px-4">
+        {/* Header row */}
+        <div className="flex items-center gap-3 border-base-300 border-b py-2.5">
+          {tableCols.map((id) => (
+            <Skeleton key={id} className="h-3 flex-1" />
+          ))}
+        </div>
+        {/* Data rows */}
+        {tableRows.map((id, i) => (
+          <div
+            key={id}
+            className="flex items-center gap-3 border-base-200/60 border-b py-3"
+            style={{ animationDelay: `${i * 60}ms` }}
+          >
+            {tableCols.map((cid) => (
+              <Skeleton key={cid} className="h-3.5 flex-1" />
+            ))}
+          </div>
+        ))}
+      </div>
+    </PageLoadingShell>
   )
 }

--- a/@robopo/web/app/summary/summaryView.tsx
+++ b/@robopo/web/app/summary/summaryView.tsx
@@ -466,11 +466,18 @@ export function SummaryView({ competitions, defaultCompetitionId }: Props) {
               </thead>
               <tbody>
                 {loading ? (
-                  <tr>
-                    <td colSpan={columns.length} className="py-12 text-center">
-                      <span className="loading loading-spinner text-primary" />
-                    </td>
-                  </tr>
+                  ["sk0", "sk1", "sk2", "sk3", "sk4"].map((id, i) => (
+                    <tr key={id}>
+                      {columns.map((col) => (
+                        <td key={col} className="py-3">
+                          <div
+                            className="skeleton-shimmer h-4 w-full rounded"
+                            style={{ animationDelay: `${i * 60}ms` }}
+                          />
+                        </td>
+                      ))}
+                    </tr>
+                  ))
                 ) : filteredAndSorted.length > 0 ? (
                   filteredAndSorted.map((player) => (
                     <PlayerRow

--- a/@robopo/web/next.config.ts
+++ b/@robopo/web/next.config.ts
@@ -2,6 +2,9 @@ import type { NextConfig } from "next"
 
 const nextConfig: NextConfig = {
   cacheComponents: true,
+  experimental: {
+    inlineCss: true,
+  },
   reactCompiler: true,
   typedRoutes: true,
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Bun workspace monorepo with two packages:
 
 - Runtime: Bun
 - Language: TypeScript (strict mode)
-- Framework: Next.js 16 (App Router, `typedRoutes: true`, `reactCompiler: true`)
+- Framework: Next.js 16 (App Router, `typedRoutes: true`, `reactCompiler: true`, `cacheComponents: true`)
 - UI: React 19, Tailwind CSS 4, daisyUI 5
 - Database: PostgreSQL (node-postgres Pool) via Drizzle ORM
 - Authentication: Better Auth with username plugin


### PR DESCRIPTION
## Summary by Sourcery

スコアリング、サマリー、および共有ページシェル全体で、汎用的なローディングスピナーを、よりリッチなスケルトンベースのローディング状態に置き換えます。

New Features:
- メインのスコアリングページ向けに、セレクターやコース／マネジメントカードを含む詳細なスケルトンローディングレイアウトを追加。
- サマリーページ向けに、ヘッダーおよび行プレースホルダーを備えたテーブル形式のスケルトンローディングUIを導入。
- 中央配置のスピナーの代わりに、リスト形式のスケルトンをレンダリングする再利用可能なページローディングシェルを提供。

Enhancements:
- サマリーテーブルビューを更新し、データ読み込み中は単一のスピナーではなく、行ベースのスケルトンプレースホルダーを表示するように変更。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace generic loading spinners with richer skeleton-based loading states across scoring, summary, and shared page shells.

New Features:
- Add detailed skeleton loading layout for the main scoring page, including selectors and course/management cards.
- Introduce a table-style skeleton loading UI for the summary page with header and row placeholders.
- Provide a reusable page loading shell that renders list-style skeletons instead of a centered spinner.

Enhancements:
- Update the summary table view to show row-based skeleton placeholders while data is loading instead of a single spinner.

</details>