### PR TITLE
fix: add isConfigured flag for validation

### DIFF
--- a/@robopo/web/app/api/course/route.ts
+++ b/@robopo/web/app/api/course/route.ts
@@ -55,6 +55,8 @@ export async function POST(req: NextRequest) {
       ? checkValidity(parsedField, parsedMission)
       : false
 
+  const isConfigured = computedFieldValid && computedMissionValid
+
   const courseData = {
     name: name,
     description: normalizedDescription,
@@ -64,6 +66,7 @@ export async function POST(req: NextRequest) {
     missionValid: computedMissionValid,
     point: point,
     courseOutRule: courseOutRule || "keep",
+    isConfigured: isConfigured,
   }
 
   const method = id ? "update" : "create"

--- a/@robopo/web/app/components/common/commonList.tsx
+++ b/@robopo/web/app/components/common/commonList.tsx
@@ -116,6 +116,13 @@ function TableComponent({
           <td className="py-3 font-medium">
             {(common as SelectCourseWithCompetition).name}
           </td>
+          <td className="py-3 text-center">
+            {(common as SelectCourseWithCompetition).isConfigured ? (
+              <span className="text-lg text-red-500">○</span>
+            ) : (
+              <span className="text-blue-500 text-lg">✕</span>
+            )}
+          </td>
           <td className="py-3">
             {(common as SelectCourseWithCompetition).competitionName?.length ? (
               <button
@@ -233,7 +240,7 @@ function itemNames(type: CommonListProps["type"]): string[] {
   } else if (type === "judge") {
     itemNames.push("ID", "名前", "紐付け大会", "備考")
   } else if (type === "course") {
-    itemNames.push("ID", "コース名", "使用大会", "作成日時", "説明")
+    itemNames.push("ID", "コース名", "設定済み", "使用大会", "作成日時", "説明")
   } else if (type === "competition") {
     itemNames.push("ID", "名前", "コース", "開催日", "終了日", "説明")
   }

--- a/@robopo/web/app/components/common/view.tsx
+++ b/@robopo/web/app/components/common/view.tsx
@@ -24,7 +24,7 @@ import type {
   SelectCourseWithCompetition,
 } from "@/app/lib/db/schema"
 
-type SortKey = "createdAt" | "name" | "id"
+type SortKey = "createdAt" | "name" | "id" | "isConfigured"
 
 export function View({
   initialCommonDataList,
@@ -186,6 +186,7 @@ export function View({
               <option value="createdAt">作成日時</option>
               <option value="name">コース名</option>
               <option value="id">ID</option>
+              <option value="isConfigured">設定済み</option>
             </select>
             <button
               type="button"
@@ -207,9 +208,13 @@ export function View({
                   ? sortOrder === "desc"
                     ? "Z→A"
                     : "A→Z"
-                  : sortOrder === "desc"
-                    ? "大きい順"
-                    : "小さい順"}
+                  : sortKey === "isConfigured"
+                    ? sortOrder === "desc"
+                      ? "設定済み優先"
+                      : "未設定優先"
+                    : sortOrder === "desc"
+                      ? "大きい順"
+                      : "小さい順"}
             </button>
           </div>
         </div>
@@ -260,6 +265,8 @@ export function View({
         cmp = a.name.localeCompare(b.name, "ja")
       } else if (sortKey === "createdAt") {
         cmp = (a.createdAt?.getTime() ?? 0) - (b.createdAt?.getTime() ?? 0)
+      } else if (sortKey === "isConfigured") {
+        cmp = Number(a.isConfigured) - Number(b.isConfigured)
       } else {
         cmp = a.id - b.id
       }

--- a/@robopo/web/app/components/home/tabs.tsx
+++ b/@robopo/web/app/components/home/tabs.tsx
@@ -108,7 +108,9 @@ export function ChallengeTab({
     const assigned = competitionCourseList.competitionCourseList
       .filter((cc) => cc.competitionId === competitionId)
       .map((cc) => cc.courseId)
-    return courseList.courses.filter((c) => assigned.includes(c.id))
+    return courseList.courses.filter(
+      (c) => assigned.includes(c.id) && c.isConfigured,
+    )
   })()
 
   const filteredJudges = (() => {

--- a/@robopo/web/app/components/server/db.ts
+++ b/@robopo/web/app/components/server/db.ts
@@ -72,6 +72,7 @@ export async function getCompetitionCourseList(competitionId: number): Promise<{
       missionValid: course.missionValid,
       point: course.point,
       courseOutRule: course.courseOutRule,
+      isConfigured: course.isConfigured,
       createdAt: course.createdAt,
     })
     .from(course)

--- a/@robopo/web/app/lib/db/queries/queries.ts
+++ b/@robopo/web/app/lib/db/queries/queries.ts
@@ -616,6 +616,7 @@ export async function getCourseWithCompetition() {
       id: course.id,
       name: course.name,
       description: course.description,
+      isConfigured: course.isConfigured,
       createdAt: course.createdAt,
       competitionId: competition.id,
       competitionName: competition.name,
@@ -632,6 +633,7 @@ export function groupByCourse(
     id: number
     name: string
     description: string | null
+    isConfigured: boolean
     createdAt: Date | null
     competitionId: number | null
     competitionName: string | null
@@ -646,6 +648,7 @@ export function groupByCourse(
         id: row.id,
         name: row.name,
         description: row.description,
+        isConfigured: row.isConfigured,
         createdAt: row.createdAt,
         competitionId: row.competitionId,
         competitionIds: [],

--- a/@robopo/web/app/lib/db/schema.ts
+++ b/@robopo/web/app/lib/db/schema.ts
@@ -26,6 +26,7 @@ export const course = pgTable("course", {
   missionValid: boolean("missionvalid").default(false).notNull(),
   point: text("point"),
   courseOutRule: text("course_out_rule").default("keep").notNull(),
+  isConfigured: boolean("is_configured").default(false).notNull(),
   createdAt: timestamp("created_at").defaultNow(),
 })
 
@@ -200,6 +201,7 @@ export type SelectCourseWithCompetition = {
   id: number
   name: string
   description: string | null
+  isConfigured: boolean
   createdAt: Date | null
   competitionId: number | null
   competitionIds: number[]

--- a/@robopo/web/test/unit/challenge/[competitionId]/[courseId]/[playerId]/view.test.tsx
+++ b/@robopo/web/test/unit/challenge/[competitionId]/[courseId]/[playerId]/view.test.tsx
@@ -25,6 +25,7 @@ const courseData = {
   missionValid: false,
   point: null,
   courseOutRule: "keep",
+  isConfigured: true,
   createdAt: null,
 }
 
@@ -34,6 +35,7 @@ const playerData = {
   furigana: null,
   bibNumber: null,
   qr: null,
+  note: null,
   createdAt: null,
 }
 

--- a/@robopo/web/test/unit/components/home/dashboard.test.tsx
+++ b/@robopo/web/test/unit/components/home/dashboard.test.tsx
@@ -29,6 +29,7 @@ const defaultProps = {
         missionValid: false,
         point: null,
         courseOutRule: "keep",
+        isConfigured: true,
         createdAt: null,
       },
     ],

--- a/@robopo/web/test/unit/components/home/tabs.test.tsx
+++ b/@robopo/web/test/unit/components/home/tabs.test.tsx
@@ -48,6 +48,7 @@ const courseList = {
       missionValid: false,
       point: null,
       courseOutRule: "keep",
+      isConfigured: true,
       createdAt: null,
     },
     {
@@ -60,6 +61,7 @@ const courseList = {
       missionValid: false,
       point: null,
       courseOutRule: "keep",
+      isConfigured: true,
       createdAt: null,
     },
   ],


### PR DESCRIPTION
## Summary by Sourcery

データベース、API、ソート用UI、およびホームビューのロジック全体で、講座設定状態を追跡し、可視化できるようにします。

New Features:
- 講座スキーマおよび API ペイロードに `isConfigured` フラグを追加し、講座が完全に設定済みかどうかを表すようにします。
- 共通の講座一覧ビューおよびソートコントロールで、講座を設定状態に基づいて公開・ソートできるようにします。
- ホームタブで利用可能なチャレンジ講座を、設定済みとしてマークされているもののみに制限します。

Enhancements:
- 講座テーブルに「設定済み／未設定」インジケーターを表示し、講座セットアップ状況をより分かりやすくします。

Tests:
- ホームタブのユニットテストを拡張し、講座データ内の新しい講座設定フラグをカバーするようにします。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Track and surface a course configuration state across the database, API, sorting UI, and home view logic.

New Features:
- Add an isConfigured flag to the course schema and API payload to represent whether a course is fully configured.
- Expose and sort courses by configuration status in the common course list view and sorting controls.
- Restrict available challenge courses on the home tab to only those that are marked as configured.

Enhancements:
- Display a configured/unconfigured indicator in the course table for better visibility into course setup status.

Tests:
- Extend home tab unit tests to cover the new course configuration flag in course data.

</details>