### PR TITLE
feat: add competition and judge summary tables

### DIFF
--- a/@robopo/web/app/api/summary/course-list/[competitionId]/route.ts
+++ b/@robopo/web/app/api/summary/course-list/[competitionId]/route.ts
@@ -1,0 +1,141 @@
+import { sql } from "drizzle-orm"
+import { calcPoint } from "@/app/components/challenge/utils"
+import { deserializePoint } from "@/app/components/course/utils"
+import type { CourseCompetitionSummary } from "@/app/components/summary/utils"
+import { isCompletedCourse } from "@/app/components/summary/utils"
+import { db } from "@/app/lib/db/db"
+import {
+  getCourseById,
+  getCourseSummaryByCompetition,
+} from "@/app/lib/db/queries/queries"
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ competitionId: string }> },
+) {
+  const { competitionId } = await params
+  const competitionIdNum = Number(competitionId)
+
+  const courseSummaryRaw = await getCourseSummaryByCompetition(competitionIdNum)
+
+  if (courseSummaryRaw.length === 0) {
+    return Response.json([])
+  }
+
+  // Batch: preload all course data and point states
+  const courseIds = courseSummaryRaw.map((row) => row.courseId)
+  const courseDataList = await Promise.all(
+    courseIds.map((id) => getCourseById(id)),
+  )
+  const pointStateMap = new Map<
+    number,
+    Awaited<ReturnType<typeof deserializePoint>>
+  >()
+  for (let i = 0; i < courseIds.length; i++) {
+    const pointState = await deserializePoint(courseDataList[i]?.point || "")
+    pointStateMap.set(courseIds[i], pointState)
+  }
+
+  // Batch: get per-player max results for ALL courses in one query
+  const playerMaxResultsAll = await db.execute(sql`
+    SELECT
+      c.course_id AS "courseId",
+      c.player_id AS "playerId",
+      MAX(GREATEST(c.first_result, COALESCE(c.retry_result, 0)))::int AS "maxResult",
+      TO_CHAR(
+        MIN(
+          CASE WHEN GREATEST(c.first_result, COALESCE(c.retry_result, 0)) = (
+            SELECT MAX(GREATEST(c2.first_result, COALESCE(c2.retry_result, 0)))
+            FROM challenge c2
+            WHERE c2.player_id = c.player_id
+              AND c2.course_id = c.course_id
+              AND c2.competition_id = ${competitionIdNum}
+          ) THEN c.created_at ELSE NULL END
+        ) AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo',
+        'YYYY-MM-DD"T"HH24:MI:SS"+09:00"'
+      ) AS "firstMaxTime"
+    FROM challenge c
+    WHERE c.competition_id = ${competitionIdNum}
+      AND c.course_id = ANY(${sql`ARRAY[${sql.join(
+        courseIds.map((id) => sql`${id}`),
+        sql`, `,
+      )}]`})
+    GROUP BY c.course_id, c.player_id
+  `)
+
+  // Group by courseId
+  const playerMaxByCourse = new Map<
+    number,
+    { playerId: number; maxResult: number; firstMaxTime: string | null }[]
+  >()
+  for (const row of playerMaxResultsAll.rows as {
+    courseId: number
+    playerId: number
+    maxResult: number
+    firstMaxTime: string | null
+  }[]) {
+    let list = playerMaxByCourse.get(row.courseId)
+    if (!list) {
+      list = []
+      playerMaxByCourse.set(row.courseId, list)
+    }
+    list.push({
+      playerId: row.playerId,
+      maxResult: row.maxResult,
+      firstMaxTime: row.firstMaxTime,
+    })
+  }
+
+  const result: CourseCompetitionSummary[] = courseSummaryRaw.map((row) => {
+    const pointState = pointStateMap.get(row.courseId) ?? []
+    const playerMaxResults = playerMaxByCourse.get(row.courseId) ?? []
+
+    let completionCount = 0
+    let firstCompletionTime: string | null = null
+
+    for (const pr of playerMaxResults) {
+      if (isCompletedCourse(pointState, pr.maxResult)) {
+        completionCount++
+        if (
+          pr.firstMaxTime &&
+          (!firstCompletionTime || pr.firstMaxTime < firstCompletionTime)
+        ) {
+          firstCompletionTime = pr.firstMaxTime
+        }
+      }
+    }
+
+    const completionRate =
+      row.challengerCount > 0
+        ? Math.round((completionCount / row.challengerCount) * 1000) / 10
+        : null
+
+    const averageScore =
+      row.averageRawScore !== null
+        ? Math.round(
+            calcPoint(pointState, Math.round(row.averageRawScore)) * 10,
+          ) / 10
+        : null
+
+    const maxScore =
+      row.maxRawScore !== null ? calcPoint(pointState, row.maxRawScore) : null
+
+    return {
+      courseId: row.courseId,
+      courseName: row.courseName,
+      firstChallengeTime: row.firstChallengeTime,
+      firstCompletionTime,
+      lastChallengeTime: row.lastChallengeTime,
+      challengerCount: row.challengerCount,
+      completionCount,
+      completionRate,
+      totalChallengeCount: row.totalChallengeCount,
+      averageScore,
+      maxScore,
+      courseOutCount: row.courseOutCount,
+      retryCount: row.retryCount,
+    }
+  })
+
+  return Response.json(result)
+}

--- a/@robopo/web/app/api/summary/judge/[competitionId]/route.ts
+++ b/@robopo/web/app/api/summary/judge/[competitionId]/route.ts
@@ -1,0 +1,13 @@
+import { getJudgeSummaryByCompetition } from "@/app/lib/db/queries/queries"
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ competitionId: string }> },
+) {
+  const { competitionId } = await params
+  const competitionIdNum = Number(competitionId)
+
+  const judgeSummary = await getJudgeSummaryByCompetition(competitionIdNum)
+
+  return Response.json(judgeSummary)
+}

--- a/@robopo/web/app/components/summary/DataTableShell.tsx
+++ b/@robopo/web/app/components/summary/DataTableShell.tsx
@@ -1,0 +1,77 @@
+"use client"
+
+import type React from "react"
+
+type Props = {
+  columns: string[]
+  loading: boolean
+  rowCount: number
+  emptyMessage?: string
+  noMatchMessage?: string
+  hasSearchQuery?: boolean
+  children: React.ReactNode
+}
+
+export function DataTableShell({
+  columns,
+  loading,
+  rowCount,
+  emptyMessage = "データがありません",
+  noMatchMessage,
+  hasSearchQuery = false,
+  children,
+}: Props) {
+  if (hasSearchQuery && !loading && rowCount === 0 && noMatchMessage) {
+    return (
+      <div className="py-8 text-center text-base-content/40">
+        {noMatchMessage}
+      </div>
+    )
+  }
+
+  return (
+    <div className="m-3 min-h-0 overflow-x-auto overflow-y-auto rounded-xl border border-base-300/50">
+      <table className="table-pin-rows table-zebra table">
+        <thead>
+          <tr className="border-base-300/50 border-b bg-base-200/60">
+            {columns.map((label) => (
+              <th
+                key={label}
+                className="whitespace-nowrap py-3 font-semibold text-base-content/50 text-xs uppercase tracking-wider"
+              >
+                {label}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {loading ? (
+            ["sk0", "sk1", "sk2", "sk3", "sk4"].map((id, i) => (
+              <tr key={id}>
+                {columns.map((col) => (
+                  <td key={col} className="py-3">
+                    <div
+                      className="skeleton-shimmer h-4 w-full rounded"
+                      style={{ animationDelay: `${i * 60}ms` }}
+                    />
+                  </td>
+                ))}
+              </tr>
+            ))
+          ) : rowCount > 0 ? (
+            children
+          ) : (
+            <tr>
+              <td
+                colSpan={columns.length}
+                className="py-12 text-center text-base-content/40"
+              >
+                {emptyMessage}
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/@robopo/web/app/components/summary/MultiSortToolbar.tsx
+++ b/@robopo/web/app/components/summary/MultiSortToolbar.tsx
@@ -1,0 +1,131 @@
+"use client"
+
+import {
+  BarsArrowDownIcon,
+  BarsArrowUpIcon,
+  MagnifyingGlassIcon,
+  PlusIcon,
+  XMarkIcon,
+} from "@heroicons/react/24/outline"
+import type {
+  SortCondition,
+  SortOrder,
+} from "@/app/components/summary/useMultiSort"
+
+type SortOption<K extends string> = {
+  value: K
+  label: string
+}
+
+type Props<K extends string> = {
+  searchPlaceholder: string
+  searchQuery: string
+  onSearchChange: (value: string) => void
+  sortConditions: SortCondition<K>[]
+  availableKeys: SortOption<K>[]
+  getSortLabel: (key: K) => string
+  getOrderLabel: (key: K, order: SortOrder) => string
+  onToggleOrder: (index: number) => void
+  onRemoveSort: (index: number) => void
+  onAddSort: (key: K) => void
+  onReset?: () => void
+}
+
+export function MultiSortToolbar<K extends string>({
+  searchPlaceholder,
+  searchQuery,
+  onSearchChange,
+  sortConditions,
+  availableKeys,
+  getSortLabel,
+  getOrderLabel,
+  onToggleOrder,
+  onRemoveSort,
+  onAddSort,
+  onReset,
+}: Props<K>) {
+  return (
+    <div className="flex shrink-0 flex-col gap-3 px-4 pb-4">
+      <label className="input input-bordered flex items-center gap-2 rounded-xl bg-base-200/40 transition-colors focus-within:bg-base-100">
+        <MagnifyingGlassIcon className="size-4 shrink-0 text-base-content/40" />
+        <input
+          type="text"
+          placeholder={searchPlaceholder}
+          className="grow"
+          value={searchQuery}
+          onChange={(e) => onSearchChange(e.target.value)}
+        />
+      </label>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="shrink-0 text-base-content/40 text-xs">ソート:</span>
+        {sortConditions.map((sc, index) => (
+          <div
+            key={sc.key}
+            className="flex items-center gap-1 rounded-lg border border-base-300 bg-base-100 px-2 py-1 shadow-sm"
+          >
+            <span className="flex size-4 items-center justify-center rounded-full bg-primary/10 font-bold text-primary text-xs">
+              {index + 1}
+            </span>
+            <span className="font-medium text-xs">{getSortLabel(sc.key)}</span>
+            <button
+              type="button"
+              className="flex items-center gap-0.5 rounded-md bg-base-200/60 px-1.5 py-0.5 text-xs transition-colors hover:bg-base-300/60"
+              onClick={() => onToggleOrder(index)}
+            >
+              {sc.order === "desc" ? (
+                <BarsArrowDownIcon className="size-3" />
+              ) : (
+                <BarsArrowUpIcon className="size-3" />
+              )}
+              {getOrderLabel(sc.key, sc.order)}
+            </button>
+            <button
+              type="button"
+              className="flex items-center justify-center rounded-full p-0.5 text-base-content/40 transition-colors hover:bg-error/10 hover:text-error"
+              onClick={() => onRemoveSort(index)}
+              aria-label={`${getSortLabel(sc.key)}のソートを削除`}
+            >
+              <XMarkIcon className="size-3.5" />
+            </button>
+          </div>
+        ))}
+
+        {availableKeys.length > 0 && (
+          <div className="flex items-center gap-1 rounded-lg bg-base-200/50 px-1.5 py-1">
+            <PlusIcon className="size-3.5 shrink-0 text-base-content/40" />
+            <select
+              className="select select-ghost select-xs bg-transparent font-medium text-base-content/60 focus:outline-none [&>option]:bg-base-100 [&>option]:text-base-content"
+              value=""
+              onChange={(e) => {
+                if (e.target.value) {
+                  onAddSort(e.target.value as K)
+                  e.target.value = ""
+                }
+              }}
+            >
+              <option value="" disabled>
+                追加
+              </option>
+              {availableKeys.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        {onReset && (
+          <button
+            type="button"
+            className="text-base-content/40 text-xs transition-colors hover:text-error"
+            onClick={onReset}
+          >
+            リセット
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/@robopo/web/app/components/summary/useMultiSort.ts
+++ b/@robopo/web/app/components/summary/useMultiSort.ts
@@ -1,0 +1,85 @@
+"use client"
+
+import { useMemo, useState } from "react"
+
+export type SortOrder = "asc" | "desc"
+
+export type SortCondition<K extends string> = {
+  key: K
+  order: SortOrder
+}
+
+type UseMultiSortArgs<T, K extends string> = {
+  data: T[]
+  defaultSort: SortCondition<K>[]
+  compareByKey: (a: T, b: T, key: K) => number
+  allKeys: { value: K; label: string }[]
+}
+
+export function useMultiSort<T, K extends string>({
+  data,
+  defaultSort,
+  compareByKey,
+  allKeys,
+}: UseMultiSortArgs<T, K>) {
+  const [conditions, setConditions] = useState<SortCondition<K>[]>(defaultSort)
+
+  const addSort = (key: K) => {
+    setConditions((prev) =>
+      prev.some((c) => c.key === key)
+        ? prev
+        : [...prev, { key, order: "desc" as SortOrder }],
+    )
+  }
+
+  const removeSort = (index: number) => {
+    setConditions((prev) => prev.filter((_, i) => i !== index))
+  }
+
+  const toggleOrder = (index: number) => {
+    setConditions((prev) =>
+      prev.map((c, i) =>
+        i === index
+          ? {
+              ...c,
+              order:
+                c.order === "asc"
+                  ? ("desc" as SortOrder)
+                  : ("asc" as SortOrder),
+            }
+          : c,
+      ),
+    )
+  }
+
+  const resetSort = () => {
+    setConditions(defaultSort)
+  }
+
+  const availableKeys = useMemo(
+    () => allKeys.filter((opt) => !conditions.some((c) => c.key === opt.value)),
+    [allKeys, conditions],
+  )
+
+  const sorted = useMemo(() => {
+    return [...data].sort((a, b) => {
+      for (const { key, order } of conditions) {
+        const cmp = compareByKey(a, b, key)
+        if (cmp !== 0) {
+          return order === "asc" ? cmp : -cmp
+        }
+      }
+      return 0
+    })
+  }, [data, conditions, compareByKey])
+
+  return {
+    sorted,
+    conditions,
+    addSort,
+    removeSort,
+    toggleOrder,
+    resetSort,
+    availableKeys,
+  }
+}

--- a/@robopo/web/app/components/summary/utils.tsx
+++ b/@robopo/web/app/components/summary/utils.tsx
@@ -1,6 +1,36 @@
 import { calcPoint } from "@/app/components/challenge/utils"
 import type { PointState } from "@/app/components/course/utils"
 
+export type JudgeSummary = {
+  judgeId: number
+  judgeName: string
+  scoredPlayerCount: number
+  scoredPlayerNames: string[]
+  firstScoringTime: string | null
+  lastScoringTime: string | null
+  totalScoringCount: number
+  courseCount: number
+  courseNames: string[]
+  averageScore: number | null
+  courseOutCount: number
+}
+
+export type CourseCompetitionSummary = {
+  courseId: number
+  courseName: string
+  firstChallengeTime: string | null
+  firstCompletionTime: string | null
+  lastChallengeTime: string | null
+  challengerCount: number
+  completionCount: number
+  completionRate: number | null
+  totalChallengeCount: number
+  averageScore: number | null
+  maxScore: number | null
+  courseOutCount: number
+  retryCount: number
+}
+
 export type CourseSummary = {
   playerId: number | null
   playerName: string | null
@@ -23,6 +53,19 @@ export type CourseSummary = {
   pointRank: number | null
   challengeCount: number | null
   challengeRank: number | null
+}
+
+// Format ISO timestamp for display
+export function formatTimestamp(iso: string | null): string {
+  if (!iso) {
+    return "-"
+  }
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) {
+    return "-"
+  }
+  const pad = (n: number) => String(n).padStart(2, "0")
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
 }
 
 // Course completion check function

--- a/@robopo/web/app/lib/db/queries/queries.ts
+++ b/@robopo/web/app/lib/db/queries/queries.ts
@@ -1,5 +1,8 @@
 import { and, count, eq, inArray, ne, type SQLWrapper, sql } from "drizzle-orm"
-import type { CourseSummary } from "@/app/components/summary/utils"
+import type {
+  CourseSummary,
+  JudgeSummary,
+} from "@/app/components/summary/utils"
 import { db } from "@/app/lib/db/db"
 import {
   challenge,
@@ -758,4 +761,85 @@ export async function getLinkedCourseIds(
     .where(inArray(competitionCourse.courseId, courseIds))
     .groupBy(competitionCourse.courseId)
   return result.map((r) => r.courseId)
+}
+
+// Get judge summary by competition (aggregated stats per judge)
+export async function getJudgeSummaryByCompetition(
+  competitionId: number,
+): Promise<JudgeSummary[]> {
+  const result = await db.execute(sql`
+    SELECT
+      j.id AS "judgeId",
+      j.name AS "judgeName",
+      COUNT(DISTINCT c.player_id)::int AS "scoredPlayerCount",
+      array_agg(DISTINCT p.name) AS "scoredPlayerNames",
+      TO_CHAR(MIN(c.created_at) AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo', 'YYYY-MM-DD"T"HH24:MI:SS"+09:00"') AS "firstScoringTime",
+      TO_CHAR(MAX(c.created_at) AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo', 'YYYY-MM-DD"T"HH24:MI:SS"+09:00"') AS "lastScoringTime",
+      COUNT(c.id)::int AS "totalScoringCount",
+      COUNT(DISTINCT c.course_id)::int AS "courseCount",
+      array_agg(DISTINCT co.name) AS "courseNames",
+      ROUND(AVG(GREATEST(c.first_result, COALESCE(c.retry_result, 0)))::numeric, 1)::float AS "averageScore",
+      SUM(
+        CASE WHEN c.detail = 'courseOut:first' THEN 1 ELSE 0 END
+        + CASE WHEN c.detail = 'courseOut:retry' THEN 1 ELSE 0 END
+      )::int AS "courseOutCount"
+    FROM judge j
+    INNER JOIN challenge c ON c.judge_id = j.id AND c.competition_id = ${competitionId}
+    INNER JOIN player p ON p.id = c.player_id
+    INNER JOIN course co ON co.id = c.course_id
+    GROUP BY j.id, j.name
+    ORDER BY j.id
+  `)
+  return result.rows as JudgeSummary[]
+}
+
+// Get course summary by competition (aggregated stats per course)
+export async function getCourseSummaryByCompetition(
+  competitionId: number,
+): Promise<
+  {
+    courseId: number
+    courseName: string
+    firstChallengeTime: string | null
+    lastChallengeTime: string | null
+    challengerCount: number
+    totalChallengeCount: number
+    averageRawScore: number | null
+    maxRawScore: number | null
+    courseOutCount: number
+    retryCount: number
+  }[]
+> {
+  const result = await db.execute(sql`
+    SELECT
+      co.id AS "courseId",
+      co.name AS "courseName",
+      TO_CHAR(MIN(c.created_at) AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo', 'YYYY-MM-DD"T"HH24:MI:SS"+09:00"') AS "firstChallengeTime",
+      TO_CHAR(MAX(c.created_at) AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo', 'YYYY-MM-DD"T"HH24:MI:SS"+09:00"') AS "lastChallengeTime",
+      COUNT(DISTINCT c.player_id)::int AS "challengerCount",
+      SUM(CASE WHEN c.retry_result IS NULL THEN 1 ELSE 2 END)::int AS "totalChallengeCount",
+      ROUND(AVG(GREATEST(c.first_result, COALESCE(c.retry_result, 0)))::numeric, 1)::float AS "averageRawScore",
+      MAX(GREATEST(c.first_result, COALESCE(c.retry_result, 0)))::int AS "maxRawScore",
+      SUM(
+        CASE WHEN c.detail = 'courseOut:first' THEN 1 ELSE 0 END
+        + CASE WHEN c.detail = 'courseOut:retry' THEN 1 ELSE 0 END
+      )::int AS "courseOutCount",
+      SUM(CASE WHEN c.retry_result IS NOT NULL THEN 1 ELSE 0 END)::int AS "retryCount"
+    FROM course co
+    INNER JOIN challenge c ON c.course_id = co.id AND c.competition_id = ${competitionId}
+    GROUP BY co.id, co.name
+    ORDER BY co.id
+  `)
+  return result.rows as {
+    courseId: number
+    courseName: string
+    firstChallengeTime: string | null
+    lastChallengeTime: string | null
+    challengerCount: number
+    totalChallengeCount: number
+    averageRawScore: number | null
+    maxRawScore: number | null
+    courseOutCount: number
+    retryCount: number
+  }[]
 }

--- a/@robopo/web/app/summary/courseSummaryTable.tsx
+++ b/@robopo/web/app/summary/courseSummaryTable.tsx
@@ -1,0 +1,216 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { DataTableShell } from "@/app/components/summary/DataTableShell"
+import { MultiSortToolbar } from "@/app/components/summary/MultiSortToolbar"
+import { useMultiSort } from "@/app/components/summary/useMultiSort"
+import {
+  type CourseCompetitionSummary,
+  formatTimestamp,
+} from "@/app/components/summary/utils"
+
+type CourseSortKey =
+  | "courseName"
+  | "firstChallengeTime"
+  | "firstCompletionTime"
+  | "lastChallengeTime"
+  | "challengerCount"
+  | "completionCount"
+  | "completionRate"
+  | "totalChallengeCount"
+  | "averageScore"
+  | "maxScore"
+  | "courseOutCount"
+  | "retryCount"
+
+const SORT_OPTIONS: { value: CourseSortKey; label: string }[] = [
+  { value: "courseName", label: "コース名" },
+  { value: "firstChallengeTime", label: "初挑戦時刻" },
+  { value: "firstCompletionTime", label: "初完走時刻" },
+  { value: "lastChallengeTime", label: "最終挑戦時刻" },
+  { value: "challengerCount", label: "挑戦者数" },
+  { value: "completionCount", label: "完走者数" },
+  { value: "completionRate", label: "完走率" },
+  { value: "totalChallengeCount", label: "総挑戦回数" },
+  { value: "averageScore", label: "平均スコア" },
+  { value: "maxScore", label: "最高スコア" },
+  { value: "courseOutCount", label: "コースアウト数" },
+  { value: "retryCount", label: "リトライ数" },
+]
+
+const TIME_SORT_KEYS = new Set<CourseSortKey>([
+  "firstChallengeTime",
+  "firstCompletionTime",
+  "lastChallengeTime",
+])
+
+function getSortLabel(key: CourseSortKey): string {
+  return SORT_OPTIONS.find((o) => o.value === key)?.label ?? key
+}
+
+function getOrderLabel(key: CourseSortKey, order: "asc" | "desc"): string {
+  if (key === "courseName") {
+    return order === "desc" ? "Z→A" : "A→Z"
+  }
+  if (TIME_SORT_KEYS.has(key)) {
+    return order === "desc" ? "新しい順" : "古い順"
+  }
+  return order === "desc" ? "大きい順" : "小さい順"
+}
+
+const compareByKey = (
+  a: CourseCompetitionSummary,
+  b: CourseCompetitionSummary,
+  key: CourseSortKey,
+): number => {
+  switch (key) {
+    case "courseName":
+      return (a.courseName ?? "").localeCompare(b.courseName ?? "", "ja")
+    case "firstChallengeTime":
+    case "firstCompletionTime":
+    case "lastChallengeTime": {
+      const aTime = a[key] ? Date.parse(a[key] as string) : Infinity
+      const bTime = b[key] ? Date.parse(b[key] as string) : Infinity
+      return aTime - bTime
+    }
+    default: {
+      const aV = (a[key] as number) ?? 0
+      const bV = (b[key] as number) ?? 0
+      return aV - bV
+    }
+  }
+}
+
+type Props = {
+  competitionId: number
+}
+
+export function CourseSummaryTable({ competitionId }: Props) {
+  const [rawData, setRawData] = useState<CourseCompetitionSummary[]>([])
+  const [loading, setLoading] = useState(false)
+  const [searchQuery, setSearchQuery] = useState("")
+
+  const filtered = (() => {
+    if (!searchQuery.trim()) {
+      return rawData
+    }
+    const q = searchQuery.trim().toLowerCase()
+    return rawData.filter(
+      (c) => c.courseName?.toLowerCase().includes(q) ?? false,
+    )
+  })()
+
+  const {
+    sorted: filteredAndSorted,
+    conditions: sortConditions,
+    addSort,
+    removeSort,
+    toggleOrder,
+    resetSort,
+    availableKeys,
+  } = useMultiSort<CourseCompetitionSummary, CourseSortKey>({
+    data: filtered,
+    defaultSort: [{ key: "challengerCount", order: "desc" }],
+    compareByKey,
+    allKeys: SORT_OPTIONS,
+  })
+
+  useEffect(() => {
+    if (!competitionId) {
+      setRawData([])
+      return
+    }
+    async function fetchData() {
+      setLoading(true)
+      try {
+        const res = await fetch(`/api/summary/course-list/${competitionId}`, {
+          cache: "no-store",
+        })
+        const data = await res.json()
+        setRawData(data)
+      } catch (error) {
+        console.error(error)
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchData()
+  }, [competitionId])
+
+  const columns = [
+    "ID",
+    "コース名",
+    "初挑戦時刻",
+    "初完走時刻",
+    "最終挑戦時刻",
+    "挑戦者数",
+    "完走者数",
+    "完走率",
+    "総挑戦回数",
+    "平均スコア",
+    "最高スコア",
+    "コースアウト数",
+    "リトライ数",
+  ]
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <MultiSortToolbar<CourseSortKey>
+        searchPlaceholder="コース名で検索"
+        searchQuery={searchQuery}
+        onSearchChange={setSearchQuery}
+        sortConditions={sortConditions}
+        availableKeys={availableKeys}
+        getSortLabel={getSortLabel}
+        getOrderLabel={getOrderLabel}
+        onToggleOrder={toggleOrder}
+        onRemoveSort={removeSort}
+        onAddSort={addSort}
+        onReset={sortConditions.length > 1 ? resetSort : undefined}
+      />
+
+      <div className="min-h-0 flex-1 overflow-x-auto overflow-y-auto">
+        <DataTableShell
+          columns={columns}
+          loading={loading}
+          rowCount={filteredAndSorted.length}
+          hasSearchQuery={!!searchQuery}
+          noMatchMessage="条件に一致するコースが見つかりません"
+        >
+          {filteredAndSorted.map((course) => (
+            <tr
+              key={course.courseId}
+              className="transition-colors duration-150 hover:bg-primary/5"
+            >
+              <td className="py-3">{course.courseId}</td>
+              <td className="whitespace-nowrap py-3 font-medium">
+                {course.courseName}
+              </td>
+              <td className="whitespace-nowrap py-3">
+                {formatTimestamp(course.firstChallengeTime)}
+              </td>
+              <td className="whitespace-nowrap py-3">
+                {formatTimestamp(course.firstCompletionTime)}
+              </td>
+              <td className="whitespace-nowrap py-3">
+                {formatTimestamp(course.lastChallengeTime)}
+              </td>
+              <td className="py-3">{course.challengerCount}</td>
+              <td className="py-3">{course.completionCount}</td>
+              <td className="py-3">
+                {course.completionRate !== null
+                  ? `${course.completionRate}%`
+                  : "-"}
+              </td>
+              <td className="py-3">{course.totalChallengeCount}</td>
+              <td className="py-3">{course.averageScore ?? "-"}</td>
+              <td className="py-3">{course.maxScore ?? "-"}</td>
+              <td className="py-3">{course.courseOutCount}</td>
+              <td className="py-3">{course.retryCount}</td>
+            </tr>
+          ))}
+        </DataTableShell>
+      </div>
+    </div>
+  )
+}

--- a/@robopo/web/app/summary/judgeSummaryTable.tsx
+++ b/@robopo/web/app/summary/judgeSummaryTable.tsx
@@ -1,0 +1,268 @@
+"use client"
+
+import { XMarkIcon } from "@heroicons/react/24/outline"
+import { useEffect, useState } from "react"
+import { DataTableShell } from "@/app/components/summary/DataTableShell"
+import { MultiSortToolbar } from "@/app/components/summary/MultiSortToolbar"
+import { useMultiSort } from "@/app/components/summary/useMultiSort"
+import {
+  formatTimestamp,
+  type JudgeSummary,
+} from "@/app/components/summary/utils"
+
+type JudgeSortKey =
+  | "judgeName"
+  | "scoredPlayerCount"
+  | "firstScoringTime"
+  | "lastScoringTime"
+  | "totalScoringCount"
+  | "courseCount"
+  | "averageScore"
+  | "courseOutCount"
+
+const SORT_OPTIONS: { value: JudgeSortKey; label: string }[] = [
+  { value: "judgeName", label: "採点者名" },
+  { value: "scoredPlayerCount", label: "採点人数" },
+  { value: "firstScoringTime", label: "初採点時刻" },
+  { value: "lastScoringTime", label: "最終採点時刻" },
+  { value: "totalScoringCount", label: "採点回数" },
+  { value: "courseCount", label: "担当コース数" },
+  { value: "averageScore", label: "平均スコア" },
+  { value: "courseOutCount", label: "コースアウト判定数" },
+]
+
+const TIME_SORT_KEYS = new Set<JudgeSortKey>([
+  "firstScoringTime",
+  "lastScoringTime",
+])
+
+function getSortLabel(key: JudgeSortKey): string {
+  return SORT_OPTIONS.find((o) => o.value === key)?.label ?? key
+}
+
+function getOrderLabel(key: JudgeSortKey, order: "asc" | "desc"): string {
+  if (key === "judgeName") {
+    return order === "desc" ? "Z→A" : "A→Z"
+  }
+  if (TIME_SORT_KEYS.has(key)) {
+    return order === "desc" ? "新しい順" : "古い順"
+  }
+  return order === "desc" ? "大きい順" : "小さい順"
+}
+
+const compareByKey = (
+  a: JudgeSummary,
+  b: JudgeSummary,
+  key: JudgeSortKey,
+): number => {
+  switch (key) {
+    case "judgeName":
+      return (a.judgeName ?? "").localeCompare(b.judgeName ?? "", "ja")
+    case "firstScoringTime":
+    case "lastScoringTime": {
+      const aTime = a[key] ? Date.parse(a[key] as string) : Infinity
+      const bTime = b[key] ? Date.parse(b[key] as string) : Infinity
+      return aTime - bTime
+    }
+    default: {
+      const aV = (a[key] as number) ?? 0
+      const bV = (b[key] as number) ?? 0
+      return aV - bV
+    }
+  }
+}
+
+type Props = {
+  competitionId: number
+}
+
+export function JudgeSummaryTable({ competitionId }: Props) {
+  const [rawData, setRawData] = useState<JudgeSummary[]>([])
+  const [loading, setLoading] = useState(false)
+  const [searchQuery, setSearchQuery] = useState("")
+  const [playerDetailNames, setPlayerDetailNames] = useState<string[] | null>(
+    null,
+  )
+
+  const filtered = (() => {
+    if (!searchQuery.trim()) {
+      return rawData
+    }
+    const q = searchQuery.trim().toLowerCase()
+    return rawData.filter(
+      (j) => j.judgeName?.toLowerCase().includes(q) ?? false,
+    )
+  })()
+
+  const {
+    sorted: filteredAndSorted,
+    conditions: sortConditions,
+    addSort,
+    removeSort,
+    toggleOrder,
+    resetSort,
+    availableKeys,
+  } = useMultiSort<JudgeSummary, JudgeSortKey>({
+    data: filtered,
+    defaultSort: [{ key: "totalScoringCount", order: "desc" }],
+    compareByKey,
+    allKeys: SORT_OPTIONS,
+  })
+
+  useEffect(() => {
+    if (!competitionId) {
+      setRawData([])
+      return
+    }
+    async function fetchData() {
+      setLoading(true)
+      try {
+        const res = await fetch(`/api/summary/judge/${competitionId}`, {
+          cache: "no-store",
+        })
+        const data = await res.json()
+        setRawData(data)
+      } catch (error) {
+        console.error(error)
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchData()
+  }, [competitionId])
+
+  const columns = [
+    "ID",
+    "採点者名",
+    "採点人数",
+    "初採点時刻",
+    "最終採点時刻",
+    "採点回数",
+    "担当コース数",
+    "担当コース",
+    "平均スコア",
+    "コースアウト判定数",
+  ]
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <MultiSortToolbar<JudgeSortKey>
+        searchPlaceholder="採点者名で検索"
+        searchQuery={searchQuery}
+        onSearchChange={setSearchQuery}
+        sortConditions={sortConditions}
+        availableKeys={availableKeys}
+        getSortLabel={getSortLabel}
+        getOrderLabel={getOrderLabel}
+        onToggleOrder={toggleOrder}
+        onRemoveSort={removeSort}
+        onAddSort={addSort}
+        onReset={sortConditions.length > 1 ? resetSort : undefined}
+      />
+
+      <div className="min-h-0 flex-1 overflow-x-auto overflow-y-auto">
+        <DataTableShell
+          columns={columns}
+          loading={loading}
+          rowCount={filteredAndSorted.length}
+          hasSearchQuery={!!searchQuery}
+          noMatchMessage="条件に一致する採点者が見つかりません"
+        >
+          {filteredAndSorted.map((judge) => (
+            <tr
+              key={judge.judgeId}
+              className="transition-colors duration-150 hover:bg-primary/5"
+            >
+              <td className="py-3">{judge.judgeId}</td>
+              <td className="whitespace-nowrap py-3 font-medium">
+                {judge.judgeName}
+              </td>
+              <td className="py-3">
+                <button
+                  type="button"
+                  className="badge badge-primary badge-outline cursor-pointer transition-colors hover:bg-primary hover:text-primary-content"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    setPlayerDetailNames(judge.scoredPlayerNames ?? [])
+                  }}
+                >
+                  {judge.scoredPlayerCount}
+                </button>
+              </td>
+              <td className="whitespace-nowrap py-3">
+                {formatTimestamp(judge.firstScoringTime)}
+              </td>
+              <td className="whitespace-nowrap py-3">
+                {formatTimestamp(judge.lastScoringTime)}
+              </td>
+              <td className="py-3">{judge.totalScoringCount}</td>
+              <td className="py-3">{judge.courseCount}</td>
+              <td className="max-w-[200px] py-3">
+                <div className="line-clamp-2 text-xs">
+                  {judge.courseNames?.join(", ") || "-"}
+                </div>
+              </td>
+              <td className="py-3">{judge.averageScore ?? "-"}</td>
+              <td className="py-3">{judge.courseOutCount}</td>
+            </tr>
+          ))}
+        </DataTableShell>
+      </div>
+
+      {/* Player detail modal */}
+      {playerDetailNames !== null && (
+        <dialog className="modal modal-open">
+          <div className="modal-box max-w-sm">
+            <div className="mb-4 flex items-center justify-between">
+              <h3 className="font-bold text-lg">採点選手一覧</h3>
+              <button
+                type="button"
+                className="btn btn-ghost btn-sm btn-circle"
+                onClick={() => setPlayerDetailNames(null)}
+              >
+                <XMarkIcon className="size-5" />
+              </button>
+            </div>
+            <div className="max-h-[60vh] overflow-y-auto">
+              {playerDetailNames.length > 0 ? (
+                <ul className="space-y-1.5">
+                  {playerDetailNames.map((name) => (
+                    <li
+                      key={name}
+                      className="rounded-lg bg-base-200/50 px-3 py-2.5 text-sm"
+                    >
+                      {name}
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="py-4 text-center text-base-content/40 text-sm">
+                  採点した選手はいません
+                </p>
+              )}
+            </div>
+            <div className="modal-action">
+              <button
+                type="button"
+                className="btn rounded-lg"
+                onClick={() => setPlayerDetailNames(null)}
+              >
+                閉じる
+              </button>
+            </div>
+          </div>
+          <form
+            method="dialog"
+            className="modal-backdrop"
+            onClick={() => setPlayerDetailNames(null)}
+            onKeyDown={(e) => e.key === "Escape" && setPlayerDetailNames(null)}
+          >
+            <button type="button" className="cursor-default">
+              close
+            </button>
+          </form>
+        </dialog>
+      )}
+    </div>
+  )
+}

--- a/@robopo/web/app/summary/playerSummaryTable.tsx
+++ b/@robopo/web/app/summary/playerSummaryTable.tsx
@@ -1,0 +1,380 @@
+"use client"
+
+import Link from "next/link"
+import { useCallback, useEffect, useState } from "react"
+import { calcPoint } from "@/app/components/challenge/utils"
+import {
+  deserializePoint,
+  type PointState,
+} from "@/app/components/course/utils"
+import { DataTableShell } from "@/app/components/summary/DataTableShell"
+import { MultiSortToolbar } from "@/app/components/summary/MultiSortToolbar"
+import { useMultiSort } from "@/app/components/summary/useMultiSort"
+import {
+  type CourseSummary,
+  formatTimestamp,
+  isCompletedCourse,
+} from "@/app/components/summary/utils"
+import type { SelectCourse } from "@/app/lib/db/schema"
+
+type SortKey =
+  | "playerFurigana"
+  | "playerBibNumber"
+  | "firstAttemptTime"
+  | "firstMaxAttemptTime"
+  | "elapsedToComplete"
+  | "lastAttemptTime"
+  | "firstMaxAttemptCount"
+  | "firstAttemptScore"
+  | "maxResult"
+  | "averageScore"
+  | "totalPoint"
+  | "sumPoint"
+  | "courseOutCount"
+  | "retryCount"
+  | "challengeCount"
+
+const SORT_OPTIONS: { value: SortKey; label: string }[] = [
+  { value: "playerFurigana", label: "ふりがな" },
+  { value: "playerBibNumber", label: "ゼッケン" },
+  { value: "firstAttemptTime", label: "初挑戦時刻" },
+  { value: "firstMaxAttemptTime", label: "完走時刻" },
+  { value: "elapsedToComplete", label: "完走経過時間" },
+  { value: "lastAttemptTime", label: "最終挑戦時刻" },
+  { value: "firstMaxAttemptCount", label: "完走数" },
+  { value: "firstAttemptScore", label: "初回得点" },
+  { value: "maxResult", label: "最高得点" },
+  { value: "averageScore", label: "平均得点" },
+  { value: "totalPoint", label: "総得点" },
+  { value: "sumPoint", label: "合計得点" },
+  { value: "courseOutCount", label: "コースアウト数" },
+  { value: "retryCount", label: "リトライ回数" },
+  { value: "challengeCount", label: "挑戦回数" },
+]
+
+const TIME_SORT_KEYS = new Set<SortKey>([
+  "firstAttemptTime",
+  "firstMaxAttemptTime",
+  "lastAttemptTime",
+])
+
+function getSortLabel(key: SortKey): string {
+  return SORT_OPTIONS.find((o) => o.value === key)?.label ?? key
+}
+
+function getOrderLabel(key: SortKey, order: "asc" | "desc"): string {
+  if (key === "playerFurigana") {
+    return order === "desc" ? "Z→A" : "A→Z"
+  }
+  if (TIME_SORT_KEYS.has(key)) {
+    return order === "desc" ? "新しい順" : "古い順"
+  }
+  return order === "desc" ? "大きい順" : "小さい順"
+}
+
+type Props = {
+  competitionId: number
+}
+
+export function PlayerSummaryTable({ competitionId }: Props) {
+  const [courses, setCourses] = useState<SelectCourse[]>([])
+  const [courseId, setCourseId] = useState<number | null>(null)
+  const [pointData, setPointData] = useState<PointState>([])
+  const [rawSummary, setRawSummary] = useState<CourseSummary[]>([])
+  const [loading, setLoading] = useState(false)
+  const [searchQuery, setSearchQuery] = useState("")
+
+  const compareByKey = useCallback(
+    (a: CourseSummary, b: CourseSummary, key: SortKey): number => {
+      switch (key) {
+        case "playerFurigana":
+          return (a.playerFurigana ?? "").localeCompare(
+            b.playerFurigana ?? "",
+            "ja",
+          )
+        case "playerBibNumber": {
+          const aNum = Number(a.playerBibNumber)
+          const bNum = Number(b.playerBibNumber)
+          if (!Number.isNaN(aNum) && !Number.isNaN(bNum)) {
+            return aNum - bNum
+          }
+          return (a.playerBibNumber ?? "").localeCompare(
+            b.playerBibNumber ?? "",
+            "ja",
+            { numeric: true },
+          )
+        }
+        case "firstAttemptTime":
+        case "lastAttemptTime": {
+          const aTime = a[key] ? Date.parse(a[key] as string) : Infinity
+          const bTime = b[key] ? Date.parse(b[key] as string) : Infinity
+          return aTime - bTime
+        }
+        case "firstMaxAttemptTime": {
+          const aC = isCompletedCourse(pointData, a.maxResult)
+          const bC = isCompletedCourse(pointData, b.maxResult)
+          const aT =
+            aC && a.firstMaxAttemptTime
+              ? Date.parse(a.firstMaxAttemptTime)
+              : Infinity
+          const bT =
+            bC && b.firstMaxAttemptTime
+              ? Date.parse(b.firstMaxAttemptTime)
+              : Infinity
+          return aT - bT
+        }
+        case "elapsedToComplete": {
+          const aV = a.elapsedToCompleteSeconds ?? Infinity
+          const bV = b.elapsedToCompleteSeconds ?? Infinity
+          return aV - bV
+        }
+        case "firstMaxAttemptCount": {
+          const aC = isCompletedCourse(pointData, a.maxResult)
+          const bC = isCompletedCourse(pointData, b.maxResult)
+          const aV = aC ? (a.firstMaxAttemptCount ?? Infinity) : Infinity
+          const bV = bC ? (b.firstMaxAttemptCount ?? Infinity) : Infinity
+          return aV - bV
+        }
+        default: {
+          const aV = (a[key] as number) ?? 0
+          const bV = (b[key] as number) ?? 0
+          return aV - bV
+        }
+      }
+    },
+    [pointData],
+  )
+
+  const filtered = (() => {
+    if (!searchQuery.trim()) {
+      return rawSummary
+    }
+    const q = searchQuery.trim().toLowerCase()
+    return rawSummary.filter(
+      (p) =>
+        (p.playerName?.toLowerCase().includes(q) ?? false) ||
+        (p.playerFurigana?.toLowerCase().includes(q) ?? false) ||
+        (p.playerBibNumber?.toLowerCase().includes(q) ?? false),
+    )
+  })()
+
+  const {
+    sorted: filteredAndSorted,
+    conditions: sortConditions,
+    addSort,
+    removeSort,
+    toggleOrder,
+    resetSort,
+    availableKeys,
+  } = useMultiSort<CourseSummary, SortKey>({
+    data: filtered,
+    defaultSort: [{ key: "totalPoint", order: "desc" }],
+    compareByKey,
+    allKeys: SORT_OPTIONS,
+  })
+
+  // Fetch courses when competition changes
+  useEffect(() => {
+    if (!competitionId) {
+      setCourses([])
+      setCourseId(null)
+      return
+    }
+    async function fetchCourses() {
+      try {
+        const res = await fetch(`/api/competition/${competitionId}/courses`, {
+          cache: "no-store",
+        })
+        if (res.ok) {
+          const data: SelectCourse[] = await res.json()
+          setCourses(data)
+          if (data.length > 0) {
+            const minId = data.reduce((min, c) => (c.id < min.id ? c : min)).id
+            setCourseId(minId)
+          } else {
+            setCourseId(null)
+          }
+        }
+      } catch (error) {
+        console.error(error)
+      }
+    }
+    fetchCourses()
+  }, [competitionId])
+
+  // Fetch summary data when course changes
+  useEffect(() => {
+    if (!competitionId || !courseId) {
+      setRawSummary([])
+      return
+    }
+    async function fetchData() {
+      setLoading(true)
+      try {
+        const selectedCourse = courses.find((c) => c.id === courseId)
+        if (selectedCourse) {
+          const point = await deserializePoint(selectedCourse.point)
+          setPointData(point)
+        }
+
+        const res = await fetch(`/api/summary/${competitionId}/${courseId}`, {
+          cache: "no-store",
+        })
+        const data = await res.json()
+        setRawSummary(data)
+      } catch (error) {
+        console.error(error)
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchData()
+  }, [competitionId, courseId, courses])
+
+  const columns = [
+    "名前",
+    "ふりがな",
+    "ゼッケン",
+    "初挑戦時刻",
+    "完走時刻",
+    "完走経過時間",
+    "最終挑戦時刻",
+    "完走数",
+    "初回得点",
+    "最高得点",
+    "平均得点",
+    "総得点",
+    "合計得点",
+    "コースアウト数",
+    "リトライ回数",
+    "挑戦回数",
+  ]
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      {/* Course selector */}
+      <div className="shrink-0 px-4 pb-2">
+        <div className="min-w-[200px]">
+          <label
+            htmlFor="player-summary-course"
+            className="mb-1 block font-semibold text-base-content/60 text-xs uppercase tracking-wider"
+          >
+            コース
+          </label>
+          <select
+            id="player-summary-course"
+            className="select select-bordered w-full"
+            value={courseId ?? 0}
+            onChange={(e) => setCourseId(Number(e.target.value))}
+            disabled={courses.length === 0}
+          >
+            <option value={0} disabled>
+              コースを選んでください
+            </option>
+            {courses.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <MultiSortToolbar<SortKey>
+        searchPlaceholder="名前・ふりがな・ゼッケン番号で検索"
+        searchQuery={searchQuery}
+        onSearchChange={setSearchQuery}
+        sortConditions={sortConditions}
+        availableKeys={availableKeys}
+        getSortLabel={getSortLabel}
+        getOrderLabel={getOrderLabel}
+        onToggleOrder={toggleOrder}
+        onRemoveSort={removeSort}
+        onAddSort={addSort}
+        onReset={sortConditions.length > 1 ? resetSort : undefined}
+      />
+
+      <div className="min-h-0 flex-1 overflow-x-auto overflow-y-auto">
+        <DataTableShell
+          columns={columns}
+          loading={loading}
+          rowCount={filteredAndSorted.length}
+          hasSearchQuery={!!searchQuery}
+          noMatchMessage="条件に一致する選手が見つかりません"
+        >
+          {filteredAndSorted.map((player) => (
+            <PlayerRow
+              key={player.playerId}
+              player={player}
+              competitionId={competitionId}
+              courseId={Number(courseId)}
+              pointData={pointData}
+            />
+          ))}
+        </DataTableShell>
+      </div>
+    </div>
+  )
+}
+
+function PlayerRow({
+  player,
+  competitionId,
+  courseId,
+  pointData,
+}: {
+  player: CourseSummary
+  competitionId: number
+  courseId: number
+  pointData: PointState
+}) {
+  const completed = isCompletedCourse(pointData, player.maxResult)
+  const maxScore =
+    player.maxResult || player.maxResult === 0
+      ? calcPoint(pointData, player.maxResult)
+      : null
+  const firstScore =
+    player.firstAttemptScore !== null
+      ? calcPoint(pointData, player.firstAttemptScore)
+      : null
+
+  return (
+    <tr className="transition-colors duration-150 hover:bg-primary/5">
+      <td className="whitespace-nowrap py-3 font-medium">
+        <Link
+          href={`/summary/${competitionId}/${courseId}/${player.playerId}`}
+          className="text-primary underline-offset-2 hover:underline"
+        >
+          {player.playerName ?? "-"}
+        </Link>
+      </td>
+      <td className="whitespace-nowrap py-3">{player.playerFurigana ?? "-"}</td>
+      <td className="py-3">{player.playerBibNumber ?? "-"}</td>
+      <td className="whitespace-nowrap py-3">
+        {formatTimestamp(player.firstAttemptTime)}
+      </td>
+      <td className="whitespace-nowrap py-3">
+        {completed ? formatTimestamp(player.firstMaxAttemptTime) : "-"}
+      </td>
+      <td className="whitespace-nowrap py-3">
+        {completed ? (player.elapsedToComplete ?? "-") : "-"}
+      </td>
+      <td className="whitespace-nowrap py-3">
+        {formatTimestamp(player.lastAttemptTime)}
+      </td>
+      <td className="py-3">
+        {completed && player.firstMaxAttemptCount
+          ? player.firstMaxAttemptCount
+          : "-"}
+      </td>
+      <td className="py-3">{firstScore !== null ? firstScore : "-"}</td>
+      <td className="py-3">{maxScore !== null ? maxScore : "-"}</td>
+      <td className="py-3">{player.averageScore ?? "-"}</td>
+      <td className="py-3 font-medium">{player.totalPoint ?? "-"}</td>
+      <td className="py-3">{player.sumPoint ?? "-"}</td>
+      <td className="py-3">{player.courseOutCount ?? 0}</td>
+      <td className="py-3">{player.retryCount ?? 0}</td>
+      <td className="py-3">{player.challengeCount}</td>
+    </tr>
+  )
+}

--- a/@robopo/web/app/summary/summaryView.tsx
+++ b/@robopo/web/app/summary/summaryView.tsx
@@ -1,147 +1,23 @@
 "use client"
 
 import {
-  BarsArrowDownIcon,
-  BarsArrowUpIcon,
-  MagnifyingGlassIcon,
-  PlusIcon,
-  XMarkIcon,
+  ClipboardDocumentCheckIcon,
+  MapIcon,
+  UserGroupIcon,
 } from "@heroicons/react/24/outline"
-import Link from "next/link"
-import { useEffect, useState } from "react"
-import { calcPoint } from "@/app/components/challenge/utils"
-import {
-  deserializePoint,
-  type PointState,
-} from "@/app/components/course/utils"
-import {
-  type CourseSummary,
-  isCompletedCourse,
-} from "@/app/components/summary/utils"
-import type { SelectCompetition, SelectCourse } from "@/app/lib/db/schema"
+import { useState } from "react"
+import type { SelectCompetition } from "@/app/lib/db/schema"
+import { CourseSummaryTable } from "@/app/summary/courseSummaryTable"
+import { JudgeSummaryTable } from "@/app/summary/judgeSummaryTable"
+import { PlayerSummaryTable } from "@/app/summary/playerSummaryTable"
 
-type SortKey =
-  | "playerFurigana"
-  | "playerBibNumber"
-  | "firstAttemptTime"
-  | "firstMaxAttemptTime"
-  | "elapsedToComplete"
-  | "lastAttemptTime"
-  | "firstMaxAttemptCount"
-  | "firstAttemptScore"
-  | "maxResult"
-  | "averageScore"
-  | "totalPoint"
-  | "sumPoint"
-  | "courseOutCount"
-  | "retryCount"
-  | "challengeCount"
+type TabKey = "player" | "judge" | "course"
 
-type SortCondition = {
-  key: SortKey
-  order: "asc" | "desc"
-}
-
-const SORT_OPTIONS: { value: SortKey; label: string }[] = [
-  { value: "playerFurigana", label: "ふりがな" },
-  { value: "playerBibNumber", label: "ゼッケン" },
-  { value: "firstAttemptTime", label: "初試行時刻" },
-  { value: "firstMaxAttemptTime", label: "完走時刻" },
-  { value: "elapsedToComplete", label: "完走経過時間" },
-  { value: "lastAttemptTime", label: "最終試行時刻" },
-  { value: "firstMaxAttemptCount", label: "完走数" },
-  { value: "firstAttemptScore", label: "初回得点" },
-  { value: "maxResult", label: "最高得点" },
-  { value: "averageScore", label: "平均得点" },
-  { value: "totalPoint", label: "総得点" },
-  { value: "sumPoint", label: "合計得点" },
-  { value: "courseOutCount", label: "コースアウト数" },
-  { value: "retryCount", label: "リトライ回数" },
-  { value: "challengeCount", label: "試行回数" },
+const TABS: { key: TabKey; label: string; icon: typeof UserGroupIcon }[] = [
+  { key: "player", label: "選手", icon: UserGroupIcon },
+  { key: "judge", label: "採点者", icon: ClipboardDocumentCheckIcon },
+  { key: "course", label: "コース", icon: MapIcon },
 ]
-
-const TIME_SORT_KEYS = new Set<SortKey>([
-  "firstAttemptTime",
-  "firstMaxAttemptTime",
-  "lastAttemptTime",
-])
-
-function getSortLabel(key: SortKey): string {
-  return SORT_OPTIONS.find((o) => o.value === key)?.label ?? key
-}
-
-function getOrderLabel(key: SortKey, order: "asc" | "desc"): string {
-  if (key === "playerFurigana") {
-    return order === "desc" ? "Z→A" : "A→Z"
-  }
-  if (TIME_SORT_KEYS.has(key)) {
-    return order === "desc" ? "新しい順" : "古い順"
-  }
-  return order === "desc" ? "大きい順" : "小さい順"
-}
-
-function compareBySortKey(
-  a: CourseSummary,
-  b: CourseSummary,
-  key: SortKey,
-  pointData: PointState,
-): number {
-  switch (key) {
-    case "playerFurigana":
-      return (a.playerFurigana ?? "").localeCompare(
-        b.playerFurigana ?? "",
-        "ja",
-      )
-    case "playerBibNumber": {
-      const aNum = Number(a.playerBibNumber)
-      const bNum = Number(b.playerBibNumber)
-      if (!Number.isNaN(aNum) && !Number.isNaN(bNum)) {
-        return aNum - bNum
-      }
-      return (a.playerBibNumber ?? "").localeCompare(
-        b.playerBibNumber ?? "",
-        "ja",
-        { numeric: true },
-      )
-    }
-    case "firstAttemptTime":
-    case "lastAttemptTime": {
-      const aTime = a[key] ? Date.parse(a[key] as string) : Infinity
-      const bTime = b[key] ? Date.parse(b[key] as string) : Infinity
-      return aTime - bTime
-    }
-    case "firstMaxAttemptTime": {
-      const aC = isCompletedCourse(pointData, a.maxResult)
-      const bC = isCompletedCourse(pointData, b.maxResult)
-      const aT =
-        aC && a.firstMaxAttemptTime
-          ? Date.parse(a.firstMaxAttemptTime)
-          : Infinity
-      const bT =
-        bC && b.firstMaxAttemptTime
-          ? Date.parse(b.firstMaxAttemptTime)
-          : Infinity
-      return aT - bT
-    }
-    case "elapsedToComplete": {
-      const aV = a.elapsedToCompleteSeconds ?? Infinity
-      const bV = b.elapsedToCompleteSeconds ?? Infinity
-      return aV - bV
-    }
-    case "firstMaxAttemptCount": {
-      const aC = isCompletedCourse(pointData, a.maxResult)
-      const bC = isCompletedCourse(pointData, b.maxResult)
-      const aV = aC ? (a.firstMaxAttemptCount ?? Infinity) : Infinity
-      const bV = bC ? (b.firstMaxAttemptCount ?? Infinity) : Infinity
-      return aV - bV
-    }
-    default: {
-      const aV = (a[key] as number) ?? 0
-      const bV = (b[key] as number) ?? 0
-      return aV - bV
-    }
-  }
-}
 
 type Props = {
   competitions: SelectCompetition[]
@@ -152,431 +28,76 @@ export function SummaryView({ competitions, defaultCompetitionId }: Props) {
   const [competitionId, setCompetitionId] = useState<number>(
     defaultCompetitionId ?? 0,
   )
-  const [courses, setCourses] = useState<SelectCourse[]>([])
-  const [courseId, setCourseId] = useState<number | null>(null)
-  const [pointData, setPointData] = useState<PointState>([])
-  const [rawSummary, setRawSummary] = useState<CourseSummary[]>([])
-  const [loading, setLoading] = useState(false)
-  const [searchQuery, setSearchQuery] = useState("")
-
-  // Multi-sort: array of conditions, first = highest priority
-  const [sortConditions, setSortConditions] = useState<SortCondition[]>([
-    { key: "totalPoint", order: "desc" },
-  ])
-
-  // Available keys not yet used in sort conditions
-  const availableKeys = SORT_OPTIONS.filter(
-    (opt) => !sortConditions.some((sc) => sc.key === opt.value),
-  )
-
-  const addSort = (key: SortKey) => {
-    if (sortConditions.some((sc) => sc.key === key)) {
-      return
-    }
-    setSortConditions((prev) => [...prev, { key, order: "desc" }])
-  }
-
-  const removeSort = (index: number) => {
-    setSortConditions((prev) => prev.filter((_, i) => i !== index))
-  }
-
-  const toggleOrder = (index: number) => {
-    setSortConditions((prev) =>
-      prev.map((sc, i) =>
-        i === index
-          ? { ...sc, order: sc.order === "asc" ? "desc" : "asc" }
-          : sc,
-      ),
-    )
-  }
-
-  // Fetch courses when competition changes
-  useEffect(() => {
-    if (!competitionId) {
-      setCourses([])
-      setCourseId(null)
-      return
-    }
-    async function fetchCourses() {
-      try {
-        const res = await fetch(`/api/competition/${competitionId}/courses`, {
-          cache: "no-store",
-        })
-        if (res.ok) {
-          const data: SelectCourse[] = await res.json()
-          setCourses(data)
-          if (data.length > 0) {
-            const minId = data.reduce((min, c) => (c.id < min.id ? c : min)).id
-            setCourseId(minId)
-          } else {
-            setCourseId(null)
-          }
-        }
-      } catch (error) {
-        console.error(error)
-      }
-    }
-    fetchCourses()
-  }, [competitionId])
-
-  // Fetch summary data when course changes
-  useEffect(() => {
-    if (!competitionId || !courseId) {
-      setRawSummary([])
-      return
-    }
-    async function fetchData() {
-      setLoading(true)
-      try {
-        const selectedCourse = courses.find((c) => c.id === courseId)
-        if (selectedCourse) {
-          const point = await deserializePoint(selectedCourse.point)
-          setPointData(point)
-        }
-
-        const res = await fetch(`/api/summary/${competitionId}/${courseId}`, {
-          cache: "no-store",
-        })
-        const data = await res.json()
-        setRawSummary(data)
-      } catch (error) {
-        console.error(error)
-      } finally {
-        setLoading(false)
-      }
-    }
-    fetchData()
-  }, [competitionId, courseId, courses])
-
-  const filteredAndSorted = (() => {
-    let list = rawSummary
-
-    // Keyword search
-    if (searchQuery.trim()) {
-      const q = searchQuery.trim().toLowerCase()
-      list = list.filter(
-        (p) =>
-          (p.playerName?.toLowerCase().includes(q) ?? false) ||
-          (p.playerFurigana?.toLowerCase().includes(q) ?? false) ||
-          (p.playerBibNumber?.toLowerCase().includes(q) ?? false),
-      )
-    }
-
-    // Multi-sort: iterate conditions from highest priority
-    return [...list].sort((a, b) => {
-      for (const { key, order } of sortConditions) {
-        const cmp = compareBySortKey(a, b, key, pointData)
-        if (cmp !== 0) {
-          return order === "asc" ? cmp : -cmp
-        }
-      }
-      return 0
-    })
-  })()
-
-  const columns = [
-    "名前",
-    "ふりがな",
-    "ゼッケン",
-    "初試行時刻",
-    "完走時刻",
-    "完走経過時間",
-    "最終試行時刻",
-    "完走数",
-    "初回得点",
-    "最高得点",
-    "平均得点",
-    "総得点",
-    "合計得点",
-    "コースアウト数",
-    "リトライ回数",
-    "試行回数",
-  ]
+  const [activeTab, setActiveTab] = useState<TabKey>("player")
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      {/* Competition & Course selectors */}
+      {/* Competition selector */}
       <div className="shrink-0 px-4 pt-4 pb-2">
-        <div className="flex flex-wrap items-center gap-3">
-          <div className="min-w-[200px] flex-1">
-            <label
-              htmlFor="summary-competition"
-              className="mb-1 block font-semibold text-base-content/60 text-xs uppercase tracking-wider"
-            >
-              大会
-            </label>
-            <select
-              id="summary-competition"
-              className="select select-bordered w-full"
-              value={competitionId}
-              onChange={(e) => setCompetitionId(Number(e.target.value))}
-            >
-              <option value={0} disabled>
-                大会を選んでください
+        <div className="min-w-[200px] max-w-md">
+          <label
+            htmlFor="summary-competition"
+            className="mb-1 block font-semibold text-base-content/60 text-xs uppercase tracking-wider"
+          >
+            大会
+          </label>
+          <select
+            id="summary-competition"
+            className="select select-bordered w-full"
+            value={competitionId}
+            onChange={(e) => setCompetitionId(Number(e.target.value))}
+          >
+            <option value={0} disabled>
+              大会を選んでください
+            </option>
+            {competitions.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
               </option>
-              {competitions.map((c) => (
-                <option key={c.id} value={c.id}>
-                  {c.name}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div className="min-w-[200px] flex-1">
-            <label
-              htmlFor="summary-course"
-              className="mb-1 block font-semibold text-base-content/60 text-xs uppercase tracking-wider"
-            >
-              コース
-            </label>
-            <select
-              id="summary-course"
-              className="select select-bordered w-full"
-              value={courseId ?? 0}
-              onChange={(e) => setCourseId(Number(e.target.value))}
-              disabled={courses.length === 0}
-            >
-              <option value={0} disabled>
-                コースを選んでください
-              </option>
-              {courses.map((c) => (
-                <option key={c.id} value={c.id}>
-                  {c.name}
-                </option>
-              ))}
-            </select>
-          </div>
+            ))}
+          </select>
         </div>
       </div>
 
-      {/* Search & Multi-sort bar */}
-      <div className="flex shrink-0 flex-col gap-3 px-4 pb-4">
-        <label className="input input-bordered flex items-center gap-2 rounded-xl bg-base-200/40 transition-colors focus-within:bg-base-100">
-          <MagnifyingGlassIcon className="size-4 shrink-0 text-base-content/40" />
-          <input
-            type="text"
-            placeholder="名前・ふりがな・ゼッケン番号で検索"
-            className="grow"
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-          />
-        </label>
-
-        {/* Sort chips */}
-        <div className="flex flex-wrap items-center gap-2">
-          <span className="shrink-0 text-base-content/40 text-xs">ソート:</span>
-          {sortConditions.map((sc, index) => (
-            <div
-              key={sc.key}
-              className="flex items-center gap-1 rounded-lg border border-base-300 bg-base-100 px-2 py-1 shadow-sm"
-            >
-              <span className="flex size-4 items-center justify-center rounded-full bg-primary/10 font-bold text-primary text-xs">
-                {index + 1}
-              </span>
-              <span className="font-medium text-xs">
-                {getSortLabel(sc.key)}
-              </span>
-              <button
-                type="button"
-                className="flex items-center gap-0.5 rounded-md bg-base-200/60 px-1.5 py-0.5 text-xs transition-colors hover:bg-base-300/60"
-                onClick={() => toggleOrder(index)}
-              >
-                {sc.order === "desc" ? (
-                  <BarsArrowDownIcon className="size-3" />
-                ) : (
-                  <BarsArrowUpIcon className="size-3" />
-                )}
-                {getOrderLabel(sc.key, sc.order)}
-              </button>
-              <button
-                type="button"
-                className="flex items-center justify-center rounded-full p-0.5 text-base-content/40 transition-colors hover:bg-error/10 hover:text-error"
-                onClick={() => removeSort(index)}
-                aria-label={`${getSortLabel(sc.key)}のソートを削除`}
-              >
-                <XMarkIcon className="size-3.5" />
-              </button>
-            </div>
-          ))}
-
-          {/* Add sort button */}
-          {availableKeys.length > 0 && (
-            <div className="flex items-center gap-1 rounded-lg bg-base-200/50 px-1.5 py-1">
-              <PlusIcon className="size-3.5 shrink-0 text-base-content/40" />
-              <select
-                className="select select-ghost select-xs bg-transparent font-medium text-base-content/60 focus:outline-none [&>option]:bg-base-100 [&>option]:text-base-content"
-                value=""
-                onChange={(e) => {
-                  if (e.target.value) {
-                    addSort(e.target.value as SortKey)
-                    e.target.value = ""
-                  }
-                }}
-              >
-                <option value="" disabled>
-                  追加
-                </option>
-                {availableKeys.map((opt) => (
-                  <option key={opt.value} value={opt.value}>
-                    {opt.label}
-                  </option>
-                ))}
-              </select>
-            </div>
-          )}
-
-          {/* Clear all */}
-          {sortConditions.length > 1 && (
+      {/* Tab bar */}
+      <div className="shrink-0 px-4 pt-2 pb-3">
+        <div className="inline-flex rounded-xl bg-base-200/60 p-1">
+          {TABS.map(({ key, label, icon: Icon }) => (
             <button
+              key={key}
               type="button"
-              className="text-base-content/40 text-xs transition-colors hover:text-error"
-              onClick={() =>
-                setSortConditions([{ key: "totalPoint", order: "desc" }])
-              }
+              onClick={() => setActiveTab(key)}
+              className={`flex items-center gap-1.5 rounded-lg px-4 py-2 font-medium text-sm transition-all duration-200 ${
+                activeTab === key
+                  ? "bg-primary text-primary-content shadow-sm"
+                  : "text-base-content/60 hover:bg-base-300/50 hover:text-base-content"
+              }`}
             >
-              リセット
+              <Icon className="size-4" />
+              {label}
             </button>
-          )}
+          ))}
         </div>
       </div>
 
-      {/* Table */}
-      <div className="min-h-0 flex-1 overflow-x-auto overflow-y-auto">
-        {competitionId === 0 ? (
-          <div className="py-12 text-center text-base-content/40">
-            大会を選択してください
-          </div>
-        ) : searchQuery && filteredAndSorted.length === 0 ? (
-          <div className="py-8 text-center text-base-content/40">
-            条件に一致する選手が見つかりません
-          </div>
-        ) : (
-          <div className="m-3 min-h-0 overflow-x-auto overflow-y-auto rounded-xl border border-base-300/50">
-            <table className="table-pin-rows table-zebra table">
-              <thead>
-                <tr className="border-base-300/50 border-b bg-base-200/60">
-                  {columns.map((label) => (
-                    <th
-                      key={label}
-                      className="whitespace-nowrap py-3 font-semibold text-base-content/50 text-xs uppercase tracking-wider"
-                    >
-                      {label}
-                    </th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody>
-                {loading ? (
-                  ["sk0", "sk1", "sk2", "sk3", "sk4"].map((id, i) => (
-                    <tr key={id}>
-                      {columns.map((col) => (
-                        <td key={col} className="py-3">
-                          <div
-                            className="skeleton-shimmer h-4 w-full rounded"
-                            style={{ animationDelay: `${i * 60}ms` }}
-                          />
-                        </td>
-                      ))}
-                    </tr>
-                  ))
-                ) : filteredAndSorted.length > 0 ? (
-                  filteredAndSorted.map((player) => (
-                    <PlayerRow
-                      key={player.playerId}
-                      player={player}
-                      competitionId={competitionId}
-                      courseId={Number(courseId)}
-                      pointData={pointData}
-                    />
-                  ))
-                ) : (
-                  <tr>
-                    <td
-                      colSpan={columns.length}
-                      className="py-12 text-center text-base-content/40"
-                    >
-                      データがありません
-                    </td>
-                  </tr>
-                )}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </div>
+      {/* Tab content */}
+      {competitionId === 0 ? (
+        <div className="py-12 text-center text-base-content/40">
+          大会を選択してください
+        </div>
+      ) : (
+        <>
+          {activeTab === "player" && (
+            <PlayerSummaryTable competitionId={competitionId} />
+          )}
+          {activeTab === "judge" && (
+            <JudgeSummaryTable competitionId={competitionId} />
+          )}
+          {activeTab === "course" && (
+            <CourseSummaryTable competitionId={competitionId} />
+          )}
+        </>
+      )}
     </div>
-  )
-}
-
-function formatTimestamp(iso: string | null): string {
-  if (!iso) {
-    return "-"
-  }
-  const d = new Date(iso)
-  if (Number.isNaN(d.getTime())) {
-    return "-"
-  }
-  const pad = (n: number) => String(n).padStart(2, "0")
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
-}
-
-function PlayerRow({
-  player,
-  competitionId,
-  courseId,
-  pointData,
-}: {
-  player: CourseSummary
-  competitionId: number
-  courseId: number
-  pointData: PointState
-}) {
-  const completed = isCompletedCourse(pointData, player.maxResult)
-  const maxScore =
-    player.maxResult || player.maxResult === 0
-      ? calcPoint(pointData, player.maxResult)
-      : null
-  const firstScore =
-    player.firstAttemptScore !== null
-      ? calcPoint(pointData, player.firstAttemptScore)
-      : null
-
-  return (
-    <tr className="transition-colors duration-150 hover:bg-primary/5">
-      <td className="whitespace-nowrap py-3 font-medium">
-        <Link
-          href={`/summary/${competitionId}/${courseId}/${player.playerId}`}
-          className="text-primary underline-offset-2 hover:underline"
-        >
-          {player.playerName ?? "-"}
-        </Link>
-      </td>
-      <td className="whitespace-nowrap py-3">{player.playerFurigana ?? "-"}</td>
-      <td className="py-3">{player.playerBibNumber ?? "-"}</td>
-      <td className="whitespace-nowrap py-3">
-        {formatTimestamp(player.firstAttemptTime)}
-      </td>
-      <td className="whitespace-nowrap py-3">
-        {completed ? formatTimestamp(player.firstMaxAttemptTime) : "-"}
-      </td>
-      <td className="whitespace-nowrap py-3">
-        {completed ? (player.elapsedToComplete ?? "-") : "-"}
-      </td>
-      <td className="whitespace-nowrap py-3">
-        {formatTimestamp(player.lastAttemptTime)}
-      </td>
-      <td className="py-3">
-        {completed && player.firstMaxAttemptCount
-          ? player.firstMaxAttemptCount
-          : "-"}
-      </td>
-      <td className="py-3">{firstScore !== null ? firstScore : "-"}</td>
-      <td className="py-3">{maxScore !== null ? maxScore : "-"}</td>
-      <td className="py-3">{player.averageScore ?? "-"}</td>
-      <td className="py-3 font-medium">{player.totalPoint ?? "-"}</td>
-      <td className="py-3">{player.sumPoint ?? "-"}</td>
-      <td className="py-3">{player.courseOutCount ?? 0}</td>
-      <td className="py-3">{player.retryCount ?? 0}</td>
-      <td className="py-3">{player.challengeCount}</td>
-    </tr>
   )
 }

--- a/@robopo/web/test/unit/summary/summaryView.test.tsx
+++ b/@robopo/web/test/unit/summary/summaryView.test.tsx
@@ -40,62 +40,45 @@ describe("SummaryView", () => {
     expect(screen.getByText("大会を選択してください")).toBeTruthy()
   })
 
-  test("renders default sort condition (totalPoint desc)", () => {
+  test("renders tab buttons", () => {
     render(
       <SummaryView competitions={competitions} defaultCompetitionId={null} />,
     )
-    expect(screen.getByText("総得点")).toBeTruthy()
-    expect(screen.getByText("大きい順")).toBeTruthy()
+    expect(screen.getByText("選手")).toBeTruthy()
+    expect(screen.getByText("採点者")).toBeTruthy()
+    expect(screen.getByText("コース")).toBeTruthy()
   })
 
-  test("toggles sort order on click", () => {
+  test("player tab is active by default", () => {
     render(
       <SummaryView competitions={competitions} defaultCompetitionId={null} />,
     )
-    const orderButton = screen.getByText("大きい順")
-    fireEvent.click(orderButton)
-    expect(screen.getByText("小さい順")).toBeTruthy()
+    const playerButton = screen.getByText("選手").closest("button")
+    expect(playerButton?.className).toContain("bg-primary")
   })
 
-  test("removes sort condition on X click", () => {
+  test("switches to judge tab on click", () => {
     render(
       <SummaryView competitions={competitions} defaultCompetitionId={null} />,
     )
-    // The sort chip should have a remove button
-    const removeButton = screen.getByLabelText("総得点のソートを削除")
-    fireEvent.click(removeButton)
-    // After removal, the sort chip label should be gone (text may still appear in dropdown options)
-    expect(screen.queryByLabelText("総得点のソートを削除")).toBeNull()
-  })
-
-  test("adds new sort condition from dropdown", () => {
-    render(
-      <SummaryView competitions={competitions} defaultCompetitionId={null} />,
-    )
-    // Find the add-sort select
-    const _addSelect = screen.getByRole("combobox", { name: "" })
-    // The last combobox is the sort adder (after competition + course selects)
-    const selects = screen
-      .getAllByRole("combobox")
-      .filter(
-        (s) =>
-          s.querySelector('option[value="playerFurigana"]') !== null ||
-          (s as HTMLSelectElement).querySelector(
-            'option[value="playerFurigana"]',
-          ),
-      )
-    if (selects.length > 0) {
-      fireEvent.change(selects[0], { target: { value: "maxResult" } })
-      expect(screen.getByText("最高得点")).toBeTruthy()
+    const judgeButton = screen.getByText("採点者").closest("button")
+    if (judgeButton) {
+      fireEvent.click(judgeButton)
     }
+    expect(judgeButton?.className).toContain("bg-primary")
+    // Player tab should no longer be active
+    const playerButton = screen.getByText("選手").closest("button")
+    expect(playerButton?.className).not.toContain("bg-primary")
   })
 
-  test("renders search input", () => {
+  test("switches to course tab on click", () => {
     render(
       <SummaryView competitions={competitions} defaultCompetitionId={null} />,
     )
-    expect(
-      screen.getByPlaceholderText("名前・ふりがな・ゼッケン番号で検索"),
-    ).toBeTruthy()
+    const courseButton = screen.getByText("コース").closest("button")
+    if (courseButton) {
+      fireEvent.click(courseButton)
+    }
+    expect(courseButton?.className).toContain("bg-primary")
   })
 })


### PR DESCRIPTION
## Summary by Sourcery

タブ付きの大会サマリービューを導入し、プレイヤー、ジャッジ、コース向けの新しい集計サマリーを追加します。

新機能:
- アイコンベースのナビゲーションを用いた大会サマリービューに、プレイヤー、ジャッジ、コースのサマリータブを追加。
- 新しい API とデータベースクエリを通じて、大会ごとのジャッジ単位の集計スコア統計情報を公開。
- 新しい API とデータベースクエリを通じて、完了状況メトリクスやスコア変換を含む、コース単位の大会集計統計情報を公開。

改善:
- プレイヤーサマリーテーブルをメインのサマリービューから切り出し、専用の再利用可能なコンポーネントとしてリファクタリング。
- ジャッジおよびコースサマリー向けにソート可能・検索可能なテーブルを追加し、ジャッジが採点したプレイヤーのモーダルドリルダウン表示に対応。

テスト:
- SummaryView の単体テストを更新し、タブのレンダリングおよびタブ切り替えの挙動をカバー。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce tabbed competition summary view and new aggregated summaries for players, judges, and courses.

New Features:
- Add player, judge, and course summary tabs to the competition summary view with icon-based navigation.
- Expose judge-level aggregated scoring statistics per competition via new API and database query.
- Expose course-level aggregated competition statistics via new API and database query, including completion metrics and score conversions.

Enhancements:
- Refactor the player summary table out of the main summary view into a dedicated, reusable component.
- Add sortable, searchable tables for judge and course summaries, including modal drill-down for judges' scored players.

Tests:
- Update SummaryView unit tests to cover tab rendering and tab switching behavior.

</details>