### PR TITLE
feat: add account for judge

### DIFF
--- a/@robopo/web/app/api/judge/[id]/route.ts
+++ b/@robopo/web/app/api/judge/[id]/route.ts
@@ -1,12 +1,12 @@
-import { eq } from "drizzle-orm"
+import { hashPassword } from "better-auth/crypto"
+import { and, eq } from "drizzle-orm"
 import { sanitizeCompetitionIds } from "@/app/api/validate"
 import { db } from "@/app/lib/db/db"
 import {
-  getJudgeByName,
   getJudgeWithCompetition,
   groupByJudge,
 } from "@/app/lib/db/queries/queries"
-import { competitionJudge, judge } from "@/app/lib/db/schema"
+import { account, competitionJudge, judge } from "@/app/lib/db/schema"
 
 export async function PATCH(
   req: Request,
@@ -18,31 +18,48 @@ export async function PATCH(
     return Response.json({ error: "Invalid ID" }, { status: 400 })
   }
 
-  const { name, note, competitionIds } = await req.json()
+  const { note, competitionIds, password } = await req.json()
 
-  if (!name?.trim()) {
+  // Validate password up front before any updates
+  if (password && password.length > 0 && password.length < 8) {
     return Response.json(
-      { success: false, message: "名前は必須です。" },
-      { status: 400 },
-    )
-  }
-
-  const existing = await getJudgeByName(name.trim(), judgeId)
-  if (existing) {
-    return Response.json(
-      { success: false, message: "同じ名前の採点者が既に登録されています。" },
+      {
+        success: false,
+        message: "パスワードは8文字以上で入力してください。",
+      },
       { status: 400 },
     )
   }
 
   try {
+    // Update judge record (only note)
     await db
       .update(judge)
-      .set({
-        name: name.trim(),
-        note: note || null,
-      })
+      .set({ note: note || null })
       .where(eq(judge.id, judgeId))
+
+    // Update password if provided
+    if (password && password.length >= 8) {
+      const judgeRecord = await db
+        .select({ userId: judge.userId })
+        .from(judge)
+        .where(eq(judge.id, judgeId))
+        .limit(1)
+
+      const userId = judgeRecord[0]?.userId
+      if (userId) {
+        const hashed = await hashPassword(password)
+        await db
+          .update(account)
+          .set({ password: hashed })
+          .where(
+            and(
+              eq(account.userId, userId),
+              eq(account.providerId, "credential"),
+            ),
+          )
+      }
+    }
 
     // Update competition links if provided
     const sanitizedIds = sanitizeCompetitionIds(competitionIds)
@@ -68,7 +85,7 @@ export async function PATCH(
       {
         success: false,
         message: "採点者の更新中にエラーが発生しました。",
-        error,
+        error: String(error),
       },
       { status: 500 },
     )

--- a/@robopo/web/app/api/judge/route.ts
+++ b/@robopo/web/app/api/judge/route.ts
@@ -1,32 +1,62 @@
-import { deleteById } from "@/app/api/delete"
+import { eq, inArray } from "drizzle-orm"
 import { sanitizeCompetitionIds } from "@/app/api/validate"
 import { db } from "@/app/lib/db/db"
 import { createJudge } from "@/app/lib/db/queries/insert"
-import { getJudgeByName } from "@/app/lib/db/queries/queries"
-import { competitionJudge } from "@/app/lib/db/schema"
+import { competitionJudge, judge, user } from "@/app/lib/db/schema"
+import { auth } from "@/lib/auth"
 
 export async function POST(req: Request) {
-  const { name, note, competitionIds } = await req.json()
+  const { note, competitionIds, username, password } = await req.json()
 
-  if (!name?.trim()) {
+  if (!username?.trim()) {
     return Response.json(
-      { success: false, message: "名前は必須です。" },
+      { success: false, message: "ユーザー名は必須です。" },
       { status: 400 },
     )
   }
 
-  const existing = await getJudgeByName(name.trim())
-  if (existing) {
+  if (!/^[a-z0-9_]+$/.test(username.trim().toLowerCase())) {
     return Response.json(
-      { success: false, message: "同じ名前の採点者が既に登録されています。" },
+      {
+        success: false,
+        message: "ユーザー名は英小文字・数字・アンダースコアのみ使用できます。",
+      },
       { status: 400 },
     )
   }
+
+  if (!password || password.length < 8) {
+    return Response.json(
+      { success: false, message: "パスワードは8文字以上で入力してください。" },
+      { status: 400 },
+    )
+  }
+
+  let createdUserId: string | null = null
 
   try {
+    // Create Better Auth user for the judge
+    const signUpRes = await auth.api.signUpEmail({
+      body: {
+        email: `${username.trim().toLowerCase()}@robopo.local`,
+        password,
+        name: username.trim().toLowerCase(),
+        username: username.trim().toLowerCase(),
+      },
+    })
+
+    if (!signUpRes?.user?.id) {
+      return Response.json(
+        { success: false, message: "ユーザーアカウントの作成に失敗しました。" },
+        { status: 500 },
+      )
+    }
+
+    createdUserId = signUpRes.user.id
+
     const result = await createJudge({
-      name: name.trim(),
       note: note || null,
+      userId: signUpRes.user.id,
     })
 
     // Insert competition links if provided
@@ -42,17 +72,61 @@ export async function POST(req: Request) {
 
     return Response.json({ success: true, data: result }, { status: 200 })
   } catch (error) {
+    // Clean up orphaned auth user if judge creation failed
+    if (createdUserId) {
+      await db
+        .delete(user)
+        .where(eq(user.id, createdUserId))
+        .catch(() => {})
+    }
+
+    const message =
+      error instanceof Error && error.message.includes("unique")
+        ? "このユーザー名は既に使用されています。"
+        : "採点者の登録中にエラーが発生しました。"
     return Response.json(
-      {
-        success: false,
-        message: "採点者の登録中にエラーが発生しました。",
-        error: error,
-      },
+      { success: false, message, error: String(error) },
       { status: 500 },
     )
   }
 }
 
 export async function DELETE(req: Request) {
-  return await deleteById(req, "judge")
+  const { id } = await req.json()
+
+  if (!id || !Array.isArray(id) || id.length === 0) {
+    return Response.json(
+      { success: false, message: "削除対象が指定されていません。" },
+      { status: 400 },
+    )
+  }
+
+  try {
+    // Find linked user IDs before deleting judges
+    const judges = await db
+      .select({ userId: judge.userId })
+      .from(judge)
+      .where(inArray(judge.id, id))
+
+    const userIds = judges.map((j) => j.userId)
+
+    // Delete judges (cascade handles competition_judge)
+    await db.delete(judge).where(inArray(judge.id, id))
+
+    // Delete linked Better Auth users (cascade handles session, account)
+    if (userIds.length > 0) {
+      await db.delete(user).where(inArray(user.id, userIds))
+    }
+
+    return Response.json({ success: true }, { status: 200 })
+  } catch (error) {
+    return Response.json(
+      {
+        success: false,
+        message: "採点者の削除中にエラーが発生しました。",
+        error: String(error),
+      },
+      { status: 500 },
+    )
+  }
 }

--- a/@robopo/web/app/components/common/commonList.tsx
+++ b/@robopo/web/app/components/common/commonList.tsx
@@ -80,7 +80,7 @@ function TableComponent({
             {(common as SelectJudgeWithCompetition).id}
           </td>
           <td className="py-3 font-medium">
-            {(common as SelectJudgeWithCompetition).name}
+            {(common as SelectJudgeWithCompetition).username}
           </td>
           <td className="py-3">
             {(common as SelectJudgeWithCompetition).competitionName?.length ? (
@@ -95,6 +95,18 @@ function TableComponent({
               </div>
             ) : (
               <span className="text-base-content/30 text-sm">-</span>
+            )}
+          </td>
+          <td
+            className="whitespace-nowrap py-3 text-base-content/60 text-sm"
+            suppressHydrationWarning={true}
+          >
+            {(common as SelectJudgeWithCompetition).lastLoginAt ? (
+              new Date(
+                (common as SelectJudgeWithCompetition).lastLoginAt as Date,
+              ).toLocaleString("ja-JP")
+            ) : (
+              <span className="text-base-content/30">-</span>
             )}
           </td>
           <td className="max-w-xs py-3">
@@ -116,7 +128,7 @@ function TableComponent({
           <td className="py-3 font-medium">
             {(common as SelectCourseWithCompetition).name}
           </td>
-          <td className="py-3 text-center">
+          <td className="py-3">
             {(common as SelectCourseWithCompetition).isConfigured ? (
               <span className="text-lg text-red-500">○</span>
             ) : (
@@ -238,7 +250,7 @@ function itemNames(type: CommonListProps["type"]): string[] {
       "備考",
     )
   } else if (type === "judge") {
-    itemNames.push("ID", "名前", "紐付け大会", "備考")
+    itemNames.push("ID", "ユーザー名", "紐付け大会", "ログイン日時", "備考")
   } else if (type === "course") {
     itemNames.push("ID", "コース名", "設定済み", "使用大会", "作成日時", "説明")
   } else if (type === "competition") {

--- a/@robopo/web/app/components/header/header.tsx
+++ b/@robopo/web/app/components/header/header.tsx
@@ -9,7 +9,10 @@ import { SIGN_IN_CONST, SIGN_OUT_CONST } from "@/app/lib/const"
 import { signOut } from "@/lib/auth-client"
 
 type Props = {
-  session: { user: { id: string; name: string } } | null
+  session: {
+    user: { id: string; name: string }
+    isJudge: boolean
+  } | null
 }
 
 export function Header({ session }: Props) {
@@ -79,9 +82,9 @@ export function Header({ session }: Props) {
             )}
           </button>
         ) : null}
-        {session?.user ? (
+        {session?.user && !session.isJudge ? (
           <NavigationDrawer />
-        ) : (
+        ) : !session?.user ? (
           <Link
             href={SIGN_IN_CONST.href}
             className="btn btn-ghost btn-sm rounded-full border border-primary/20 text-primary hover:bg-primary hover:text-primary-content"
@@ -90,7 +93,7 @@ export function Header({ session }: Props) {
             {SIGN_IN_CONST.icon}
             {SIGN_IN_CONST.label}
           </Link>
-        )}
+        ) : null}
       </div>
     </header>
   )

--- a/@robopo/web/app/components/header/headerServer.tsx
+++ b/@robopo/web/app/components/header/headerServer.tsx
@@ -1,8 +1,17 @@
+import { eq } from "drizzle-orm"
 import { headers } from "next/headers"
+import { db } from "@/app/lib/db/db"
+import { judge } from "@/app/lib/db/schema"
 import { auth } from "@/lib/auth"
 
+export type HeaderSession = {
+  user: { id: string; name: string }
+  isJudge: boolean
+  judgeId: number | null
+} | null
+
 export default async function HeaderServer(): Promise<{
-  session: { user: { id: string; name: string } } | null
+  session: HeaderSession
 }> {
   const session = await auth.api.getSession({
     headers: await headers(),
@@ -10,12 +19,25 @@ export default async function HeaderServer(): Promise<{
   if (!session) {
     return { session: null }
   }
+
+  // Check if the user is a judge
+  const judgeRecord = await db
+    .select({ id: judge.id })
+    .from(judge)
+    .where(eq(judge.userId, session.user.id))
+    .limit(1)
+
+  const isJudge = judgeRecord.length > 0
+  const judgeId = isJudge ? judgeRecord[0].id : null
+
   return {
     session: {
       user: {
         id: session.user.id,
         name: session.user.name,
       },
+      isJudge,
+      judgeId,
     },
   }
 }

--- a/@robopo/web/app/components/home/dashboard.tsx
+++ b/@robopo/web/app/components/home/dashboard.tsx
@@ -11,15 +11,16 @@ import type {
   SelectCompetitionCourse,
   SelectCompetitionJudge,
   SelectCourse,
-  SelectJudge,
+  SelectJudgeWithUsername,
 } from "@/app/lib/db/schema"
 
 type DashboardProps = {
   competitionList: { competitions: SelectCompetition[] }
   courseList: { courses: SelectCourse[] }
   competitionCourseList: { competitionCourseList: SelectCompetitionCourse[] }
-  judgeList: SelectJudge[]
+  judgeList: SelectJudgeWithUsername[]
   competitionJudgeList: { competitionJudgeList: SelectCompetitionJudge[] }
+  loggedInJudgeId?: number
 }
 
 function DashboardCard({
@@ -64,6 +65,7 @@ export function Dashboard({
   competitionCourseList,
   judgeList,
   competitionJudgeList,
+  loggedInJudgeId,
 }: DashboardProps) {
   return (
     <div className="mx-auto max-w-4xl px-4 py-6">
@@ -81,6 +83,7 @@ export function Dashboard({
               competitionCourseList={competitionCourseList}
               judgeList={judgeList}
               competitionJudgeList={competitionJudgeList}
+              loggedInJudgeId={loggedInJudgeId}
             />
           </DashboardCard>
         </div>

--- a/@robopo/web/app/components/home/tabs.tsx
+++ b/@robopo/web/app/components/home/tabs.tsx
@@ -17,7 +17,7 @@ import type {
   SelectCompetitionCourse,
   SelectCompetitionJudge,
   SelectCourse,
-  SelectJudge,
+  SelectJudgeWithUsername,
 } from "@/app/lib/db/schema"
 
 function CourseCard({
@@ -62,8 +62,9 @@ type ChallengeTabProps = {
   competitionList: { competitions: SelectCompetition[] }
   courseList: { courses: SelectCourse[] }
   competitionCourseList: { competitionCourseList: SelectCompetitionCourse[] }
-  judgeList: SelectJudge[]
+  judgeList: SelectJudgeWithUsername[]
   competitionJudgeList: { competitionJudgeList: SelectCompetitionJudge[] }
+  loggedInJudgeId?: number
 }
 
 export function ChallengeTab({
@@ -72,6 +73,7 @@ export function ChallengeTab({
   competitionCourseList,
   judgeList,
   competitionJudgeList,
+  loggedInJudgeId,
 }: ChallengeTabProps): React.JSX.Element {
   const activeCompetitions =
     competitionList.competitions.filter(isCompetitionActive)
@@ -79,7 +81,7 @@ export function ChallengeTab({
     activeCompetitions.length === 1 ? activeCompetitions[0] : null
 
   const [competitionId, setCompetitionId] = useState(singleCompetition?.id ?? 0)
-  const [judgeId, setJudgeId] = useState(0)
+  const [judgeId, setJudgeId] = useState(loggedInJudgeId ?? 0)
   const [showAlert, setShowAlert] = useState(false)
   const judgeSelectRef = useRef<HTMLSelectElement>(null)
   const disableCondition = competitionId === 0 || judgeId === 0
@@ -186,7 +188,7 @@ export function ChallengeTab({
           </option>
           {filteredJudges.map((u) => (
             <option key={u.id} value={u.id}>
-              {u.name}
+              {u.username}
             </option>
           ))}
         </select>

--- a/@robopo/web/app/components/server/db.ts
+++ b/@robopo/web/app/components/server/db.ts
@@ -19,8 +19,9 @@ import {
   type SelectCompetitionJudge,
   type SelectCompetitionWithCourse,
   type SelectCourse,
-  type SelectJudge,
+  type SelectJudgeWithUsername,
   type SelectPlayer,
+  user,
 } from "@/app/lib/db/schema"
 
 // Get player list
@@ -28,9 +29,19 @@ export async function getPlayerList(): Promise<SelectPlayer[]> {
   return await db.select().from(player)
 }
 
-// Get judge list
-export async function getJudgeList(): Promise<SelectJudge[]> {
-  return await db.select().from(judge)
+// Get judge list (with username from user table)
+export async function getJudgeList(): Promise<SelectJudgeWithUsername[]> {
+  return await db
+    .select({
+      id: judge.id,
+      note: judge.note,
+      userId: judge.userId,
+      createdAt: judge.createdAt,
+      username: user.username,
+    })
+    .from(judge)
+    .innerJoin(user, eq(judge.userId, user.id))
+    .then((rows) => rows.map((r) => ({ ...r, username: r.username ?? "" })))
 }
 
 // Get competition list
@@ -123,20 +134,24 @@ export async function getCompetitionJudgeAssignList(): Promise<{
   return { competitionJudgeList }
 }
 
-// Get judges by competition ID
+// Get judges by competition ID (with username from user table)
 export async function getCompetitionJudgeList(competitionId: number): Promise<{
-  judges: SelectJudge[]
+  judges: SelectJudgeWithUsername[]
 }> {
-  const judges: SelectJudge[] = await db
+  const rows = await db
     .select({
       id: judge.id,
-      name: judge.name,
       note: judge.note,
+      userId: judge.userId,
       createdAt: judge.createdAt,
+      username: user.username,
     })
     .from(judge)
+    .innerJoin(user, eq(judge.userId, user.id))
     .innerJoin(competitionJudge, eq(judge.id, competitionJudge.judgeId))
     .where(eq(competitionJudge.competitionId, competitionId))
 
-  return { judges }
+  return {
+    judges: rows.map((r) => ({ ...r, username: r.username ?? "" })),
+  }
 }

--- a/@robopo/web/app/judge/modals.tsx
+++ b/@robopo/web/app/judge/modals.tsx
@@ -4,6 +4,8 @@ import {
   CheckCircleIcon,
   CheckIcon,
   ExclamationTriangleIcon,
+  EyeIcon,
+  EyeSlashIcon,
   PlusIcon,
   XCircleIcon,
   XMarkIcon,
@@ -29,7 +31,9 @@ export function JudgeFormModal({
   onClose,
   onSuccess,
 }: JudgeFormModalProps) {
-  const [name, setName] = useState(judge?.name ?? "")
+  const [username, setUsername] = useState("")
+  const [password, setPassword] = useState("")
+  const [showPassword, setShowPassword] = useState(false)
   const [note, setNote] = useState(judge?.note ?? "")
   const [selectedCompetitionIds, setSelectedCompetitionIds] = useState<
     number[]
@@ -45,8 +49,29 @@ export function JudgeFormModal({
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
-    if (!name.trim()) {
-      setError("名前は必須です。")
+
+    if (mode === "create") {
+      if (!username.trim()) {
+        setError("ユーザー名は必須です。")
+        return
+      }
+      if (!/^[a-z0-9_]+$/.test(username.trim())) {
+        setError("ユーザー名は英小文字・数字・アンダースコアのみ使用できます。")
+        return
+      }
+      if (!password || password.length < 8) {
+        setError("パスワードは8文字以上で入力してください。")
+        return
+      }
+    }
+
+    if (
+      mode === "edit" &&
+      password &&
+      password.length > 0 &&
+      password.length < 8
+    ) {
+      setError("パスワードは8文字以上で入力してください。")
       return
     }
 
@@ -55,11 +80,16 @@ export function JudgeFormModal({
 
     try {
       const body: Record<string, unknown> = {
-        name: name.trim(),
         note: note.trim() || null,
+        competitionIds: selectedCompetitionIds,
       }
 
-      body.competitionIds = selectedCompetitionIds
+      if (mode === "create") {
+        body.username = username.trim()
+        body.password = password
+      } else if (password) {
+        body.password = password
+      }
 
       const url = mode === "create" ? "/api/judge" : `/api/judge/${judge?.id}`
       const method = mode === "create" ? "POST" : "PATCH"
@@ -95,22 +125,84 @@ export function JudgeFormModal({
           {mode === "create" ? "採点者を登録" : "採点者を編集"}
         </h3>
         <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          {mode === "create" ? (
+            <div>
+              <label className="label" htmlFor="judge-username">
+                <span className="label-text">
+                  ユーザー名 <span className="text-error">*</span>
+                </span>
+              </label>
+              <input
+                id="judge-username"
+                type="text"
+                className="input input-bordered w-full lowercase"
+                value={username}
+                onChange={(e) => setUsername(e.target.value.toLowerCase())}
+                placeholder="英小文字・数字（例: judge1）"
+                pattern="[a-z0-9_]+"
+                required
+              />
+              <p className="mt-1 text-base-content/40 text-xs">
+                英小文字・数字・アンダースコアのみ使用可能（ログインにも使用）
+              </p>
+            </div>
+          ) : (
+            <div>
+              <label className="label" htmlFor="judge-username-display">
+                <span className="label-text">ユーザー名</span>
+              </label>
+              <input
+                id="judge-username-display"
+                type="text"
+                className="input input-bordered w-full"
+                value={judge?.username ?? ""}
+                disabled
+              />
+            </div>
+          )}
+
           <div>
-            <label className="label" htmlFor="judge-name">
+            <label className="label" htmlFor="judge-password">
               <span className="label-text">
-                名前 <span className="text-error">*</span>
+                パスワード
+                {mode === "create" && <span className="text-error"> *</span>}
               </span>
             </label>
-            <input
-              id="judge-name"
-              type="text"
-              className="input input-bordered w-full"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="採点者名"
-              required
-            />
+            <div className="relative">
+              <input
+                id="judge-password"
+                type={showPassword ? "text" : "password"}
+                className="input input-bordered w-full pr-12"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder={
+                  mode === "create"
+                    ? "8文字以上"
+                    : "変更する場合のみ入力（8文字以上）"
+                }
+                minLength={mode === "create" ? 8 : undefined}
+                required={mode === "create"}
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword((prev) => !prev)}
+                className="absolute inset-y-0 right-2 flex items-center rounded-lg p-1.5 text-base-content/40 transition-colors hover:bg-base-300/50 hover:text-base-content/70"
+                aria-label="パスワードを表示"
+              >
+                {showPassword ? (
+                  <EyeSlashIcon className="size-5" />
+                ) : (
+                  <EyeIcon className="size-5" />
+                )}
+              </button>
+            </div>
+            {mode === "edit" && (
+              <p className="mt-1 text-base-content/40 text-xs">
+                空欄の場合、パスワードは変更されません
+              </p>
+            )}
           </div>
+
           <div>
             <label className="label" htmlFor="judge-note">
               <span className="label-text">備考</span>
@@ -254,7 +346,7 @@ export function JudgeDeleteModal({
               <ul className="w-full list-inside list-disc text-sm">
                 {judges.map((j) => (
                   <li key={j.id} className="font-medium">
-                    {j.name}
+                    {j.username}
                   </li>
                 ))}
               </ul>

--- a/@robopo/web/app/judge/view.tsx
+++ b/@robopo/web/app/judge/view.tsx
@@ -17,7 +17,7 @@ import type {
   SelectJudgeWithCompetition,
 } from "@/app/lib/db/schema"
 
-type SortKey = "name" | "id"
+type SortKey = "username" | "id"
 
 export function JudgeView({
   initialJudgeList,
@@ -62,7 +62,7 @@ export function JudgeView({
       const q = searchQuery.trim().toLowerCase()
       list = list.filter(
         (j) =>
-          j.name.toLowerCase().includes(q) ||
+          j.username.toLowerCase().includes(q) ||
           (j.note?.toLowerCase().includes(q) ?? false),
       )
     }
@@ -71,8 +71,8 @@ export function JudgeView({
     }
     return [...list].sort((a, b) => {
       let cmp = 0
-      if (sortKey === "name") {
-        cmp = a.name.localeCompare(b.name, "ja")
+      if (sortKey === "username") {
+        cmp = a.username.localeCompare(b.username)
       } else {
         cmp = a.id - b.id
       }
@@ -161,7 +161,7 @@ export function JudgeView({
           <MagnifyingGlassIcon className="size-4 shrink-0 text-base-content/40" />
           <input
             type="text"
-            placeholder="名前・備考で検索"
+            placeholder="ユーザー名・備考で検索"
             className="grow"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
@@ -192,7 +192,7 @@ export function JudgeView({
               onChange={(e) => setSortKey(e.target.value as SortKey)}
             >
               <option value="id">ID</option>
-              <option value="name">名前</option>
+              <option value="username">ユーザー名</option>
             </select>
             <button
               type="button"
@@ -206,7 +206,7 @@ export function JudgeView({
               ) : (
                 <BarsArrowUpIcon className="size-3.5" />
               )}
-              {sortKey === "name"
+              {sortKey === "username"
                 ? sortOrder === "desc"
                   ? "Z→A"
                   : "A→Z"

--- a/@robopo/web/app/lib/db/queries/queries.ts
+++ b/@robopo/web/app/lib/db/queries/queries.ts
@@ -18,6 +18,8 @@ import {
   type SelectCourseWithCompetition,
   type SelectJudgeWithCompetition,
   type SelectPlayerWithCompetition,
+  session,
+  user,
 } from "@/app/lib/db/schema"
 
 // Check if a course name already exists (optionally excluding a specific course ID)
@@ -475,23 +477,6 @@ export async function getPlayerByName(
   return result.length > 0 ? result[0] : null
 }
 
-// Check if a judge name already exists (optionally excluding a specific judge ID)
-export async function getJudgeByName(
-  name: string,
-  excludeId?: number,
-): Promise<{ id: number } | null> {
-  const conditions = [eq(judge.name, name)]
-  if (excludeId) {
-    conditions.push(ne(judge.id, excludeId))
-  }
-  const result = await db
-    .select({ id: judge.id })
-    .from(judge)
-    .where(and(...conditions))
-    .limit(1)
-  return result.length > 0 ? result[0] : null
-}
-
 // Get players with their competitions
 export async function getPlayersWithCompetition() {
   return await db
@@ -555,18 +540,32 @@ export function groupByPlayer(
   return Array.from(map.values())
 }
 
-// Get judges with their competitions
+// Get judges with their competitions (username from user table)
 export async function getJudgeWithCompetition() {
+  // Subquery: latest session createdAt per userId
+  const lastLoginSubquery = db
+    .select({
+      userId: session.userId,
+      lastLoginAt: sql<Date>`MAX(${session.createdAt})`.as("last_login_at"),
+    })
+    .from(session)
+    .groupBy(session.userId)
+    .as("last_login")
+
   return await db
     .select({
       id: judge.id,
-      name: judge.name,
+      username: user.username,
       note: judge.note,
+      userId: judge.userId,
+      lastLoginAt: lastLoginSubquery.lastLoginAt,
       createdAt: judge.createdAt,
       competitionId: competition.id,
       competitionName: competition.name,
     })
     .from(judge)
+    .innerJoin(user, eq(judge.userId, user.id))
+    .leftJoin(lastLoginSubquery, eq(user.id, lastLoginSubquery.userId))
     .leftJoin(competitionJudge, eq(judge.id, competitionJudge.judgeId))
     .leftJoin(competition, eq(competitionJudge.competitionId, competition.id))
     .orderBy(judge.id)
@@ -576,8 +575,10 @@ export async function getJudgeWithCompetition() {
 export function groupByJudge(
   flatRows: {
     id: number
-    name: string
+    username: string | null
     note: string | null
+    userId: string
+    lastLoginAt: Date | null
     createdAt: Date | null
     competitionId: number | null
     competitionName: string | null
@@ -590,8 +591,10 @@ export function groupByJudge(
     if (!existing) {
       existing = {
         id: row.id,
-        name: row.name,
+        username: row.username ?? "",
         note: row.note,
+        userId: row.userId,
+        lastLoginAt: row.lastLoginAt,
         createdAt: row.createdAt,
         competitionId: row.competitionId,
         competitionIds: [],
@@ -770,7 +773,7 @@ export async function getJudgeSummaryByCompetition(
   const result = await db.execute(sql`
     SELECT
       j.id AS "judgeId",
-      j.name AS "judgeName",
+      u.username AS "judgeName",
       COUNT(DISTINCT c.player_id)::int AS "scoredPlayerCount",
       array_agg(DISTINCT p.name) AS "scoredPlayerNames",
       TO_CHAR(MIN(c.created_at) AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo', 'YYYY-MM-DD"T"HH24:MI:SS"+09:00"') AS "firstScoringTime",
@@ -784,10 +787,11 @@ export async function getJudgeSummaryByCompetition(
         + CASE WHEN c.detail = 'courseOut:retry' THEN 1 ELSE 0 END
       )::int AS "courseOutCount"
     FROM judge j
+    INNER JOIN "user" u ON u.id = j.user_id
     INNER JOIN challenge c ON c.judge_id = j.id AND c.competition_id = ${competitionId}
     INNER JOIN player p ON p.id = c.player_id
     INNER JOIN course co ON co.id = c.course_id
-    GROUP BY j.id, j.name
+    GROUP BY j.id, u.username
     ORDER BY j.id
   `)
   return result.rows as JudgeSummary[]

--- a/@robopo/web/app/lib/db/schema.ts
+++ b/@robopo/web/app/lib/db/schema.ts
@@ -42,8 +42,10 @@ export const player = pgTable("player", {
 
 export const judge = pgTable("judge", {
   id: serial("id").primaryKey(),
-  name: text("name").notNull().unique(),
   note: text("note"),
+  userId: text("user_id")
+    .notNull()
+    .references(() => user.id, { onDelete: "cascade" }),
   createdAt: timestamp("created_at").defaultNow(),
 })
 
@@ -163,6 +165,11 @@ export type SelectPlayer = typeof player.$inferSelect
 export type InsertJudge = typeof judge.$inferInsert
 export type SelectJudge = typeof judge.$inferSelect
 
+// Judge with username from user table (used for display)
+export type SelectJudgeWithUsername = SelectJudge & {
+  username: string
+}
+
 export type InsertChallenge = typeof challenge.$inferInsert
 export type SelectChallenge = typeof challenge.$inferSelect
 
@@ -189,8 +196,10 @@ export type SelectPlayerWithCompetition = {
 
 export type SelectJudgeWithCompetition = {
   id: number
-  name: string
+  username: string
   note: string | null
+  userId: string
+  lastLoginAt: Date | null
   createdAt: Date | null
   competitionId: number | null
   competitionIds: number[]

--- a/@robopo/web/app/lib/db/seed.ts
+++ b/@robopo/web/app/lib/db/seed.ts
@@ -1,5 +1,6 @@
 import { sql } from "drizzle-orm"
 import { db } from "@/app/lib/db/db"
+import { auth } from "@/lib/auth"
 
 async function seed() {
   await db.execute(sql`BEGIN`)
@@ -51,29 +52,67 @@ async function seed() {
       SELECT setval('course_id_seq', (SELECT COALESCE(MAX(id), 0) FROM course))
     `)
 
-    // Test judges
+    // Known test judge usernames
+    const judgeUsernames = ["testjudge", "judgeb", "judgec"]
+    const usernameList = sql.join(
+      judgeUsernames.map((u) => sql`${u}`),
+      sql`, `,
+    )
+
+    // Clean up test judges by username (single-pass, targeted cleanup)
     await db.execute(sql`
-      INSERT INTO judge (id, name)
-      VALUES (1, 'TestJudge')
-      ON CONFLICT (id) DO UPDATE SET name = 'TestJudge'
-    `)
-    await db.execute(sql`
-      UPDATE challenge SET judge_id = NULL WHERE judge_id IN (
-        SELECT id FROM judge WHERE name IN ('審判B', '審判C')
+      UPDATE challenge SET judge_id = NULL
+      WHERE judge_id IN (
+        SELECT j.id FROM judge j
+        JOIN "user" u ON j.user_id = u.id
+        WHERE u.username IN (${usernameList})
       )
     `)
     await db.execute(sql`
-      DELETE FROM competition_judge WHERE judge_id IN (
-        SELECT id FROM judge WHERE name IN ('審判B', '審判C')
+      DELETE FROM competition_judge
+      WHERE judge_id IN (
+        SELECT j.id FROM judge j
+        JOIN "user" u ON j.user_id = u.id
+        WHERE u.username IN (${usernameList})
       )
     `)
-    await db.execute(sql`DELETE FROM judge WHERE name IN ('審判B', '審判C')`)
     await db.execute(sql`
-      SELECT setval('judge_id_seq', (SELECT COALESCE(MAX(id), 0) FROM judge))
+      DELETE FROM judge
+      WHERE user_id IN (SELECT id FROM "user" WHERE username IN (${usernameList}))
     `)
     await db.execute(sql`
-      INSERT INTO judge (name) VALUES ('審判B'), ('審判C')
+      DELETE FROM "user" WHERE username IN (${usernameList})
     `)
+    await db.execute(sql`
+      SELECT setval('judge_id_seq', GREATEST((SELECT COALESCE(MAX(id), 0) FROM judge), 1))
+    `)
+
+    // Create judge accounts (user + judge record)
+    async function createJudgeAccount(username: string) {
+      const res = await auth.api.signUpEmail({
+        body: {
+          email: `${username}@robopo.local`,
+          password: "judge1234",
+          name: username,
+          username,
+        },
+      })
+      if (!res?.user?.id) {
+        return
+      }
+      await db.execute(sql`
+        INSERT INTO judge (user_id) VALUES (${res.user.id})
+      `)
+      console.log(`  Judge account created: ${username}`)
+    }
+
+    for (const uname of judgeUsernames) {
+      try {
+        await createJudgeAccount(uname)
+      } catch (e) {
+        console.error(`  Failed to create account for ${uname}:`, e)
+      }
+    }
 
     // Delete existing data to prevent test data duplication
     await db.execute(sql`

--- a/@robopo/web/app/page.tsx
+++ b/@robopo/web/app/page.tsx
@@ -1,3 +1,4 @@
+import { eq } from "drizzle-orm"
 import { headers } from "next/headers"
 import { Dashboard } from "@/app/components/home/dashboard"
 import { ChallengeTab } from "@/app/components/home/tabs"
@@ -8,13 +9,15 @@ import {
   getCourseList,
   getJudgeList,
 } from "@/app/components/server/db"
+import { db } from "@/app/lib/db/db"
 import type {
   SelectCompetition,
   SelectCompetitionCourse,
   SelectCompetitionJudge,
   SelectCourse,
-  SelectJudge,
+  SelectJudgeWithUsername,
 } from "@/app/lib/db/schema"
+import { judge } from "@/app/lib/db/schema"
 import { auth } from "@/lib/auth"
 
 export default async function Home() {
@@ -27,30 +30,57 @@ export default async function Home() {
   const competitionCourseList: {
     competitionCourseList: SelectCompetitionCourse[]
   } = await getCompetitionCourseAssignList()
-  const judgeList: SelectJudge[] = await getJudgeList()
+  const judgeList: SelectJudgeWithUsername[] = await getJudgeList()
   const competitionJudgeList: {
     competitionJudgeList: SelectCompetitionJudge[]
   } = await getCompetitionJudgeAssignList()
 
-  return session?.user ? (
-    <Dashboard
+  // Check if logged-in user is a judge
+  let isJudge = false
+  let loggedInJudgeId: number | undefined
+  if (session?.user) {
+    const judgeRecord = await db
+      .select({ id: judge.id })
+      .from(judge)
+      .where(eq(judge.userId, session.user.id))
+      .limit(1)
+    if (judgeRecord.length > 0) {
+      isJudge = true
+      loggedInJudgeId = judgeRecord[0].id
+    }
+  }
+
+  const isAdmin = session?.user && !isJudge
+
+  const challengeTab = (
+    <ChallengeTab
+      key="challenge"
       competitionList={competitionList}
       courseList={courseList}
       competitionCourseList={competitionCourseList}
       judgeList={judgeList}
       competitionJudgeList={competitionJudgeList}
+      loggedInJudgeId={loggedInJudgeId}
     />
-  ) : (
+  )
+
+  if (isAdmin) {
+    return (
+      <Dashboard
+        competitionList={competitionList}
+        courseList={courseList}
+        competitionCourseList={competitionCourseList}
+        judgeList={judgeList}
+        competitionJudgeList={competitionJudgeList}
+        loggedInJudgeId={loggedInJudgeId}
+      />
+    )
+  }
+
+  return (
     <div className="mx-auto mt-8 max-w-lg">
       <div className="rounded-box border border-base-300 bg-base-100 p-6 shadow-sm">
-        <ChallengeTab
-          key="challenge"
-          competitionList={competitionList}
-          courseList={courseList}
-          competitionCourseList={competitionCourseList}
-          judgeList={judgeList}
-          competitionJudgeList={competitionJudgeList}
-        />
+        {challengeTab}
       </div>
     </div>
   )

--- a/@robopo/web/app/summary/judgeSummaryTable.tsx
+++ b/@robopo/web/app/summary/judgeSummaryTable.tsx
@@ -21,7 +21,7 @@ type JudgeSortKey =
   | "courseOutCount"
 
 const SORT_OPTIONS: { value: JudgeSortKey; label: string }[] = [
-  { value: "judgeName", label: "採点者名" },
+  { value: "judgeName", label: "ユーザー名" },
   { value: "scoredPlayerCount", label: "採点人数" },
   { value: "firstScoringTime", label: "初採点時刻" },
   { value: "lastScoringTime", label: "最終採点時刻" },
@@ -133,7 +133,7 @@ export function JudgeSummaryTable({ competitionId }: Props) {
 
   const columns = [
     "ID",
-    "採点者名",
+    "ユーザー名",
     "採点人数",
     "初採点時刻",
     "最終採点時刻",
@@ -147,7 +147,7 @@ export function JudgeSummaryTable({ competitionId }: Props) {
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <MultiSortToolbar<JudgeSortKey>
-        searchPlaceholder="採点者名で検索"
+        searchPlaceholder="ユーザー名で検索"
         searchQuery={searchQuery}
         onSearchChange={setSearchQuery}
         sortConditions={sortConditions}

--- a/@robopo/web/test/unit/components/home/tabs.test.tsx
+++ b/@robopo/web/test/unit/components/home/tabs.test.tsx
@@ -75,8 +75,8 @@ const competitionCourseList = {
 }
 
 const judgeList = [
-  { id: 1, name: "Judge A", createdAt: null },
-  { id: 2, name: "Judge B", createdAt: null },
+  { id: 1, username: "judgea", note: null, userId: "u1", createdAt: null },
+  { id: 2, username: "judgeb", note: null, userId: "u2", createdAt: null },
 ]
 
 const competitionJudgeList = {
@@ -123,8 +123,8 @@ describe("ChallengeTab", () => {
         competitionJudgeList={competitionJudgeList}
       />,
     )
-    expect(screen.getByText("Judge A")).toBeTruthy()
-    expect(screen.getByText("Judge B")).toBeTruthy()
+    expect(screen.getByText("judgea")).toBeTruthy()
+    expect(screen.getByText("judgeb")).toBeTruthy()
   })
 
   test("shows warning when course card clicked without judge selected", () => {

--- a/@robopo/web/test/unit/lib/db/groupBy.test.ts
+++ b/@robopo/web/test/unit/lib/db/groupBy.test.ts
@@ -65,23 +65,85 @@ describe("groupByPlayer", () => {
 describe("groupByJudge", () => {
   test("groups flat rows by judge id and collects competition names", () => {
     const result = groupByJudge([
-      { id: 1, name: "U1", competitionId: 10, competitionName: "Comp1" },
-      { id: 1, name: "U1", competitionId: 20, competitionName: "Comp2" },
-      { id: 2, name: "U2", competitionId: 10, competitionName: "Comp1" },
+      {
+        id: 1,
+        username: "U1",
+        userId: "u1",
+        note: null,
+        lastLoginAt: null,
+        createdAt: null,
+        competitionId: 10,
+        competitionName: "Comp1",
+      },
+      {
+        id: 1,
+        username: "U1",
+        userId: "u1",
+        note: null,
+        lastLoginAt: null,
+        createdAt: null,
+        competitionId: 20,
+        competitionName: "Comp2",
+      },
+      {
+        id: 2,
+        username: "U2",
+        userId: "u2",
+        note: null,
+        lastLoginAt: null,
+        createdAt: null,
+        competitionId: 10,
+        competitionName: "Comp1",
+      },
     ])
 
     expect(result).toHaveLength(2)
+    expect(result[0].username).toBe("U1")
+    expect(result[0].userId).toBe("u1")
+    expect(result[0].lastLoginAt).toBeNull()
     expect(result[0].competitionName).toEqual(["Comp1", "Comp2"])
+    expect(result[1].username).toBe("U2")
+    expect(result[1].userId).toBe("u2")
     expect(result[1].competitionName).toEqual(["Comp1"])
   })
 
   test("handles judge with no competition", () => {
     const result = groupByJudge([
-      { id: 1, name: "U1", competitionId: null, competitionName: null },
+      {
+        id: 1,
+        username: "U1",
+        userId: "u1",
+        note: null,
+        lastLoginAt: null,
+        createdAt: null,
+        competitionId: null,
+        competitionName: null,
+      },
     ])
 
     expect(result).toHaveLength(1)
+    expect(result[0].username).toBe("U1")
+    expect(result[0].userId).toBe("u1")
     expect(result[0].competitionName).toEqual([])
+  })
+
+  test("normalizes null username to empty string", () => {
+    const result = groupByJudge([
+      {
+        id: 1,
+        username: null,
+        userId: "u1",
+        note: null,
+        lastLoginAt: new Date("2024-01-01T00:00:00.000Z"),
+        createdAt: null,
+        competitionId: 10,
+        competitionName: "Comp1",
+      },
+    ])
+
+    expect(result).toHaveLength(1)
+    expect(result[0].username).toBe("")
+    expect(result[0].lastLoginAt).toEqual(new Date("2024-01-01T00:00:00.000Z"))
   })
 
   test("returns empty array for empty input", () => {

--- a/@robopo/web/test/unit/lib/db/queries.test.ts
+++ b/@robopo/web/test/unit/lib/db/queries.test.ts
@@ -5,7 +5,6 @@ import {
   getChallengeCount,
   getCourseSummary,
   getFirstCount,
-  getJudgeByName,
   getMaxResult,
   getPlayerByName,
   getPlayerResult,
@@ -18,7 +17,6 @@ import {
   competitionCourse,
   competitionPlayer,
   course,
-  judge,
   player,
 } from "@/app/lib/db/schema"
 
@@ -41,18 +39,6 @@ async function setupTestData() {
       .delete(competitionCourse)
       .where(eq(competitionCourse.courseId, existing[0].id))
     await db.delete(course).where(eq(course.id, existing[0].id))
-  }
-
-  // Clean up leftover test judges
-  for (const jName of ["__test_judge_A__"]) {
-    const existingJudge = await db
-      .select({ id: judge.id })
-      .from(judge)
-      .where(eq(judge.name, jName))
-      .limit(1)
-    if (existingJudge.length > 0) {
-      await db.delete(judge).where(eq(judge.id, existingJudge[0].id))
-    }
   }
 
   // Clean up leftover test players
@@ -292,38 +278,6 @@ describe("getPlayerByName", () => {
   })
 })
 
-describe("getJudgeByName", () => {
-  let testJudgeId: number
-
-  beforeAll(async () => {
-    const [j] = await db
-      .insert(judge)
-      .values({ name: "__test_judge_A__" })
-      .returning({ id: judge.id })
-    testJudgeId = j.id
-  })
-
-  afterAll(async () => {
-    await db.delete(judge).where(eq(judge.id, testJudgeId))
-  })
-
-  test("returns null when no judge matches", async () => {
-    const result = await getJudgeByName("__nonexistent_judge__")
-    expect(result).toBeNull()
-  })
-
-  test("returns the correct judge when there is a match", async () => {
-    const result = await getJudgeByName("__test_judge_A__")
-    expect(result).not.toBeNull()
-    expect(result?.id).toBe(testJudgeId)
-  })
-
-  test("honors excludeId when provided", async () => {
-    const result = await getJudgeByName("__test_judge_A__", testJudgeId)
-    expect(result).toBeNull()
-  })
-})
-
 describe("groupByPlayer", () => {
   test("groups rows by player and populates competitionIds", () => {
     const rows = [
@@ -433,24 +387,30 @@ describe("groupByJudge", () => {
     const rows = [
       {
         id: 1,
-        name: "Judge A",
+        username: "judgeA",
+        userId: "u1",
         note: null,
+        lastLoginAt: null,
         createdAt: null,
         competitionId: 10,
         competitionName: "Comp A",
       },
       {
         id: 1,
-        name: "Judge A",
+        username: "judgeA",
+        userId: "u1",
         note: null,
+        lastLoginAt: null,
         createdAt: null,
         competitionId: 20,
         competitionName: "Comp B",
       },
       {
         id: 2,
-        name: "Judge B",
+        username: "judgeB",
+        userId: "u2",
         note: null,
+        lastLoginAt: null,
         createdAt: null,
         competitionId: 10,
         competitionName: "Comp A",
@@ -460,24 +420,34 @@ describe("groupByJudge", () => {
     expect(result).toHaveLength(2)
     const judgeA = result.find((j) => j.id === 1)
     expect(judgeA).toBeDefined()
+    expect(judgeA?.username).toBe("judgeA")
+    expect(judgeA?.userId).toBe("u1")
+    expect(judgeA?.lastLoginAt).toBeNull()
     expect(judgeA?.competitionIds).toEqual([10, 20])
     expect(judgeA?.competitionName).toEqual(["Comp A", "Comp B"])
+    const judgeB = result.find((j) => j.id === 2)
+    expect(judgeB?.username).toBe("judgeB")
+    expect(judgeB?.userId).toBe("u2")
   })
 
   test("de-duplicates competitionIds", () => {
     const rows = [
       {
         id: 1,
-        name: "Judge A",
+        username: "judgeA",
+        userId: "u1",
         note: null,
+        lastLoginAt: null,
         createdAt: null,
         competitionId: 10,
         competitionName: "Comp A",
       },
       {
         id: 1,
-        name: "Judge A",
+        username: "judgeA",
+        userId: "u1",
         note: null,
+        lastLoginAt: null,
         createdAt: null,
         competitionId: 10,
         competitionName: "Comp A",
@@ -492,8 +462,10 @@ describe("groupByJudge", () => {
     const rows = [
       {
         id: 1,
-        name: "Judge A",
+        username: "judgeA",
+        userId: "u1",
         note: null,
+        lastLoginAt: null,
         createdAt: null,
         competitionId: null,
         competitionName: null,

--- a/@robopo/web/test/unit/lib/db/seed.test.ts
+++ b/@robopo/web/test/unit/lib/db/seed.test.ts
@@ -6,13 +6,18 @@ import {
   deserializeMission,
 } from "@/app/components/course/utils"
 import { db } from "@/app/lib/db/db"
-import { course, judge } from "@/app/lib/db/schema"
+import { course, judge, user } from "@/app/lib/db/schema"
 
 describe("seed data", () => {
   test("test judge exists in database", async () => {
-    const result = await db.select().from(judge).where(eq(judge.id, 1)).limit(1)
+    const result = await db
+      .select({ id: judge.id, username: user.username })
+      .from(judge)
+      .innerJoin(user, eq(judge.userId, user.id))
+      .where(eq(user.username, "testjudge"))
+      .limit(1)
     expect(result).toHaveLength(1)
-    expect(result[0].name).toBe("TestJudge")
+    expect(result[0].username).toBe("testjudge")
   })
 
   for (const courseName of ["TestCourse", "TestCourse2"]) {


### PR DESCRIPTION
## Summary by Sourcery

ユーザーに紐づいた認証済みジャッジアカウントを導入し、スタンドアロンのジャッジ名ではなく、ユーザー名および Better Auth アカウントを基盤としてジャッジ管理を行うように更新します。

New Features:
- ユーザー名とパスワードを持つ Better Auth ユーザーに裏打ちされたジャッジアカウントの作成・管理機能を追加し、ジャッジフォームでのバリデーションおよびパスワード表示切り替えをサポート。
- ジャッジがログインしてチャレンジビューへ直接アクセスできるようにしつつ、管理用ナビゲーション UI は非ジャッジユーザーにのみ表示されるよう制限。

Enhancements:
- ジャッジのデータモデルをリファクタリングし、name の代わりにクエリ・一覧・サマリー全体で username を利用するよう変更するとともに、Better Auth ユーザーを userId で参照し、セッションから最終ログイン時刻を追跡。
- ジャッジ削除・更新 API を更新し、関連する Better Auth ユーザーおよびアカウントレコードを管理（パスワード変更やカスケード削除を含む）。
- シーディングロジックを改修し、Better Auth 経由でテスト用ジャッジアカウントを作成するようにするとともに、新しいジャッジスキーマおよびユーザー名ベースのフローにテストと型定義を揃える。

Tests:
- DB クエリ、グルーピング、シーディング、および UI コンポーネントに関する単体テストを調整し、ユーザー名ベースのジャッジおよび新しいジャッジ関連の型で動作するように対応。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce authenticated judge accounts linked to users and update judge management to operate on usernames and Better Auth accounts instead of standalone judge names.

New Features:
- Add creation and management of judge accounts backed by Better Auth users with username and password, including validation and password visibility toggle in the judge form.
- Allow judges to log in and access the challenge view directly while restricting admin navigation UI to non-judge users.

Enhancements:
- Refactor judge data model to reference Better Auth users via userId, replacing name with username throughout queries, listings, and summaries, and tracking last login time from sessions.
- Update judge deletion and update APIs to manage associated Better Auth user and account records, including password changes and cascaded cleanup.
- Revise seeding logic to create test judge accounts via Better Auth and align tests and types with the new judge schema and username-based flows.

Tests:
- Adjust unit tests for DB queries, grouping, seeding, and UI components to work with username-based judges and the new judge-related types.

</details>