### PR TITLE
fix: disable login button when no input

### DIFF
--- a/@robopo/web/app/@auth/signIn/page.tsx
+++ b/@robopo/web/app/@auth/signIn/page.tsx
@@ -16,7 +16,13 @@ import {
 } from "@/app/components/common/commonModal"
 import { signInAction } from "@/app/components/server/auth"
 
-function SubmitButton({ success }: { success?: boolean }) {
+function SubmitButton({
+  success,
+  disabled,
+}: {
+  success?: boolean
+  disabled?: boolean
+}) {
   const { pending } = useFormStatus()
 
   if (success) {
@@ -35,7 +41,7 @@ function SubmitButton({ success }: { success?: boolean }) {
   return (
     <button
       type="submit"
-      disabled={pending}
+      disabled={pending || disabled}
       className="btn btn-primary w-full rounded-xl shadow-lg shadow-primary/25 transition-all duration-200 hover:shadow-primary/30 hover:shadow-xl"
     >
       {pending ? (
@@ -58,11 +64,15 @@ function FormFields({
   passwordId,
   showPassword,
   setShowPassword,
+  onUsernameChange,
+  onPasswordChange,
 }: {
   usernameId: string
   passwordId: string
   showPassword: boolean
   setShowPassword: (fn: (prev: boolean) => boolean) => void
+  onUsernameChange: (value: string) => void
+  onPasswordChange: (value: string) => void
 }) {
   const { pending } = useFormStatus()
 
@@ -81,6 +91,7 @@ function FormFields({
           name="username"
           placeholder="robosava"
           required
+          onChange={(e) => onUsernameChange(e.target.value)}
           className="input w-full rounded-xl border-base-300/50 bg-base-200/50 transition-all duration-200 focus:border-primary/50 focus:bg-base-100 focus:ring-2 focus:ring-primary/20"
         />
       </div>
@@ -98,6 +109,7 @@ function FormFields({
             name="password"
             placeholder="12345678"
             required
+            onChange={(e) => onPasswordChange(e.target.value)}
             className="input w-full rounded-xl border-base-300/50 bg-base-200/50 pr-12 transition-all duration-200 focus:border-primary/50 focus:bg-base-100 focus:ring-2 focus:ring-primary/20"
           />
           <button
@@ -145,6 +157,8 @@ export default function SignIn() {
   const callbackUrl = getSafeCallbackUrl(rawCallbackUrl)
   const [state, action] = useActionState(signInAction, undefined)
   const [showPassword, setShowPassword] = useState(false)
+  const [username, setUsername] = useState("")
+  const [password, setPassword] = useState("")
 
   useEffect(() => {
     if (state?.success) {
@@ -171,10 +185,15 @@ export default function SignIn() {
             passwordId={passwordId}
             showPassword={showPassword}
             setShowPassword={setShowPassword}
+            onUsernameChange={setUsername}
+            onPasswordChange={setPassword}
           />
 
           <div className="mt-6 flex w-full flex-col gap-2">
-            <SubmitButton success={state?.success} />
+            <SubmitButton
+              success={state?.success}
+              disabled={!username.trim() || !password.trim()}
+            />
             <ModalBackButton />
           </div>
 

--- a/@robopo/web/app/components/server/auth.ts
+++ b/@robopo/web/app/components/server/auth.ts
@@ -5,10 +5,6 @@ import { auth } from "@/lib/auth"
 // Form state for signIn
 type FormState =
   | {
-      errors?: {
-        username?: string[]
-        password?: string[]
-      }
       message?: string
       success?: boolean
     }
@@ -16,20 +12,13 @@ type FormState =
 
 // Server action for sign-in
 export async function signInAction(_state: FormState, formData: FormData) {
-  const username = formData.get("username")
-  const password = formData.get("password")
+  const username = formData.get("username")?.toString().trim() ?? ""
+  const password = formData.get("password")?.toString() ?? ""
 
-  // Validation
-  if (!username || typeof username !== "string") {
+  if (!username || !password) {
     return {
       success: false,
-      message: "ユーザーネームが未入力です",
-    }
-  }
-  if (!password || typeof password !== "string") {
-    return {
-      success: false,
-      message: "パスワードが未入力です",
+      message: "ログインに失敗しました",
     }
   }
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,3 +100,10 @@ bun run test:e2e     # Playwright e2e tests
 bun run db:seed      # Seed database with test data
 bun run docs-dev     # Start docs dev server
 ```
+
+### Post-Edit Checks
+
+After completing code changes, always run the following and fix any errors before finishing:
+
+1. `bun lint:fix --unsafe` — auto-fix lint and formatting issues
+2. `bun test:unit` — ensure all unit tests pass


### PR DESCRIPTION
## Summary by Sourcery

ユーザー名またはパスワードが空のときはサインイン送信を無効化し、サインインのバリデーションロジックを整理しました。

New Features:
- ユーザー名とパスワードの両方のフィールドに空白以外の入力が行われるまで、サインインの送信ボタンをクライアント側で無効化する機能を追加。

Bug Fixes:
- サーバー側のバリデーションエラーを返すのではなく、UI レベルで送信をブロックすることで、空の認証情報でのサインイン試行を防止。

Enhancements:
- 使われていないフィールドレベルのエラーストラクチャを削除し、サインインのサーバーアクションにおけるフォームステートを簡素化。
- クライアント側で存在チェックが行われた後、サインインのサーバーアクションが送信されたフォーム値を文字列として扱うように更新。

Documentation:
- AGENTS.md に、編集後に必要となる lint とユニットテストのコマンドを記載。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Disable sign-in submission when username or password is empty and streamline sign-in validation logic.

New Features:
- Add client-side disabling of the sign-in submit button until both username and password fields contain non-whitespace input.

Bug Fixes:
- Prevent sign-in attempts with empty credentials by blocking submission at the UI level instead of returning server-side validation errors.

Enhancements:
- Simplify sign-in server action form state by removing unused field-level error structures.
- Update sign-in server action to treat submitted form values as strings after client-side presence validation.

Documentation:
- Document required post-edit linting and unit test commands in AGENTS.md.

</details>