### PR TITLE
feat: remove eye icon on password form

### DIFF
--- a/@robopo/web/app/@auth/signIn/page.tsx
+++ b/@robopo/web/app/@auth/signIn/page.tsx
@@ -4,8 +4,6 @@ import {
   ArrowRightEndOnRectangleIcon,
   CheckCircleIcon,
   ExclamationCircleIcon,
-  EyeIcon,
-  EyeSlashIcon,
 } from "@heroicons/react/24/outline"
 import { useSearchParams } from "next/navigation"
 import { useActionState, useEffect, useId, useState } from "react"
@@ -32,8 +30,8 @@ function SubmitButton({
         disabled
         className="btn btn-success w-full rounded-xl text-success-content shadow-lg shadow-success/25"
       >
-        ログイン成功
         <CheckCircleIcon className="size-5" />
+        ログイン成功
       </button>
     )
   }
@@ -46,13 +44,13 @@ function SubmitButton({
     >
       {pending ? (
         <>
-          ログイン中
           <span className="loading loading-spinner loading-sm" />
+          ログイン中
         </>
       ) : (
         <>
-          ログイン
           <ArrowRightEndOnRectangleIcon className="size-5" />
+          ログイン
         </>
       )}
     </button>
@@ -62,15 +60,11 @@ function SubmitButton({
 function FormFields({
   usernameId,
   passwordId,
-  showPassword,
-  setShowPassword,
   onUsernameChange,
   onPasswordChange,
 }: {
   usernameId: string
   passwordId: string
-  showPassword: boolean
-  setShowPassword: (fn: (prev: boolean) => boolean) => void
   onUsernameChange: (value: string) => void
   onPasswordChange: (value: string) => void
 }) {
@@ -102,29 +96,15 @@ function FormFields({
         >
           パスワード
         </label>
-        <div className="relative">
-          <input
-            id={passwordId}
-            type={showPassword ? "text" : "password"}
-            name="password"
-            placeholder="12345678"
-            required
-            onChange={(e) => onPasswordChange(e.target.value)}
-            className="input w-full rounded-xl border-base-300/50 bg-base-200/50 pr-12 transition-all duration-200 focus:border-primary/50 focus:bg-base-100 focus:ring-2 focus:ring-primary/20"
-          />
-          <button
-            type="button"
-            onClick={() => setShowPassword((prev) => !prev)}
-            className="absolute inset-y-0 right-2 flex items-center rounded-lg p-1.5 text-base-content/40 transition-colors hover:bg-base-300/50 hover:text-base-content/70"
-            aria-label="パスワードを表示"
-          >
-            {showPassword ? (
-              <EyeSlashIcon className="size-5" />
-            ) : (
-              <EyeIcon className="size-5" />
-            )}
-          </button>
-        </div>
+        <input
+          id={passwordId}
+          type="password"
+          name="password"
+          placeholder="12345678"
+          required
+          onChange={(e) => onPasswordChange(e.target.value)}
+          className="input w-full rounded-xl border-base-300/50 bg-base-200/50 transition-all duration-200 focus:border-primary/50 focus:bg-base-100 focus:ring-2 focus:ring-primary/20"
+        />
       </div>
     </fieldset>
   )
@@ -156,7 +136,6 @@ export default function SignIn() {
 
   const callbackUrl = getSafeCallbackUrl(rawCallbackUrl)
   const [state, action] = useActionState(signInAction, undefined)
-  const [showPassword, setShowPassword] = useState(false)
   const [username, setUsername] = useState("")
   const [password, setPassword] = useState("")
 
@@ -175,16 +154,11 @@ export default function SignIn() {
         <form action={action} className="flex flex-col items-center px-2">
           <div className="mb-6 w-full text-center">
             <h2 className="font-bold text-2xl text-base-content">ログイン</h2>
-            <p className="mt-1 text-base-content/50 text-sm">
-              アカウントにログインしてください
-            </p>
           </div>
 
           <FormFields
             usernameId={usernameId}
             passwordId={passwordId}
-            showPassword={showPassword}
-            setShowPassword={setShowPassword}
             onUsernameChange={setUsername}
             onPasswordChange={setPassword}
           />

--- a/@robopo/web/app/challenge/challenge.tsx
+++ b/@robopo/web/app/challenge/challenge.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from "next/navigation"
 import type React from "react"
-import { useEffect, useRef, useState } from "react"
+import { useCallback, useRef, useState } from "react"
 import {
   SoundController,
   useAudioContext,
@@ -299,20 +299,44 @@ export function Challenge({
   })
   const [botDirection, setBotDirection] = useState(missionState[0])
   const [strictMode, _setStrictMode] = useState(false)
-  const nextAudioRef = useRef<HTMLAudioElement | null>(null)
-  const nextSound = nextAudioRef.current
-  const backAudioRef = useRef<HTMLAudioElement | null>(null)
-  const backSound = backAudioRef.current
-  const goalAudioRef = useRef<HTMLAudioElement | null>(null)
-  const goalSound = goalAudioRef.current
   const { muted } = useAudioContext()
+  const audioPoolRef = useRef<Map<string, HTMLAudioElement[]>>(new Map())
 
-  useEffect(() => {
-    if (nextSound && backSound) {
-      nextSound.volume = 0.4
-      backSound.volume = 0.2
-    }
-  }, [nextSound, backSound])
+  const playSound = useCallback(
+    (src: string, volume: number) => {
+      if (muted) {
+        return
+      }
+      const pool = audioPoolRef.current
+      if (!pool.has(src)) {
+        pool.set(src, [])
+      }
+      const instances = pool.get(src) as HTMLAudioElement[]
+      // 再生が終了済みのインスタンスを再利用、なければ新規作成
+      let audio = instances.find((a) => a.ended || a.paused)
+      if (!audio) {
+        audio = new Audio(src)
+        instances.push(audio)
+      }
+      audio.volume = volume
+      audio.currentTime = 0
+      audio.play().catch(() => {})
+    },
+    [muted],
+  )
+
+  const playNext = useCallback(
+    () => playSound("/sound/02_next.mp3", 0.4),
+    [playSound],
+  )
+  const playBack = useCallback(
+    () => playSound("/sound/03_back.mp3", 0.2),
+    [playSound],
+  )
+  const playGoal = useCallback(
+    () => playSound("/sound/04_goal.mp3", 1.0),
+    [playSound],
+  )
 
   const handleNext = (row: number, col: number) => {
     if (
@@ -331,10 +355,10 @@ export function Challenge({
         if (nowMission === missionPair.length - 1) {
           setIsGoal(true)
           setModalOpen(1)
-          !muted && goalSound?.play()
+          playGoal()
         } else if (nowMission < missionPair.length - 1) {
           setNowMission(nowMission + 1)
-          !muted && nextSound?.play()
+          playNext()
         }
         if (!isRetry && !isGoal) {
           setFirstResult(firstResult + 1)
@@ -371,7 +395,7 @@ export function Challenge({
       if (isGoal) {
         setIsGoal(false)
       }
-      !muted && backSound?.play()
+      playBack()
     }
   }
 
@@ -404,11 +428,11 @@ export function Challenge({
       setPointCount(newPoint + goalPt)
       setIsGoal(true)
       setModalOpen(1)
-      !muted && goalSound?.play()
+      playGoal()
     } else {
       setPointCount(newPoint)
       setNowMission(nowMission + 1)
-      !muted && nextSound?.play()
+      playNext()
     }
 
     // Update robot position
@@ -465,9 +489,6 @@ export function Challenge({
 
   return (
     <>
-      <audio src="/sound/02_next.mp3" ref={nextAudioRef} muted={muted} />
-      <audio src="/sound/03_back.mp3" ref={backAudioRef} muted={muted} />
-      <audio src="/sound/04_goal.mp3" ref={goalAudioRef} muted={muted} />
       <NormalChallengeSection
         isGoal={isGoal}
         pointState={pointState}


### PR DESCRIPTION
## Summary by Sourcery

チャレンジビューでのオーディオ再生をリファクタリングし、サインインフォームのパスワードおよびボタンのUIを簡素化しました。

Enhancements:
- チャレンジ画面で事前マウントされていたオーディオ要素を、`HTMLAudioElement` インスタンスを利用する再利用可能なサウンド再生用ヘルパーに置き換えました。
- サインインのパスワードフィールドから表示／非表示のトグルと目のアイコンを削除しつつ、必要なバリデーションとスタイリングは維持して簡素化しました。
- サインインボタンのコンテンツレイアウトを調整し、UI をすっきりさせるためにセカンダリのログイン説明テキストを削除しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor audio playback in the challenge view and simplify the sign-in form password and button UI.

Enhancements:
- Replace pre-mounted audio elements in the challenge screen with a reusable sound-playing helper using HTMLAudioElement instances.
- Simplify the sign-in password field by removing the show/hide toggle and eye icon while preserving required validation and styling.
- Adjust sign-in button content layout and remove the secondary login description text for a cleaner UI.

</details>