### PR TITLE
feat: use lucide icon instead of heroicons

### DIFF
--- a/.mise/prepare-state.toml
+++ b/.mise/prepare-state.toml
@@ -1,3 +1,3 @@
 [providers.bun]
-"bun.lock" = "17b6cdaadc9a75897b9eef0fdc35e94d007573e771a21d801e4e0c1a0cbcd580"
+"bun.lock" = "e63f0fb76931c3654e7cd4d4413b20737009c58517120ab79f9aa2ac85d300e0"
 "package.json" = "7fb2193f773ad401981ab6e757ccdd3c79e0ace156fe984a0b9413f22140a6b2"

--- a/@robopo/web/app/@auth/signIn/page.tsx
+++ b/@robopo/web/app/@auth/signIn/page.tsx
@@ -1,10 +1,6 @@
 "use client"
 
-import {
-  ArrowRightEndOnRectangleIcon,
-  CheckCircleIcon,
-  ExclamationCircleIcon,
-} from "@heroicons/react/24/outline"
+import { CircleAlert, CircleCheck, LogIn } from "lucide-react"
 import { useSearchParams } from "next/navigation"
 import { useActionState, useEffect, useId, useState } from "react"
 import { useFormStatus } from "react-dom"
@@ -30,7 +26,7 @@ function SubmitButton({
         disabled
         className="btn btn-success w-full rounded-xl text-success-content shadow-lg shadow-success/25"
       >
-        <CheckCircleIcon className="size-5" />
+        <CircleCheck className="size-5" />
         ログイン成功
       </button>
     )
@@ -49,7 +45,7 @@ function SubmitButton({
         </>
       ) : (
         <>
-          <ArrowRightEndOnRectangleIcon className="size-5" />
+          <LogIn className="size-5" />
           ログイン
         </>
       )}
@@ -173,7 +169,7 @@ export default function SignIn() {
 
           {state?.message && !state?.success && (
             <div className="mt-4 flex w-full items-center gap-2 rounded-lg bg-error/10 px-4 py-2.5 text-error text-sm">
-              <ExclamationCircleIcon className="size-5 shrink-0" />
+              <CircleAlert className="size-5 shrink-0" />
               {state.message}
             </div>
           )}

--- a/@robopo/web/app/challenge/[competitionId]/[courseId]/[playerId]/audioContext.tsx
+++ b/@robopo/web/app/challenge/[competitionId]/[courseId]/[playerId]/audioContext.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { SpeakerWaveIcon, SpeakerXMarkIcon } from "@heroicons/react/24/outline"
+import { Volume2, VolumeX } from "lucide-react"
 import type React from "react"
 import { createContext, useContext, useEffect, useRef, useState } from "react"
 
@@ -78,9 +78,9 @@ export function SoundController() {
       aria-label="効果音のオン・オフ切り替え"
     >
       {muted ? (
-        <SpeakerXMarkIcon className="size-5 text-base-content/40" />
+        <VolumeX className="size-5 text-base-content/40" />
       ) : (
-        <SpeakerWaveIcon className="size-5 text-success" />
+        <Volume2 className="size-5 text-success" />
       )}
     </button>
   )

--- a/@robopo/web/app/competition/tabs.tsx
+++ b/@robopo/web/app/competition/tabs.tsx
@@ -1,11 +1,6 @@
 "use client"
 
-import {
-  CheckIcon,
-  PlusIcon,
-  TrashIcon,
-  XMarkIcon,
-} from "@heroicons/react/24/outline"
+import { Check, Plus, Trash2, X } from "lucide-react"
 import { useState } from "react"
 import type {
   SelectCompetitionWithCourse,
@@ -230,7 +225,7 @@ export function CompetitionFormModal({
               onClick={onClose}
               disabled={loading}
             >
-              <XMarkIcon className="size-4" />
+              <X className="size-4" />
               キャンセル
             </button>
             <button
@@ -241,9 +236,9 @@ export function CompetitionFormModal({
               {loading ? (
                 <span className="loading loading-spinner loading-sm" />
               ) : mode === "create" ? (
-                <PlusIcon className="size-4" />
+                <Plus className="size-4" />
               ) : (
-                <CheckIcon className="size-4" />
+                <Check className="size-4" />
               )}
               {mode === "create" ? "作成" : "保存"}
             </button>
@@ -335,7 +330,7 @@ export function DeleteCompetitionModal({
             onClick={onClose}
             disabled={loading}
           >
-            <XMarkIcon className="size-4" />
+            <X className="size-4" />
             キャンセル
           </button>
           <button
@@ -347,7 +342,7 @@ export function DeleteCompetitionModal({
             {loading ? (
               <span className="loading loading-spinner loading-sm" />
             ) : (
-              <TrashIcon className="size-4" />
+              <Trash2 className="size-4" />
             )}
             削除する
           </button>

--- a/@robopo/web/app/competition/view.tsx
+++ b/@robopo/web/app/competition/view.tsx
@@ -1,14 +1,16 @@
 "use client"
 
 import {
-  BarsArrowDownIcon,
-  BarsArrowUpIcon,
-  FunnelIcon,
-  MagnifyingGlassIcon,
-  PencilSquareIcon,
-  PlusIcon,
-  TrashIcon,
-} from "@heroicons/react/24/outline"
+  ArrowDown01,
+  ArrowDownAZ,
+  ArrowUp01,
+  ArrowUpAZ,
+  Filter,
+  Plus,
+  Search,
+  SquarePen,
+  Trash2,
+} from "lucide-react"
 import { useState } from "react"
 import {
   CompetitionFormModal,
@@ -123,7 +125,7 @@ export function CompetitionView({
               setCreateModalOpen(true)
             }}
           >
-            <PlusIcon className="size-4" />
+            <Plus className="size-4" />
             新規作成
           </button>
           <button
@@ -139,7 +141,7 @@ export function CompetitionView({
               setEditModalOpen(true)
             }}
           >
-            <PencilSquareIcon className="size-4" />
+            <SquarePen className="size-4" />
             編集
           </button>
           <button
@@ -155,7 +157,7 @@ export function CompetitionView({
               setDeleteModalOpen(true)
             }}
           >
-            <TrashIcon className="size-4" />
+            <Trash2 className="size-4" />
             削除
           </button>
         </div>
@@ -164,7 +166,7 @@ export function CompetitionView({
       {/* Filter bar */}
       <div className="flex shrink-0 flex-col gap-3 px-4 pb-4">
         <label className="input input-bordered flex items-center gap-2 rounded-xl bg-base-200/40 transition-colors focus-within:bg-base-100">
-          <MagnifyingGlassIcon className="size-4 shrink-0 text-base-content/40" />
+          <Search className="size-4 shrink-0 text-base-content/40" />
           <input
             type="text"
             placeholder="名前・説明で検索"
@@ -175,7 +177,7 @@ export function CompetitionView({
         </label>
         <div className="flex flex-wrap items-center gap-2">
           <div className="flex shrink-0 items-center gap-1.5 rounded-lg bg-base-200/50 px-2.5 py-1.5">
-            <FunnelIcon className="size-3.5 shrink-0 text-base-content/40" />
+            <Filter className="size-3.5 shrink-0 text-base-content/40" />
             <span className="shrink-0 text-xs">状態</span>
             <select
               className="select select-ghost select-xs bg-transparent pe-0 font-medium focus:outline-none [&>option]:bg-base-100 [&>option]:text-base-content"
@@ -208,10 +210,16 @@ export function CompetitionView({
                 setSortOrder((prev) => (prev === "asc" ? "desc" : "asc"))
               }
             >
-              {sortOrder === "desc" ? (
-                <BarsArrowDownIcon className="size-3.5" />
+              {sortKey === "name" ? (
+                sortOrder === "desc" ? (
+                  <ArrowDownAZ className="size-3.5" />
+                ) : (
+                  <ArrowUpAZ className="size-3.5" />
+                )
+              ) : sortOrder === "desc" ? (
+                <ArrowDown01 className="size-3.5" />
               ) : (
-                <BarsArrowUpIcon className="size-3.5" />
+                <ArrowUp01 className="size-3.5" />
               )}
               {sortKey === "name"
                 ? sortOrder === "desc"

--- a/@robopo/web/app/components/challenge/missionOverview.tsx
+++ b/@robopo/web/app/components/challenge/missionOverview.tsx
@@ -1,11 +1,6 @@
 "use client"
 
-import {
-  CheckCircleIcon,
-  ChevronRightIcon,
-  XMarkIcon,
-} from "@heroicons/react/24/outline"
-import { Bars3BottomLeftIcon } from "@heroicons/react/24/solid"
+import { ChevronRight, CircleCheck, ListOrdered, X } from "lucide-react"
 import { useEffect, useRef, useState } from "react"
 import type { MissionProgress } from "@/app/components/challenge/utils"
 import {
@@ -80,7 +75,7 @@ function MissionOverviewItem({
     <div ref={isCurrent ? currentRef : undefined} className={containerClass}>
       {/* Status icon / Number */}
       {isCompleted ? (
-        <CheckCircleIcon className="size-6 shrink-0 text-success" />
+        <CircleCheck className="size-6 shrink-0 text-success" />
       ) : (
         <div
           className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs ${
@@ -107,7 +102,7 @@ function MissionOverviewItem({
 
       {/* Current indicator */}
       {isCurrent && (
-        <ChevronRightIcon className="size-4 shrink-0 animate-pulse text-primary" />
+        <ChevronRight className="size-4 shrink-0 animate-pulse text-primary" />
       )}
     </div>
   )
@@ -166,7 +161,7 @@ export function MissionOverview({
         onClick={() => setOpen(true)}
         aria-label="ミッション一覧を開く"
       >
-        <Bars3BottomLeftIcon className="size-5" />
+        <ListOrdered className="size-5" />
         <span className="font-medium text-xs">
           {progress.completed}/{progress.total}
         </span>
@@ -199,7 +194,7 @@ export function MissionOverview({
                 onClick={() => setOpen(false)}
                 aria-label="閉じる"
               >
-                <XMarkIcon className="size-5" />
+                <X className="size-5" />
               </button>
             </div>
 

--- a/@robopo/web/app/components/common/commonModal.tsx
+++ b/@robopo/web/app/components/common/commonModal.tsx
@@ -1,10 +1,6 @@
 "use client"
 
-import {
-  CheckCircleIcon,
-  ExclamationTriangleIcon,
-  XCircleIcon,
-} from "@heroicons/react/24/outline"
+import { CircleCheck, CircleX, TriangleAlert } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { useState } from "react"
 import { BackButton } from "@/app/components/parts/buttons"
@@ -79,12 +75,12 @@ export function DeleteModal({ type, ids }: { type: InputType; ids: number[] }) {
         <div className="flex flex-col items-center px-2 py-2">
           {successMessage ? (
             <div className="flex flex-col items-center gap-3">
-              <CheckCircleIcon className="size-12 text-success" />
+              <CircleCheck className="size-12 text-success" />
               <p className="text-center font-medium">{successMessage}</p>
             </div>
           ) : (
             <div className="flex flex-col items-center gap-3">
-              <ExclamationTriangleIcon className="size-12 text-warning" />
+              <TriangleAlert className="size-12 text-warning" />
               <p className="text-center font-medium">
                 選択した{commonString}を削除しますか?
               </p>
@@ -93,7 +89,7 @@ export function DeleteModal({ type, ids }: { type: InputType; ids: number[] }) {
 
           {errorMessage && (
             <div className="mt-4 flex w-full items-center gap-2 rounded-lg bg-error/10 px-4 py-2.5 text-error text-sm">
-              <XCircleIcon className="size-5 shrink-0" />
+              <CircleX className="size-5 shrink-0" />
               {errorMessage}
             </div>
           )}

--- a/@robopo/web/app/components/common/view.tsx
+++ b/@robopo/web/app/components/common/view.tsx
@@ -1,19 +1,21 @@
 "use client"
 
 import {
-  BarsArrowDownIcon,
-  BarsArrowUpIcon,
-  CheckCircleIcon,
-  Cog6ToothIcon,
-  ExclamationTriangleIcon,
-  FunnelIcon,
-  MagnifyingGlassIcon,
-  PencilSquareIcon,
-  PlusIcon,
-  TrashIcon,
-  XCircleIcon,
-  XMarkIcon,
-} from "@heroicons/react/24/outline"
+  ArrowDown01,
+  ArrowDownAZ,
+  ArrowUp01,
+  ArrowUpAZ,
+  CircleCheck,
+  CircleX,
+  Filter,
+  Plus,
+  Search,
+  Settings,
+  SquarePen,
+  Trash2,
+  TriangleAlert,
+  X,
+} from "lucide-react"
 import Link from "next/link"
 import type React from "react"
 import { useState } from "react"
@@ -70,7 +72,7 @@ export function View({
               setCreateModalOpen(true)
             }}
           >
-            <PlusIcon className="size-4" />
+            <Plus className="size-4" />
             新規作成
           </button>
           <button
@@ -86,7 +88,7 @@ export function View({
               onEditClick?.()
             }}
           >
-            <PencilSquareIcon className="size-4" />
+            <SquarePen className="size-4" />
             編集
           </button>
           <Link
@@ -102,7 +104,7 @@ export function View({
               setSuccessMessage(null)
             }}
           >
-            <Cog6ToothIcon className="size-4" />
+            <Settings className="size-4" />
             コース編集
           </Link>
           <button
@@ -118,7 +120,7 @@ export function View({
               onDeleteClick?.()
             }}
           >
-            <TrashIcon className="size-4" />
+            <Trash2 className="size-4" />
             削除
           </button>
         </div>
@@ -150,7 +152,7 @@ export function View({
     return (
       <div className="flex flex-col gap-3 px-4 pb-4">
         <label className="input input-bordered flex items-center gap-2 rounded-xl bg-base-200/40 transition-colors focus-within:bg-base-100">
-          <MagnifyingGlassIcon className="size-4 shrink-0 text-base-content/40" />
+          <Search className="size-4 shrink-0 text-base-content/40" />
           <input
             type="text"
             placeholder="コース名・説明で検索"
@@ -161,7 +163,7 @@ export function View({
         </label>
         <div className="flex flex-wrap items-center gap-2">
           <div className="flex shrink-0 items-center gap-1.5 rounded-lg bg-base-200/50 px-2.5 py-1.5">
-            <FunnelIcon className="size-3.5 shrink-0 text-base-content/40" />
+            <Filter className="size-3.5 shrink-0 text-base-content/40" />
             <span className="shrink-0 text-xs">大会</span>
             <select
               className="select select-ghost select-xs bg-transparent pe-0 font-medium focus:outline-none [&>option]:bg-base-100 [&>option]:text-base-content"
@@ -195,10 +197,16 @@ export function View({
                 setSortOrder((prev) => (prev === "asc" ? "desc" : "asc"))
               }
             >
-              {sortOrder === "desc" ? (
-                <BarsArrowDownIcon className="size-3.5" />
+              {sortKey === "name" ? (
+                sortOrder === "desc" ? (
+                  <ArrowDownAZ className="size-3.5" />
+                ) : (
+                  <ArrowUpAZ className="size-3.5" />
+                )
+              ) : sortOrder === "desc" ? (
+                <ArrowDown01 className="size-3.5" />
               ) : (
-                <BarsArrowUpIcon className="size-3.5" />
+                <ArrowUp01 className="size-3.5" />
               )}
               {sortKey === "createdAt"
                 ? sortOrder === "desc"
@@ -349,7 +357,7 @@ export function View({
                 className="btn btn-ghost btn-sm btn-circle"
                 onClick={() => setCompetitionDetailNames(null)}
               >
-                <XMarkIcon className="size-5" />
+                <X className="size-5" />
               </button>
             </div>
             <div className="max-h-[60vh] overflow-y-auto">
@@ -474,12 +482,12 @@ function CourseDeleteModal({
         <div className="flex flex-col items-center px-2 py-2">
           {successMessage ? (
             <div className="flex flex-col items-center gap-3">
-              <CheckCircleIcon className="size-12 text-success" />
+              <CircleCheck className="size-12 text-success" />
               <p className="text-center font-medium">{successMessage}</p>
             </div>
           ) : hasLinkedCourses ? (
             <div className="flex flex-col items-center gap-3">
-              <ExclamationTriangleIcon className="size-12 text-warning" />
+              <TriangleAlert className="size-12 text-warning" />
               <p className="text-center font-medium">
                 使用大会が0でないコースは削除できません。
                 <br />
@@ -488,7 +496,7 @@ function CourseDeleteModal({
             </div>
           ) : (
             <div className="flex flex-col items-center gap-3">
-              <ExclamationTriangleIcon className="size-12 text-warning" />
+              <TriangleAlert className="size-12 text-warning" />
               <p className="text-center font-medium">
                 選択したコースを削除しますか?
               </p>
@@ -504,7 +512,7 @@ function CourseDeleteModal({
 
           {errorMessage && (
             <div className="mt-4 flex w-full items-center gap-2 rounded-lg bg-error/10 px-4 py-2.5 text-error text-sm">
-              <XCircleIcon className="size-5 shrink-0" />
+              <CircleX className="size-5 shrink-0" />
               {errorMessage}
             </div>
           )}

--- a/@robopo/web/app/components/course/missionList.tsx
+++ b/@robopo/web/app/components/course/missionList.tsx
@@ -15,14 +15,15 @@ import {
 } from "@dnd-kit/sortable"
 import { CSS } from "@dnd-kit/utilities"
 import {
-  ArrowUturnLeftIcon,
-  ArrowUturnRightIcon,
-  Bars3Icon,
-  ExclamationTriangleIcon,
-  PlusIcon,
-  TrashIcon,
-} from "@heroicons/react/24/outline"
-import { PlayIcon, StopIcon } from "@heroicons/react/24/solid"
+  GripVertical,
+  Play,
+  Plus,
+  Redo2,
+  Square,
+  Trash2,
+  TriangleAlert,
+  Undo2,
+} from "lucide-react"
 import { useEffect, useRef, useState } from "react"
 import {
   type FieldState,
@@ -344,9 +345,9 @@ export function MissionList({
                 disabled={!canPlay && !isPlaying}
               >
                 {isPlaying ? (
-                  <StopIcon className="size-3.5" />
+                  <Square className="size-3.5" fill="currentColor" />
                 ) : (
-                  <PlayIcon className="size-3.5" />
+                  <Play className="size-3.5" fill="currentColor" />
                 )}
               </button>
             </div>
@@ -358,7 +359,7 @@ export function MissionList({
             disabled={!canUndoMission || isPlaying}
             title="元に戻す"
           >
-            <ArrowUturnLeftIcon className="size-4" />
+            <Undo2 className="size-4" />
           </button>
           <button
             type="button"
@@ -367,7 +368,7 @@ export function MissionList({
             disabled={!canRedoMission || isPlaying}
             title="やり直す"
           >
-            <ArrowUturnRightIcon className="size-4" />
+            <Redo2 className="size-4" />
           </button>
         </div>
       </div>
@@ -762,7 +763,7 @@ function SortableMissionRow({
           {...listeners}
           onClick={(e) => e.stopPropagation()}
         >
-          <Bars3Icon className="size-4" />
+          <GripVertical className="size-4" />
         </button>
 
         {/* Order number */}
@@ -839,7 +840,7 @@ function SortableMissionRow({
               className="tooltip tooltip-left hidden sm:block"
               data-tip={errorMessage}
             >
-              <ExclamationTriangleIcon className="size-4 text-error" />
+              <TriangleAlert className="size-4 text-error" />
             </div>
             {/* Mobile: tap to show message */}
             <button
@@ -847,7 +848,7 @@ function SortableMissionRow({
               className="sm:hidden"
               onClick={handleErrorTap}
             >
-              <ExclamationTriangleIcon className="size-4 text-error" />
+              <TriangleAlert className="size-4 text-error" />
             </button>
           </>
         )}
@@ -862,7 +863,7 @@ function SortableMissionRow({
           }}
           title="削除"
         >
-          <TrashIcon className="size-4" />
+          <Trash2 className="size-4" />
         </button>
       </div>
       {/* Mobile error message */}
@@ -1279,7 +1280,7 @@ function AddButton({
         onClick={onClick}
         title="ミッションを追加"
       >
-        <PlusIcon className="size-3 text-primary" />
+        <Plus className="size-3 text-primary" />
       </button>
     </div>
   )

--- a/@robopo/web/app/components/course/nextArrow.tsx
+++ b/@robopo/web/app/components/course/nextArrow.tsx
@@ -1,4 +1,4 @@
-import { PauseIcon } from "@heroicons/react/24/solid"
+import { Pause } from "lucide-react"
 import {
   getNextPosition,
   type MissionValue,
@@ -350,7 +350,10 @@ export function NextPauseIndicator({
   return (
     <div style={getCellStyle({ row, col, responsive })}>
       <div className="pause-indicator flex h-3/4 w-3/4 items-center justify-center rounded-full bg-warning/25 ring-2 ring-warning/40">
-        <PauseIcon className="h-1/2 w-1/2 text-warning drop-shadow-sm" />
+        <Pause
+          className="h-1/2 w-1/2 text-warning drop-shadow-sm"
+          fill="currentColor"
+        />
       </div>
     </div>
   )

--- a/@robopo/web/app/components/course/panel.tsx
+++ b/@robopo/web/app/components/course/panel.tsx
@@ -1,4 +1,4 @@
-import { ExclamationTriangleIcon } from "@heroicons/react/24/outline"
+import { TriangleAlert } from "lucide-react"
 import { PanelString, type PanelValue } from "@/app/components/course/utils"
 
 // Panel component
@@ -71,7 +71,7 @@ export function Panel({
         ))}
       {isIsolated && hasRole && (
         <div className="pointer-events-none absolute inset-0 flex items-start justify-end border-2 border-error border-dashed bg-error/20 p-0.5">
-          <ExclamationTriangleIcon className="size-3.5 text-error sm:size-4" />
+          <TriangleAlert className="size-3.5 text-error sm:size-4" />
         </div>
       )}
     </button>

--- a/@robopo/web/app/components/header/navigationDrawer.tsx
+++ b/@robopo/web/app/components/header/navigationDrawer.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Bars3Icon, XMarkIcon } from "@heroicons/react/24/outline"
+import { Menu, X } from "lucide-react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { useEffect, useRef, useState } from "react"
@@ -188,7 +188,7 @@ export function NavigationDrawer() {
             className="btn btn-ghost btn-sm btn-square rounded-full transition-transform duration-200 hover:rotate-90 active:scale-90"
             aria-label="メニューを閉じる"
           >
-            <XMarkIcon className="size-5" />
+            <X className="size-5" />
           </button>
         </div>
 
@@ -239,7 +239,7 @@ export function NavigationDrawer() {
         className="btn btn-ghost btn-sm btn-square rounded-full transition-transform duration-200 active:scale-90"
         aria-label="メニューを開く"
       >
-        <Bars3Icon className="size-5" />
+        <Menu className="size-5" />
       </button>
 
       {mounted && createPortal(drawerOverlay, document.body)}

--- a/@robopo/web/app/components/home/dashboard.tsx
+++ b/@robopo/web/app/components/home/dashboard.tsx
@@ -1,9 +1,6 @@
 "use client"
 
-import {
-  ClipboardDocumentCheckIcon,
-  Cog6ToothIcon,
-} from "@heroicons/react/24/outline"
+import { ClipboardCheck, Settings } from "lucide-react"
 import type React from "react"
 import { ChallengeTab, ManageTab } from "@/app/components/home/tabs"
 import type {
@@ -74,7 +71,7 @@ export function Dashboard({
         <div className="md:col-span-2">
           <DashboardCard
             title="採点"
-            icon={<ClipboardDocumentCheckIcon className="h-5 w-5" />}
+            icon={<ClipboardCheck className="h-5 w-5" />}
             variant="primary"
           >
             <ChallengeTab
@@ -92,7 +89,7 @@ export function Dashboard({
         <div className="md:col-span-2">
           <DashboardCard
             title="大会管理"
-            icon={<Cog6ToothIcon className="h-5 w-5" />}
+            icon={<Settings className="h-5 w-5" />}
           >
             <ManageTab />
           </DashboardCard>

--- a/@robopo/web/app/components/home/player-selector.tsx
+++ b/@robopo/web/app/components/home/player-selector.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { CheckIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline"
+import { Check, Search } from "lucide-react"
 import { useEffect, useRef, useState, useTransition } from "react"
 
 import { getCompetitionPlayerList } from "@/app/components/server/db"
@@ -67,7 +67,7 @@ export function PlayerSelector({
       {/* Search bar */}
       {loaded && players.length > 0 && (
         <div className="relative">
-          <MagnifyingGlassIcon className="pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-base-content/40" />
+          <Search className="pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-base-content/40" />
           <input
             type="text"
             placeholder="選手を検索..."
@@ -122,7 +122,7 @@ export function PlayerSelector({
                   )}
                 </div>
                 {isSelected && (
-                  <CheckIcon className="h-5 w-5 shrink-0 text-primary" />
+                  <Check className="h-5 w-5 shrink-0 text-primary" />
                 )}
               </button>
             )

--- a/@robopo/web/app/components/home/tabs.tsx
+++ b/@robopo/web/app/components/home/tabs.tsx
@@ -1,11 +1,6 @@
 "use client"
 
-import {
-  MagnifyingGlassIcon,
-  PlayIcon,
-  TrophyIcon,
-  UserCircleIcon,
-} from "@heroicons/react/24/outline"
+import { Play, Search, Trophy, UserCheck } from "lucide-react"
 import type { Route } from "next"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
@@ -240,7 +235,7 @@ export function ChallengeTab({
         {singleCompetition ? (
           <SelectionCard
             name={singleCompetition.name}
-            icon={<TrophyIcon className="h-4 w-4" />}
+            icon={<Trophy className="h-4 w-4" />}
             isSelected
           />
         ) : activeCompetitions.length > 0 ? (
@@ -249,7 +244,7 @@ export function ChallengeTab({
               <SelectionCard
                 key={c.id}
                 name={c.name}
-                icon={<TrophyIcon className="h-4 w-4" />}
+                icon={<Trophy className="h-4 w-4" />}
                 isSelected={competitionId === c.id}
                 onClick={() => handleCompetitionChange(c.id)}
               />
@@ -271,7 +266,7 @@ export function ChallengeTab({
               <SelectionCard
                 key={c.id}
                 name={c.name}
-                icon={<PlayIcon className="h-4 w-4" />}
+                icon={<Play className="h-4 w-4" />}
                 isSelected={selectedCourseId === c.id}
                 onClick={
                   courseDisabled ? undefined : () => handleCourseSelect(c.id)
@@ -294,7 +289,7 @@ export function ChallengeTab({
         {competitionJudges.length > 0 ? (
           <div className="space-y-2">
             <div className="relative">
-              <MagnifyingGlassIcon className="pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-base-content/40" />
+              <Search className="pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-base-content/40" />
               <input
                 type="text"
                 placeholder="採点者を検索..."
@@ -310,7 +305,7 @@ export function ChallengeTab({
                   <SelectionCard
                     key={u.id}
                     name={u.username}
-                    icon={<UserCircleIcon className="h-4 w-4" />}
+                    icon={<UserCheck className="h-4 w-4" />}
                     isSelected={judgeId === u.id}
                     onClick={
                       competitionDisabled
@@ -362,7 +357,7 @@ export function ChallengeTab({
             : "cursor-not-allowed bg-base-300 text-base-content/30"
         }`}
       >
-        <PlayIcon className="h-5 w-5" />
+        <Play className="h-5 w-5" />
         採点を開始
       </button>
     </div>

--- a/@robopo/web/app/components/parts/buttons.tsx
+++ b/@robopo/web/app/components/parts/buttons.tsx
@@ -1,13 +1,13 @@
 "use client"
 
 import {
-  ArrowPathIcon,
-  ArrowUpCircleIcon,
-  ArrowUturnLeftIcon,
-  ExclamationTriangleIcon,
-  HomeIcon,
-  PlayIcon,
-} from "@heroicons/react/24/outline"
+  House,
+  Play,
+  RefreshCw,
+  SendHorizontal,
+  TriangleAlert,
+  Undo2,
+} from "lucide-react"
 import { useRouter } from "next/navigation"
 
 export function ReloadButton() {
@@ -17,7 +17,7 @@ export function ReloadButton() {
       className="btn btn-primary mx-auto mt-5 min-w-28 max-w-fit"
       onClick={() => window.location.reload()}
     >
-      <ArrowPathIcon className="size-6" />
+      <RefreshCw className="size-6" />
       再読み込み
     </button>
   )
@@ -31,7 +31,7 @@ export function HomeButton() {
       className="btn btn-primary m-5 mx-auto min-w-28 max-w-fit"
       onClick={() => router.push("/")}
     >
-      <HomeIcon className="size-6" />
+      <House className="size-6" />
       ホーム
     </button>
   )
@@ -65,7 +65,7 @@ export function BackButton({
       onClick={onClick}
       disabled={disabled}
     >
-      <ArrowUturnLeftIcon className="size-5" />
+      <Undo2 className="size-5" />
       {label}
     </button>
   )
@@ -99,7 +99,7 @@ export function SubmitButton({
         <span className="loading loading-spinner" />
       ) : (
         <>
-          <ArrowUpCircleIcon className="size-5" />
+          <SendHorizontal className="size-5" />
           {label}
         </>
       )}
@@ -129,7 +129,7 @@ export function RetryButton({
       onClick={onClick}
       disabled={disabled}
     >
-      <PlayIcon className="size-5" />
+      <Play className="size-5" />
       {label}
     </button>
   )
@@ -158,7 +158,7 @@ export function CourseOutButton({
       onClick={onClick}
       disabled={disabled}
     >
-      <ExclamationTriangleIcon className="size-4" />
+      <TriangleAlert className="size-4" />
       コースアウト
     </button>
   )
@@ -178,7 +178,7 @@ export function FailButton({
       className={`btn btn-error rounded-xl transition-all duration-200 ${extraClassName ?? ""}`.trim()}
       onClick={onClick}
     >
-      <ExclamationTriangleIcon className="size-5" />
+      <TriangleAlert className="size-5" />
       失敗
     </button>
   )

--- a/@robopo/web/app/components/summary/MultiSortToolbar.tsx
+++ b/@robopo/web/app/components/summary/MultiSortToolbar.tsx
@@ -1,12 +1,14 @@
 "use client"
 
 import {
-  BarsArrowDownIcon,
-  BarsArrowUpIcon,
-  MagnifyingGlassIcon,
-  PlusIcon,
-  XMarkIcon,
-} from "@heroicons/react/24/outline"
+  ArrowDown01,
+  ArrowDownAZ,
+  ArrowUp01,
+  ArrowUpAZ,
+  Plus,
+  Search,
+  X,
+} from "lucide-react"
 import type {
   SortCondition,
   SortOrder,
@@ -29,6 +31,7 @@ type Props<K extends string> = {
   onRemoveSort: (index: number) => void
   onAddSort: (key: K) => void
   onReset?: () => void
+  isTextKey?: (key: K) => boolean
 }
 
 export function MultiSortToolbar<K extends string>({
@@ -43,11 +46,12 @@ export function MultiSortToolbar<K extends string>({
   onRemoveSort,
   onAddSort,
   onReset,
+  isTextKey,
 }: Props<K>) {
   return (
     <div className="flex shrink-0 flex-col gap-3 px-4 pb-4">
       <label className="input input-bordered flex items-center gap-2 rounded-xl bg-base-200/40 transition-colors focus-within:bg-base-100">
-        <MagnifyingGlassIcon className="size-4 shrink-0 text-base-content/40" />
+        <Search className="size-4 shrink-0 text-base-content/40" />
         <input
           type="text"
           placeholder={searchPlaceholder}
@@ -73,10 +77,16 @@ export function MultiSortToolbar<K extends string>({
               className="flex items-center gap-0.5 rounded-md bg-base-200/60 px-1.5 py-0.5 text-xs transition-colors hover:bg-base-300/60"
               onClick={() => onToggleOrder(index)}
             >
-              {sc.order === "desc" ? (
-                <BarsArrowDownIcon className="size-3" />
+              {isTextKey?.(sc.key) ? (
+                sc.order === "desc" ? (
+                  <ArrowDownAZ className="size-3" />
+                ) : (
+                  <ArrowUpAZ className="size-3" />
+                )
+              ) : sc.order === "desc" ? (
+                <ArrowDown01 className="size-3" />
               ) : (
-                <BarsArrowUpIcon className="size-3" />
+                <ArrowUp01 className="size-3" />
               )}
               {getOrderLabel(sc.key, sc.order)}
             </button>
@@ -86,14 +96,14 @@ export function MultiSortToolbar<K extends string>({
               onClick={() => onRemoveSort(index)}
               aria-label={`${getSortLabel(sc.key)}のソートを削除`}
             >
-              <XMarkIcon className="size-3.5" />
+              <X className="size-3.5" />
             </button>
           </div>
         ))}
 
         {availableKeys.length > 0 && (
           <div className="flex items-center gap-1 rounded-lg bg-base-200/50 px-1.5 py-1">
-            <PlusIcon className="size-3.5 shrink-0 text-base-content/40" />
+            <Plus className="size-3.5 shrink-0 text-base-content/40" />
             <select
               className="select select-ghost select-xs bg-transparent font-medium text-base-content/60 focus:outline-none [&>option]:bg-base-100 [&>option]:text-base-content"
               value=""

--- a/@robopo/web/app/course/edit/editorPage.tsx
+++ b/@robopo/web/app/course/edit/editorPage.tsx
@@ -1,10 +1,6 @@
 "use client"
 
-import {
-  ArrowDownTrayIcon,
-  CheckCircleIcon,
-  ExclamationTriangleIcon,
-} from "@heroicons/react/24/outline"
+import { CircleCheck, Download, TriangleAlert } from "lucide-react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
   buildPreviewMission,
@@ -371,7 +367,7 @@ export function EditorPage({
                 className="tooltip tooltip-right hidden sm:inline-flex"
                 data-tip={saveBlockMessage}
               >
-                <ExclamationTriangleIcon className="size-5 text-warning" />
+                <TriangleAlert className="size-5 text-warning" />
               </div>
               {/* Mobile: tap to toggle message */}
               <button
@@ -379,7 +375,7 @@ export function EditorPage({
                 className="sm:hidden"
                 onClick={() => setShowSaveWarning((prev) => !prev)}
               >
-                <ExclamationTriangleIcon className="size-5 text-warning" />
+                <TriangleAlert className="size-5 text-warning" />
               </button>
             </>
           )}
@@ -390,7 +386,7 @@ export function EditorPage({
               className="btn btn-success min-w-28 max-w-fit rounded-xl shadow-lg shadow-success/20 transition-all duration-200"
             >
               保存成功
-              <CheckCircleIcon className="size-5" />
+              <CircleCheck className="size-5" />
             </button>
           ) : (
             <button
@@ -406,7 +402,7 @@ export function EditorPage({
                 </>
               ) : (
                 <>
-                  <ArrowDownTrayIcon className="size-5" />
+                  <Download className="size-5" />
                   保存
                 </>
               )}

--- a/@robopo/web/app/course/modals.tsx
+++ b/@robopo/web/app/course/modals.tsx
@@ -1,11 +1,6 @@
 "use client"
 
-import {
-  CheckCircleIcon,
-  CheckIcon,
-  PlusIcon,
-  XMarkIcon,
-} from "@heroicons/react/24/outline"
+import { Check, CircleCheck, Plus, X } from "lucide-react"
 import { useState } from "react"
 import type {
   SelectCompetition,
@@ -221,7 +216,7 @@ export function CourseFormModal({
               onClick={onClose}
               disabled={loading || success}
             >
-              <XMarkIcon className="size-4" />
+              <X className="size-4" />
               キャンセル
             </button>
             {success ? (
@@ -230,7 +225,7 @@ export function CourseFormModal({
                 disabled
                 className="btn btn-success gap-1.5 rounded-lg shadow-lg shadow-success/20 transition-all duration-200"
               >
-                <CheckCircleIcon className="size-4 animate-[scale-in_0.3s_ease-out]" />
+                <CircleCheck className="size-4 animate-[scale-in_0.3s_ease-out]" />
                 登録成功
               </button>
             ) : (
@@ -242,9 +237,9 @@ export function CourseFormModal({
                 {loading ? (
                   <span className="loading loading-spinner loading-sm" />
                 ) : mode === "create" ? (
-                  <PlusIcon className="size-4" />
+                  <Plus className="size-4" />
                 ) : (
-                  <CheckIcon className="size-4" />
+                  <Check className="size-4" />
                 )}
                 {mode === "create" ? "登録" : "保存"}
               </button>

--- a/@robopo/web/app/judge/modals.tsx
+++ b/@robopo/web/app/judge/modals.tsx
@@ -1,15 +1,15 @@
 "use client"
 
 import {
-  CheckCircleIcon,
-  CheckIcon,
-  ExclamationTriangleIcon,
-  EyeIcon,
-  EyeSlashIcon,
-  PlusIcon,
-  XCircleIcon,
-  XMarkIcon,
-} from "@heroicons/react/24/outline"
+  Check,
+  CircleCheck,
+  CircleX,
+  Eye,
+  EyeOff,
+  Plus,
+  TriangleAlert,
+  X,
+} from "lucide-react"
 import { useState } from "react"
 import type {
   SelectCompetition,
@@ -190,9 +190,9 @@ export function JudgeFormModal({
                 aria-label="パスワードを表示"
               >
                 {showPassword ? (
-                  <EyeSlashIcon className="size-5" />
+                  <EyeOff className="size-5" />
                 ) : (
-                  <EyeIcon className="size-5" />
+                  <Eye className="size-5" />
                 )}
               </button>
             </div>
@@ -259,7 +259,7 @@ export function JudgeFormModal({
               onClick={onClose}
               disabled={loading}
             >
-              <XMarkIcon className="size-4" />
+              <X className="size-4" />
               キャンセル
             </button>
             <button
@@ -270,9 +270,9 @@ export function JudgeFormModal({
               {loading ? (
                 <span className="loading loading-spinner loading-sm" />
               ) : mode === "create" ? (
-                <PlusIcon className="size-4" />
+                <Plus className="size-4" />
               ) : (
-                <CheckIcon className="size-4" />
+                <Check className="size-4" />
               )}
               {mode === "create" ? "登録" : "保存"}
             </button>
@@ -334,12 +334,12 @@ export function JudgeDeleteModal({
         <div className="flex flex-col items-center px-2 py-2">
           {successMessage ? (
             <div className="flex flex-col items-center gap-3">
-              <CheckCircleIcon className="size-12 text-success" />
+              <CircleCheck className="size-12 text-success" />
               <p className="text-center font-medium">{successMessage}</p>
             </div>
           ) : (
             <div className="flex flex-col items-center gap-3">
-              <ExclamationTriangleIcon className="size-12 text-warning" />
+              <TriangleAlert className="size-12 text-warning" />
               <p className="text-center font-medium">
                 選択した採点者を削除しますか?
               </p>
@@ -358,7 +358,7 @@ export function JudgeDeleteModal({
 
           {errorMessage && (
             <div className="mt-4 flex w-full items-center gap-2 rounded-lg bg-error/10 px-4 py-2.5 text-error text-sm">
-              <XCircleIcon className="size-5 shrink-0" />
+              <CircleX className="size-5 shrink-0" />
               {errorMessage}
             </div>
           )}

--- a/@robopo/web/app/judge/view.tsx
+++ b/@robopo/web/app/judge/view.tsx
@@ -1,14 +1,16 @@
 "use client"
 
 import {
-  BarsArrowDownIcon,
-  BarsArrowUpIcon,
-  FunnelIcon,
-  MagnifyingGlassIcon,
-  PencilSquareIcon,
-  PlusIcon,
-  TrashIcon,
-} from "@heroicons/react/24/outline"
+  ArrowDown01,
+  ArrowDownAZ,
+  ArrowUp01,
+  ArrowUpAZ,
+  Filter,
+  Plus,
+  Search,
+  SquarePen,
+  Trash2,
+} from "lucide-react"
 import { useState } from "react"
 import { CommonCheckboxList } from "@/app/components/common/commonList"
 import { JudgeDeleteModal, JudgeFormModal } from "@/app/judge/modals"
@@ -117,7 +119,7 @@ export function JudgeView({
               setCreateModalOpen(true)
             }}
           >
-            <PlusIcon className="size-4" />
+            <Plus className="size-4" />
             新規作成
           </button>
           <button
@@ -133,7 +135,7 @@ export function JudgeView({
               setEditModalOpen(true)
             }}
           >
-            <PencilSquareIcon className="size-4" />
+            <SquarePen className="size-4" />
             編集
           </button>
           <button
@@ -149,7 +151,7 @@ export function JudgeView({
               setDeleteModalOpen(true)
             }}
           >
-            <TrashIcon className="size-4" />
+            <Trash2 className="size-4" />
             削除
           </button>
         </div>
@@ -158,7 +160,7 @@ export function JudgeView({
       {/* Filter bar */}
       <div className="flex shrink-0 flex-col gap-3 px-4 pb-4">
         <label className="input input-bordered flex items-center gap-2 rounded-xl bg-base-200/40 transition-colors focus-within:bg-base-100">
-          <MagnifyingGlassIcon className="size-4 shrink-0 text-base-content/40" />
+          <Search className="size-4 shrink-0 text-base-content/40" />
           <input
             type="text"
             placeholder="ユーザー名・備考で検索"
@@ -169,7 +171,7 @@ export function JudgeView({
         </label>
         <div className="flex flex-wrap items-center gap-2">
           <div className="flex shrink-0 items-center gap-1.5 rounded-lg bg-base-200/50 px-2.5 py-1.5">
-            <FunnelIcon className="size-3.5 shrink-0 text-base-content/40" />
+            <Filter className="size-3.5 shrink-0 text-base-content/40" />
             <span className="shrink-0 text-xs">大会</span>
             <select
               className="select select-ghost select-xs bg-transparent pe-0 font-medium focus:outline-none [&>option]:bg-base-100 [&>option]:text-base-content"
@@ -201,10 +203,16 @@ export function JudgeView({
                 setSortOrder((prev) => (prev === "asc" ? "desc" : "asc"))
               }
             >
-              {sortOrder === "desc" ? (
-                <BarsArrowDownIcon className="size-3.5" />
+              {sortKey === "username" ? (
+                sortOrder === "desc" ? (
+                  <ArrowDownAZ className="size-3.5" />
+                ) : (
+                  <ArrowUpAZ className="size-3.5" />
+                )
+              ) : sortOrder === "desc" ? (
+                <ArrowDown01 className="size-3.5" />
               ) : (
-                <BarsArrowUpIcon className="size-3.5" />
+                <ArrowUp01 className="size-3.5" />
               )}
               {sortKey === "username"
                 ? sortOrder === "desc"

--- a/@robopo/web/app/lib/const.tsx
+++ b/@robopo/web/app/lib/const.tsx
@@ -1,16 +1,16 @@
 import {
-  ArrowRightEndOnRectangleIcon,
-  ArrowRightStartOnRectangleIcon,
-  ArrowUpCircleIcon,
-  ArrowUturnLeftIcon,
-  CalculatorIcon,
-  HomeIcon,
-  PlayIcon,
-  TrophyIcon,
-  UserCircleIcon,
-  UserIcon,
-  WrenchIcon,
-} from "@heroicons/react/24/outline"
+  BarChart3,
+  House,
+  LogIn,
+  LogOut,
+  Play,
+  Route as RouteIcon,
+  SendHorizontal,
+  Trophy,
+  Undo2,
+  UserCheck,
+  Users,
+} from "lucide-react"
 import type { Route } from "next"
 import type { JSX } from "react"
 
@@ -23,46 +23,46 @@ export interface NavItem {
 export const HOME_CONST: NavItem = {
   label: "ホーム",
   href: "/",
-  icon: <HomeIcon className="size-6" />,
+  icon: <House className="size-6" />,
 }
 
 export const SIGN_IN_CONST: NavItem = {
   label: "ログイン",
   href: "/signIn",
-  icon: <ArrowRightEndOnRectangleIcon className="size-6" />,
+  icon: <LogIn className="size-6" />,
 }
 
 export const SIGN_OUT_CONST: NavItem = {
   label: "ログアウト",
   href: "/signOut" as Route,
-  icon: <ArrowRightStartOnRectangleIcon className="size-6" />,
+  icon: <LogOut className="size-6" />,
 }
 
 export const COMPETITION_MANAGEMENT_LIST: NavItem[] = [
   {
     label: "大会一覧",
     href: "/competition",
-    icon: <TrophyIcon className="size-6" />,
+    icon: <Trophy className="size-6" />,
   },
   {
     label: "コース一覧",
     href: "/course",
-    icon: <WrenchIcon className="size-6" />,
+    icon: <RouteIcon className="size-6" />,
   },
   {
     label: "選手一覧",
     href: "/player",
-    icon: <UserIcon className="size-6" />,
+    icon: <Users className="size-6" />,
   },
   {
     label: "採点者一覧",
     href: "/judge",
-    icon: <UserCircleIcon className="size-6" />,
+    icon: <UserCheck className="size-6" />,
   },
   {
     label: "集計結果",
     href: "/summary" as Route,
-    icon: <CalculatorIcon className="size-6" />,
+    icon: <BarChart3 className="size-6" />,
   },
 ]
 
@@ -70,18 +70,18 @@ export const NAVIGATION_GENERAL_LIST: NavItem[] = [
   {
     label: "ホーム",
     href: "/",
-    icon: <HomeIcon className="size-6" />,
+    icon: <House className="size-6" />,
   },
 ]
 
 export const RETRY_CONST = {
   label: "2回目のチャレンジへ",
-  icon: <PlayIcon className="size-6" />,
+  icon: <Play className="size-6" />,
 }
 
 const BACK_CONST = {
   label: "戻る",
-  icon: <ArrowUturnLeftIcon className="size-6" />,
+  icon: <Undo2 className="size-6" />,
 }
 
 export function BackLabelWithIcon(): JSX.Element {
@@ -94,5 +94,5 @@ export function BackLabelWithIcon(): JSX.Element {
 }
 
 export function SendIcon(): JSX.Element {
-  return <ArrowUpCircleIcon className="size-6" />
+  return <SendHorizontal className="size-6" />
 }

--- a/@robopo/web/app/player/modals.tsx
+++ b/@robopo/web/app/player/modals.tsx
@@ -1,13 +1,13 @@
 "use client"
 
 import {
-  CheckCircleIcon,
-  CheckIcon,
-  ExclamationTriangleIcon,
-  PlusIcon,
-  XCircleIcon,
-  XMarkIcon,
-} from "@heroicons/react/24/outline"
+  Check,
+  CircleCheck,
+  CircleX,
+  Plus,
+  TriangleAlert,
+  X,
+} from "lucide-react"
 import { useState } from "react"
 import type {
   SelectCompetition,
@@ -198,7 +198,7 @@ export function PlayerFormModal({
               onClick={onClose}
               disabled={loading}
             >
-              <XMarkIcon className="size-4" />
+              <X className="size-4" />
               キャンセル
             </button>
             <button
@@ -209,9 +209,9 @@ export function PlayerFormModal({
               {loading ? (
                 <span className="loading loading-spinner loading-sm" />
               ) : mode === "create" ? (
-                <PlusIcon className="size-4" />
+                <Plus className="size-4" />
               ) : (
-                <CheckIcon className="size-4" />
+                <Check className="size-4" />
               )}
               {mode === "create" ? "登録" : "保存"}
             </button>
@@ -273,12 +273,12 @@ export function PlayerDeleteModal({
         <div className="flex flex-col items-center px-2 py-2">
           {successMessage ? (
             <div className="flex flex-col items-center gap-3">
-              <CheckCircleIcon className="size-12 text-success" />
+              <CircleCheck className="size-12 text-success" />
               <p className="text-center font-medium">{successMessage}</p>
             </div>
           ) : (
             <div className="flex flex-col items-center gap-3">
-              <ExclamationTriangleIcon className="size-12 text-warning" />
+              <TriangleAlert className="size-12 text-warning" />
               <p className="text-center font-medium">
                 選択した選手を削除しますか?
               </p>
@@ -297,7 +297,7 @@ export function PlayerDeleteModal({
 
           {errorMessage && (
             <div className="mt-4 flex w-full items-center gap-2 rounded-lg bg-error/10 px-4 py-2.5 text-error text-sm">
-              <XCircleIcon className="size-5 shrink-0" />
+              <CircleX className="size-5 shrink-0" />
               {errorMessage}
             </div>
           )}

--- a/@robopo/web/app/player/view.tsx
+++ b/@robopo/web/app/player/view.tsx
@@ -1,14 +1,16 @@
 "use client"
 
 import {
-  BarsArrowDownIcon,
-  BarsArrowUpIcon,
-  FunnelIcon,
-  MagnifyingGlassIcon,
-  PencilSquareIcon,
-  PlusIcon,
-  TrashIcon,
-} from "@heroicons/react/24/outline"
+  ArrowDown01,
+  ArrowDownAZ,
+  ArrowUp01,
+  ArrowUpAZ,
+  Filter,
+  Plus,
+  Search,
+  SquarePen,
+  Trash2,
+} from "lucide-react"
 import { useState } from "react"
 import { CommonCheckboxList } from "@/app/components/common/commonList"
 import type {
@@ -125,7 +127,7 @@ export function PlayerView({
               setCreateModalOpen(true)
             }}
           >
-            <PlusIcon className="size-4" />
+            <Plus className="size-4" />
             新規作成
           </button>
           <button
@@ -141,7 +143,7 @@ export function PlayerView({
               setEditModalOpen(true)
             }}
           >
-            <PencilSquareIcon className="size-4" />
+            <SquarePen className="size-4" />
             編集
           </button>
           <button
@@ -157,7 +159,7 @@ export function PlayerView({
               setDeleteModalOpen(true)
             }}
           >
-            <TrashIcon className="size-4" />
+            <Trash2 className="size-4" />
             削除
           </button>
         </div>
@@ -166,7 +168,7 @@ export function PlayerView({
       {/* Filter bar */}
       <div className="flex shrink-0 flex-col gap-3 px-4 pb-4">
         <label className="input input-bordered flex items-center gap-2 rounded-xl bg-base-200/40 transition-colors focus-within:bg-base-100">
-          <MagnifyingGlassIcon className="size-4 shrink-0 text-base-content/40" />
+          <Search className="size-4 shrink-0 text-base-content/40" />
           <input
             type="text"
             placeholder="名前・ふりがな・ゼッケン番号・備考で検索"
@@ -177,7 +179,7 @@ export function PlayerView({
         </label>
         <div className="flex flex-wrap items-center gap-2">
           <div className="flex shrink-0 items-center gap-1.5 rounded-lg bg-base-200/50 px-2.5 py-1.5">
-            <FunnelIcon className="size-3.5 shrink-0 text-base-content/40" />
+            <Filter className="size-3.5 shrink-0 text-base-content/40" />
             <span className="shrink-0 text-xs">大会</span>
             <select
               className="select select-ghost select-xs bg-transparent pe-0 font-medium focus:outline-none [&>option]:bg-base-100 [&>option]:text-base-content"
@@ -211,10 +213,16 @@ export function PlayerView({
                 setSortOrder((prev) => (prev === "asc" ? "desc" : "asc"))
               }
             >
-              {sortOrder === "desc" ? (
-                <BarsArrowDownIcon className="size-3.5" />
+              {sortKey === "name" || sortKey === "furigana" ? (
+                sortOrder === "desc" ? (
+                  <ArrowDownAZ className="size-3.5" />
+                ) : (
+                  <ArrowUpAZ className="size-3.5" />
+                )
+              ) : sortOrder === "desc" ? (
+                <ArrowDown01 className="size-3.5" />
               ) : (
-                <BarsArrowUpIcon className="size-3.5" />
+                <ArrowUp01 className="size-3.5" />
               )}
               {sortKey === "name" || sortKey === "furigana"
                 ? sortOrder === "desc"

--- a/@robopo/web/app/summary/courseSummaryTable.tsx
+++ b/@robopo/web/app/summary/courseSummaryTable.tsx
@@ -167,6 +167,7 @@ export function CourseSummaryTable({ competitionId }: Props) {
         onRemoveSort={removeSort}
         onAddSort={addSort}
         onReset={sortConditions.length > 1 ? resetSort : undefined}
+        isTextKey={(key) => key === "courseName"}
       />
 
       <div className="min-h-0 flex-1 overflow-x-auto overflow-y-auto">

--- a/@robopo/web/app/summary/judgeSummaryTable.tsx
+++ b/@robopo/web/app/summary/judgeSummaryTable.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { XMarkIcon } from "@heroicons/react/24/outline"
+import { X } from "lucide-react"
 import { useEffect, useState } from "react"
 import { DataTableShell } from "@/app/components/summary/DataTableShell"
 import { MultiSortToolbar } from "@/app/components/summary/MultiSortToolbar"
@@ -158,6 +158,7 @@ export function JudgeSummaryTable({ competitionId }: Props) {
         onRemoveSort={removeSort}
         onAddSort={addSort}
         onReset={sortConditions.length > 1 ? resetSort : undefined}
+        isTextKey={(key) => key === "judgeName"}
       />
 
       <div className="min-h-0 flex-1 overflow-x-auto overflow-y-auto">
@@ -220,7 +221,7 @@ export function JudgeSummaryTable({ competitionId }: Props) {
                 className="btn btn-ghost btn-sm btn-circle"
                 onClick={() => setPlayerDetailNames(null)}
               >
-                <XMarkIcon className="size-5" />
+                <X className="size-5" />
               </button>
             </div>
             <div className="max-h-[60vh] overflow-y-auto">

--- a/@robopo/web/app/summary/playerSummaryTable.tsx
+++ b/@robopo/web/app/summary/playerSummaryTable.tsx
@@ -292,6 +292,7 @@ export function PlayerSummaryTable({ competitionId }: Props) {
         onRemoveSort={removeSort}
         onAddSort={addSort}
         onReset={sortConditions.length > 1 ? resetSort : undefined}
+        isTextKey={(key) => key === "playerFurigana"}
       />
 
       <div className="min-h-0 flex-1 overflow-x-auto overflow-y-auto">

--- a/@robopo/web/app/summary/summaryView.tsx
+++ b/@robopo/web/app/summary/summaryView.tsx
@@ -1,10 +1,6 @@
 "use client"
 
-import {
-  ClipboardDocumentCheckIcon,
-  MapIcon,
-  UserGroupIcon,
-} from "@heroicons/react/24/outline"
+import { type LucideIcon, Route as RouteIcon, Scale, Users } from "lucide-react"
 import { useState } from "react"
 import type { SelectCompetition } from "@/app/lib/db/schema"
 import { CourseSummaryTable } from "@/app/summary/courseSummaryTable"
@@ -13,10 +9,10 @@ import { PlayerSummaryTable } from "@/app/summary/playerSummaryTable"
 
 type TabKey = "player" | "judge" | "course"
 
-const TABS: { key: TabKey; label: string; icon: typeof UserGroupIcon }[] = [
-  { key: "player", label: "選手", icon: UserGroupIcon },
-  { key: "judge", label: "採点者", icon: ClipboardDocumentCheckIcon },
-  { key: "course", label: "コース", icon: MapIcon },
+const TABS: { key: TabKey; label: string; icon: LucideIcon }[] = [
+  { key: "player", label: "選手", icon: Users },
+  { key: "judge", label: "採点者", icon: Scale },
+  { key: "course", label: "コース", icon: RouteIcon },
 ]
 
 type Props = {

--- a/@robopo/web/package.json
+++ b/@robopo/web/package.json
@@ -43,6 +43,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "better-auth": "^1.6.2",
     "drizzle-orm": "^0.45.2",
+    "lucide-react": "^1.8.0",
     "next": "^16.2.3",
     "pg": "^8.20.0",
     "react": "^19.2.5",
@@ -52,7 +53,6 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.10",
     "@happy-dom/global-registrator": "^20.9.0",
-    "@heroicons/react": "^2.2.0",
     "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4.2.2",
     "@testing-library/dom": "^10.4.1",

--- a/bun.lock
+++ b/bun.lock
@@ -41,6 +41,7 @@
         "@dnd-kit/utilities": "^3.2.2",
         "better-auth": "^1.6.2",
         "drizzle-orm": "^0.45.2",
+        "lucide-react": "^1.8.0",
         "next": "^16.2.3",
         "pg": "^8.20.0",
         "react": "^19.2.5",
@@ -50,7 +51,6 @@
       "devDependencies": {
         "@biomejs/biome": "^2.4.10",
         "@happy-dom/global-registrator": "^20.9.0",
-        "@heroicons/react": "^2.2.0",
         "@playwright/test": "^1.59.1",
         "@tailwindcss/postcss": "^4.2.2",
         "@testing-library/dom": "^10.4.1",
@@ -606,8 +606,6 @@
     "@hapi/topo": ["@hapi/topo@5.1.0", "", { "dependencies": { "@hapi/hoek": "^9.0.0" } }, "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg=="],
 
     "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.9.0", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.9.0" } }, "sha512-lBW6/m5BIFl3pMuWPNN0lIOYw9LMCmPfix53ExS3FBi4E+NELEljQ3xH6aAV9IYiQRfn9YIIgzzMrD0vIcD7tw=="],
-
-    "@heroicons/react": ["@heroicons/react@2.2.0", "", { "peerDependencies": { "react": ">= 16 || ^19.0.0-rc" } }, "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ=="],
 
     "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
 
@@ -2006,6 +2004,8 @@
     "lowercase-keys": ["lowercase-keys@3.0.0", "", {}, "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ=="],
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "lucide-react": ["lucide-react@1.8.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 


### PR DESCRIPTION
## Summary by Sourcery

Webアプリ全体で使用している Heroicons を lucide-react のアイコンに置き換え、それに伴う関連コンポーネントの調整を行います。

Enhancements:
- ナビゲーション、ボタン、モーダル、ツールバー、ダッシュボードなどを含むすべての UI コンポーネントで、`@heroicons/react` の代わりに `lucide-react` のアイコンを使用するよう統一します。
- ナビゲーションおよびサマリータブの設定を更新し、`lucide-react` のアイコン型を参照するようにします。
- 依存関係の構成を更新し、`lucide-react` を追加、`@heroicons/react` を削除し、Bun のロックファイルを再生成します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace Heroicons usage across the web app with lucide-react icons and adjust related components accordingly.

Enhancements:
- Standardize all UI components to use lucide-react icons instead of @heroicons/react, including navigation, buttons, modals, toolbars, and dashboards.
- Update navigation and summary tab configurations to reference lucide-react icon types.
- Refresh dependency configuration by adding lucide-react, removing @heroicons/react, and regenerating the Bun lockfile.

</details>