### PR TITLE
feat: polish skelton loading

### DIFF
--- a/@robopo/web/app/@auth/signIn/layout.tsx
+++ b/@robopo/web/app/@auth/signIn/layout.tsx
@@ -1,9 +1,43 @@
 import type React from "react"
 import { Suspense } from "react"
-import { PageLoading } from "@/app/components/parts/pageLoading"
+import { Skeleton } from "@/app/components/common/skeleton"
+
+function SignInSkeleton() {
+  return (
+    <dialog open className="modal modal-open">
+      <div className="modal-box max-w-sm">
+        <div className="flex animate-[skeletonFadeIn_0.3s_ease-out] flex-col items-center px-2">
+          {/* Title */}
+          <div className="mb-6 w-full text-center">
+            <Skeleton className="mx-auto h-7 w-24" />
+          </div>
+
+          {/* Form fields */}
+          <div className="flex w-full flex-col gap-4">
+            <div>
+              <Skeleton className="mb-1.5 h-3.5 w-20" />
+              <Skeleton className="h-12 w-full rounded-xl" />
+            </div>
+            <div>
+              <Skeleton className="mb-1.5 h-3.5 w-20" />
+              <Skeleton className="h-12 w-full rounded-xl" />
+            </div>
+          </div>
+
+          {/* Buttons */}
+          <div className="mt-6 flex w-full flex-col gap-2">
+            <Skeleton className="h-12 w-full rounded-xl" />
+            <Skeleton className="h-12 w-full rounded-xl" />
+          </div>
+        </div>
+      </div>
+      <div className="modal-backdrop" />
+    </dialog>
+  )
+}
 
 export default function Layout({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
-  return <Suspense fallback={<PageLoading />}>{children}</Suspense> // modal
+  return <Suspense fallback={<SignInSkeleton />}>{children}</Suspense>
 }

--- a/@robopo/web/app/challenge/[competitionId]/[courseId]/[playerId]/loading.tsx
+++ b/@robopo/web/app/challenge/[competitionId]/[courseId]/[playerId]/loading.tsx
@@ -1,0 +1,49 @@
+import { Skeleton } from "@/app/components/common/skeleton"
+
+export default function Loading() {
+  return (
+    <div className="flex h-[calc(100dvh-3.5rem)] animate-[skeletonFadeIn_0.3s_ease-out] flex-col">
+      {/* Status bar */}
+      <div className="border-base-300 border-b bg-base-100">
+        <div className="flex items-center justify-between px-3 py-1.5">
+          {/* Left: attempt badge + course/player info */}
+          <div className="flex min-w-0 items-center gap-2">
+            <Skeleton className="h-6 w-14 rounded-full" />
+            <Skeleton className="h-3.5 w-32" />
+          </div>
+          {/* Right: mission overview + sound + score */}
+          <div className="flex shrink-0 items-center gap-2">
+            <Skeleton className="h-5 w-20 rounded" />
+            <Skeleton className="h-6 w-6 rounded" />
+            <Skeleton className="h-7 w-14 rounded" />
+          </div>
+        </div>
+        {/* Progress bar */}
+        <Skeleton className="h-1 w-full rounded-none" />
+      </div>
+
+      {/* Mission info area */}
+      <div className="flex shrink-0 items-center justify-center gap-4 bg-base-200/30 px-4 py-3">
+        <Skeleton className="h-9 w-9 rounded-full" />
+        <div className="space-y-1">
+          <Skeleton className="h-5 w-36" />
+          <Skeleton className="h-3.5 w-20" />
+        </div>
+      </div>
+
+      {/* Field (game board) */}
+      <div className="flex flex-1 items-center justify-center px-4">
+        <Skeleton className="aspect-square w-full max-w-sm rounded-2xl" />
+      </div>
+
+      {/* Action bar */}
+      <div className="border-base-300 border-t bg-base-100 px-4 py-3">
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-10 flex-1 rounded-lg" />
+          <Skeleton className="h-10 w-28 rounded-lg" />
+          <Skeleton className="h-10 flex-1 rounded-lg" />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/@robopo/web/app/loading.tsx
+++ b/@robopo/web/app/loading.tsx
@@ -1,7 +1,29 @@
 import { Skeleton } from "@/app/components/common/skeleton"
 
-const courseCards = ["cc0", "cc1", "cc2", "cc3"]
+const selectionCardKeys = ["sc0", "sc1"]
+const playerCardKeys = ["pc0", "pc1", "pc2"]
 const manageItems = ["m0", "m1", "m2", "m3", "m4"]
+
+function SelectionCardSkeleton() {
+  return (
+    <div className="flex min-h-[56px] w-full items-center gap-3 rounded-xl border border-base-300 px-4 py-2.5">
+      <Skeleton className="h-9 w-9 shrink-0 rounded-lg" />
+      <Skeleton className="h-4 w-3/5" />
+    </div>
+  )
+}
+
+function PlayerCardSkeleton() {
+  return (
+    <div className="flex w-full items-center gap-3 rounded-xl border border-base-300 px-3 py-2.5">
+      <Skeleton className="h-10 w-10 shrink-0 rounded-full" />
+      <div className="min-w-0 flex-1 space-y-1">
+        <Skeleton className="h-3.5 w-3/5" />
+        <Skeleton className="h-2.5 w-2/5" />
+      </div>
+    </div>
+  )
+}
 
 export default function Loading() {
   return (
@@ -15,30 +37,51 @@ export default function Loading() {
               <Skeleton className="h-9 w-9 rounded-lg" />
               <Skeleton className="h-5 w-14" />
             </div>
-            {/* Competition selector */}
-            <div className="space-y-4">
+            {/* ChallengeTab 2x2 grid */}
+            <div className="grid grid-cols-2 gap-3">
+              {/* Competition selection */}
               <div>
-                <Skeleton className="mb-1 h-3.5 w-20" />
-                <Skeleton className="h-10 w-full rounded-lg" />
+                <Skeleton className="mb-2 h-3.5 w-20" />
+                <div className="grid gap-2">
+                  {selectionCardKeys.map((id) => (
+                    <SelectionCardSkeleton key={id} />
+                  ))}
+                </div>
               </div>
-              {/* Judge selector */}
+
+              {/* Course selection */}
               <div>
-                <Skeleton className="mb-1 h-3.5 w-24" />
-                <Skeleton className="h-10 w-full rounded-lg" />
+                <Skeleton className="mb-2 h-3.5 w-24" />
+                <div className="grid gap-2">
+                  {selectionCardKeys.map((id) => (
+                    <SelectionCardSkeleton key={`c-${id}`} />
+                  ))}
+                </div>
               </div>
-              {/* Course cards grid */}
-              <div className="grid gap-3 sm:grid-cols-2">
-                {courseCards.map((id, i) => (
-                  <div
-                    key={id}
-                    className="flex min-h-[72px] items-center gap-3 rounded-xl border border-base-300 px-4 py-3"
-                    style={{ animationDelay: `${i * 60}ms` }}
-                  >
-                    <Skeleton className="h-10 w-10 shrink-0 rounded-lg" />
-                    <Skeleton className="h-4 w-3/5" />
-                  </div>
-                ))}
+
+              {/* Judge selection */}
+              <div>
+                <Skeleton className="mb-2 h-3.5 w-24" />
+                <Skeleton className="h-8 w-full rounded-lg" />
+                <div className="mt-2 grid gap-2">
+                  {selectionCardKeys.map((id) => (
+                    <SelectionCardSkeleton key={`j-${id}`} />
+                  ))}
+                </div>
               </div>
+
+              {/* Player selection */}
+              <div>
+                <Skeleton className="mb-2 h-3.5 w-20" />
+                <div className="grid gap-1.5">
+                  {playerCardKeys.map((id) => (
+                    <PlayerCardSkeleton key={id} />
+                  ))}
+                </div>
+              </div>
+
+              {/* Start scoring button */}
+              <Skeleton className="col-span-2 h-12 w-full rounded-xl" />
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary by Sourcery

チャレンジ選択画面、チャレンジプレイヤー画面、サインインフローにおけるスケルトンローディング体験を洗練し、最終的なUIとの視覚的な整合性を高めます。

新機能:
- チャレンジプレイヤービュー専用のスケルトンローディングUIを追加し、ステータスバー、ミッション情報、フィールド、アクションバー用のプレースホルダーを含めました。

改善点:
- メインチャレンジ選択画面のローディングUIを刷新し、コンペティション、コース、ジャッジ、プレイヤーおよび開始アクションに対して、2x2グリッドのカード型スケルトンを使用するようにしました。
- サインインルートの汎用的なページレベルのローディングコンポーネントを、実際のレイアウトを反映したサインインフォーム用スケルトンダイアログに置き換えました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine skeleton loading experiences across the challenge selection, challenge player, and sign-in flows for better visual alignment with their final UIs.

New Features:
- Add a dedicated skeleton loading UI for the challenge player view, including status bar, mission info, field, and action bar placeholders.

Enhancements:
- Revamp the main challenge selection loading screen to use card-based skeletons in a 2x2 grid for competitions, courses, judges, players, and the start action.
- Replace the generic page-level loading component on the sign-in route with a tailored sign-in form skeleton dialog that mirrors the actual layout.

</details>