### PR TITLE
feat: add admin page

### DIFF
--- a/@robopo/web/app/admin/loading.tsx
+++ b/@robopo/web/app/admin/loading.tsx
@@ -1,0 +1,10 @@
+import { PageLoadingShell } from "@/components/common/pageLoadingShell"
+
+export default function Loading() {
+  return (
+    <PageLoadingShell
+      title="管理者一覧"
+      description="管理者の登録・編集・削除を行います"
+    />
+  )
+}

--- a/@robopo/web/app/admin/page.tsx
+++ b/@robopo/web/app/admin/page.tsx
@@ -1,0 +1,24 @@
+import { AdminView } from "@/components/admin/view"
+import { getAdminList } from "@/server/db"
+
+export default async function Admin() {
+  const initialAdminList = await getAdminList()
+
+  return (
+    <div className="flex h-[calc(100dvh-3.5rem)] flex-col overflow-hidden px-4 py-6 sm:px-10 lg:px-16">
+      <div className="mb-4 flex shrink-0 items-center justify-between">
+        <div>
+          <h1 className="font-bold text-2xl text-base-content tracking-tight">
+            管理者一覧
+          </h1>
+          <p className="mt-1 text-base-content/60 text-sm">
+            管理者の登録・編集・削除を行います
+          </p>
+        </div>
+      </div>
+      <div className="flex min-h-0 flex-1 flex-col rounded-2xl border border-base-300 bg-base-100 shadow-sm">
+        <AdminView initialAdminList={initialAdminList} />
+      </div>
+    </div>
+  )
+}

--- a/@robopo/web/app/api/admin/[id]/route.ts
+++ b/@robopo/web/app/api/admin/[id]/route.ts
@@ -1,0 +1,75 @@
+import { hashPassword } from "better-auth/crypto"
+import { and, eq } from "drizzle-orm"
+import { db } from "@/lib/db/db"
+import { account, user } from "@/lib/db/schema"
+import { getAdminList } from "@/server/db"
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+  const body = await req.json()
+
+  if (!id) {
+    return Response.json(
+      { success: false, message: "Admin ID is required." },
+      { status: 400 },
+    )
+  }
+
+  try {
+    // Update username if provided
+    if (body.username) {
+      const trimmed = body.username.trim().toLowerCase()
+      if (!/^[a-z0-9_]+$/.test(trimmed)) {
+        return Response.json(
+          {
+            success: false,
+            message:
+              "Username can only contain lowercase letters, numbers, and underscores.",
+          },
+          { status: 400 },
+        )
+      }
+      await db
+        .update(user)
+        .set({
+          username: trimmed,
+          displayUsername: trimmed,
+          name: trimmed,
+        })
+        .where(eq(user.id, id))
+    }
+
+    // Update password if provided
+    if (body.password) {
+      if (body.password.length < 8) {
+        return Response.json(
+          {
+            success: false,
+            message: "Password must be at least 8 characters.",
+          },
+          { status: 400 },
+        )
+      }
+      const hashedPassword = await hashPassword(body.password)
+      await db
+        .update(account)
+        .set({ password: hashedPassword })
+        .where(
+          and(eq(account.userId, id), eq(account.providerId, "credential")),
+        )
+    }
+
+    const newList = await getAdminList()
+    return Response.json({ success: true, newList }, { status: 200 })
+  } catch (error) {
+    console.error("Error updating admin:", error)
+    const message =
+      error instanceof Error && error.message.includes("unique")
+        ? "This username is already in use."
+        : "An error occurred while updating."
+    return Response.json({ success: false, message }, { status: 500 })
+  }
+}

--- a/@robopo/web/app/api/admin/route.ts
+++ b/@robopo/web/app/api/admin/route.ts
@@ -1,0 +1,103 @@
+import { inArray } from "drizzle-orm"
+import { headers } from "next/headers"
+import { db } from "@/lib/db/db"
+import { user } from "@/lib/db/schema"
+import { getAdminList } from "@/server/db"
+
+export async function POST(req: Request) {
+  const { auth } = await import("@/lib/auth/auth")
+  const { username, password } = await req.json()
+
+  if (!username?.trim()) {
+    return Response.json(
+      { success: false, message: "Username is required." },
+      { status: 400 },
+    )
+  }
+
+  if (!/^[a-z0-9_]+$/.test(username.trim().toLowerCase())) {
+    return Response.json(
+      {
+        success: false,
+        message:
+          "Username can only contain lowercase letters, numbers, and underscores.",
+      },
+      { status: 400 },
+    )
+  }
+
+  if (!password || password.length < 8) {
+    return Response.json(
+      { success: false, message: "Password must be at least 8 characters." },
+      { status: 400 },
+    )
+  }
+
+  try {
+    const signUpRes = await auth.api.signUpEmail({
+      body: {
+        email: `${username.trim().toLowerCase()}@robopo.local`,
+        password,
+        name: username.trim().toLowerCase(),
+        username: username.trim().toLowerCase(),
+      },
+    })
+
+    if (!signUpRes?.user?.id) {
+      return Response.json(
+        { success: false, message: "Failed to create user account." },
+        { status: 500 },
+      )
+    }
+
+    const newList = await getAdminList()
+    return Response.json({ success: true, newList }, { status: 200 })
+  } catch (error) {
+    console.error("Error creating admin:", error)
+    const message =
+      error instanceof Error && error.message.includes("unique")
+        ? "This username is already in use."
+        : "An error occurred while creating the admin."
+    return Response.json({ success: false, message }, { status: 500 })
+  }
+}
+
+export async function DELETE(req: Request) {
+  const { auth } = await import("@/lib/auth/auth")
+  const { id } = await req.json()
+
+  if (!id || !Array.isArray(id) || id.length === 0) {
+    return Response.json(
+      { success: false, message: "No items specified for deletion." },
+      { status: 400 },
+    )
+  }
+
+  // Prevent self-deletion
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  })
+
+  if (session?.user && id.includes(session.user.id)) {
+    return Response.json(
+      {
+        success: false,
+        message:
+          "You cannot delete your own account. Please ask another admin to remove it.",
+      },
+      { status: 400 },
+    )
+  }
+
+  try {
+    await db.delete(user).where(inArray(user.id, id))
+    const newList = await getAdminList()
+    return Response.json({ success: true, newList }, { status: 200 })
+  } catch (error) {
+    console.error("Error deleting admin:", error)
+    return Response.json(
+      { success: false, message: "An error occurred while deleting." },
+      { status: 500 },
+    )
+  }
+}

--- a/@robopo/web/app/api/judge/[id]/route.ts
+++ b/@robopo/web/app/api/judge/[id]/route.ts
@@ -3,7 +3,7 @@ import { and, eq } from "drizzle-orm"
 import { sanitizeCompetitionIds } from "@/app/api/validate"
 import { db } from "@/lib/db/db"
 import { getJudgeWithCompetition, groupByJudge } from "@/lib/db/queries/queries"
-import { account, competitionJudge, judge } from "@/lib/db/schema"
+import { account, competitionJudge, judge, user } from "@/lib/db/schema"
 
 export async function PATCH(
   req: Request,
@@ -15,7 +15,18 @@ export async function PATCH(
     return Response.json({ error: "Invalid ID" }, { status: 400 })
   }
 
-  const { note, competitionIds, password } = await req.json()
+  const { note, competitionIds, password, username } = await req.json()
+
+  // Validate username if provided
+  if (username && !/^[a-z0-9_]+$/.test(username.trim().toLowerCase())) {
+    return Response.json(
+      {
+        success: false,
+        message: "ユーザー名は英小文字・数字・アンダースコアのみ使用できます。",
+      },
+      { status: 400 },
+    )
+  }
 
   // Validate password up front before any updates
   if (password && password.length > 0 && password.length < 8) {
@@ -35,27 +46,36 @@ export async function PATCH(
       .set({ note: note || null })
       .where(eq(judge.id, judgeId))
 
-    // Update password if provided
-    if (password && password.length >= 8) {
-      const judgeRecord = await db
-        .select({ userId: judge.userId })
-        .from(judge)
-        .where(eq(judge.id, judgeId))
-        .limit(1)
+    // Get linked user ID for username/password updates
+    const judgeRecord = await db
+      .select({ userId: judge.userId })
+      .from(judge)
+      .where(eq(judge.id, judgeId))
+      .limit(1)
+    const userId = judgeRecord[0]?.userId
 
-      const userId = judgeRecord[0]?.userId
-      if (userId) {
-        const hashed = await hashPassword(password)
-        await db
-          .update(account)
-          .set({ password: hashed })
-          .where(
-            and(
-              eq(account.userId, userId),
-              eq(account.providerId, "credential"),
-            ),
-          )
-      }
+    // Update username if provided
+    if (username && userId) {
+      const trimmed = username.trim().toLowerCase()
+      await db
+        .update(user)
+        .set({
+          username: trimmed,
+          displayUsername: trimmed,
+          name: trimmed,
+        })
+        .where(eq(user.id, userId))
+    }
+
+    // Update password if provided
+    if (password && password.length >= 8 && userId) {
+      const hashed = await hashPassword(password)
+      await db
+        .update(account)
+        .set({ password: hashed })
+        .where(
+          and(eq(account.userId, userId), eq(account.providerId, "credential")),
+        )
     }
 
     // Update competition links if provided

--- a/@robopo/web/app/competition/tabs.tsx
+++ b/@robopo/web/app/competition/tabs.tsx
@@ -130,7 +130,7 @@ export function CompetitionFormModal({
             <input
               id="comp-name"
               type="text"
-              className="input input-bordered w-full"
+              className="input input-bordered w-full rounded-xl"
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="大会名"
@@ -143,7 +143,7 @@ export function CompetitionFormModal({
             </label>
             <textarea
               id="comp-desc"
-              className="textarea textarea-bordered w-full"
+              className="textarea textarea-bordered w-full rounded-xl"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               placeholder="大会の説明（任意）"
@@ -158,7 +158,7 @@ export function CompetitionFormModal({
               <input
                 id="comp-start"
                 type="date"
-                className="input input-bordered w-full"
+                className="input input-bordered w-full rounded-xl"
                 value={startDate}
                 onChange={(e) => setStartDate(e.target.value)}
               />
@@ -170,7 +170,7 @@ export function CompetitionFormModal({
               <input
                 id="comp-end"
                 type="date"
-                className="input input-bordered w-full"
+                className="input input-bordered w-full rounded-xl"
                 value={endDate}
                 onChange={(e) => setEndDate(e.target.value)}
               />

--- a/@robopo/web/components/admin/modals.tsx
+++ b/@robopo/web/components/admin/modals.tsx
@@ -1,0 +1,342 @@
+"use client"
+
+import {
+  CircleCheck,
+  CircleX,
+  Eye,
+  EyeOff,
+  Plus,
+  TriangleAlert,
+  X,
+} from "lucide-react"
+import { useState } from "react"
+import type { SelectAdmin } from "@/lib/db/schema"
+
+type AdminFormModalProps = {
+  mode: "create" | "edit"
+  admin?: SelectAdmin | null
+  onClose: () => void
+  onSuccess: (newList: SelectAdmin[]) => void
+}
+
+export function AdminFormModal({
+  mode,
+  admin,
+  onClose,
+  onSuccess,
+}: AdminFormModalProps) {
+  const [username, setUsername] = useState(admin?.username ?? "")
+  const [password, setPassword] = useState("")
+  const [showPassword, setShowPassword] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+
+    if (mode === "create") {
+      if (!username.trim()) {
+        setError("ユーザー名は必須です。")
+        return
+      }
+      if (!/^[a-z0-9_]+$/.test(username.trim())) {
+        setError("ユーザー名は英小文字・数字・アンダースコアのみ使用できます。")
+        return
+      }
+      if (!password || password.length < 8) {
+        setError("パスワードは8文字以上で入力してください。")
+        return
+      }
+    }
+
+    if (mode === "edit") {
+      if (username.trim() && !/^[a-z0-9_]+$/.test(username.trim())) {
+        setError("ユーザー名は英小文字・数字・アンダースコアのみ使用できます。")
+        return
+      }
+      if (password && password.length < 8) {
+        setError("パスワードは8文字以上で入力してください。")
+        return
+      }
+    }
+
+    setLoading(true)
+    setError(null)
+
+    try {
+      const body: Record<string, unknown> = {}
+
+      if (mode === "create") {
+        body.username = username.trim()
+        body.password = password
+      } else {
+        if (username.trim() && username.trim() !== admin?.username) {
+          body.username = username.trim()
+        }
+        if (password) {
+          body.password = password
+        }
+      }
+
+      const url = mode === "create" ? "/api/admin" : `/api/admin/${admin?.id}`
+      const method = mode === "create" ? "POST" : "PATCH"
+
+      const response = await fetch(url, {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      })
+
+      const result = await response.json()
+
+      if (response.ok && result.success) {
+        if (result.newList) {
+          onSuccess(result.newList)
+        } else {
+          window.location.href = "/admin"
+        }
+      } else {
+        setError(result.message || "エラーが発生しました。")
+      }
+    } catch {
+      setError("通信エラーが発生しました。")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <dialog className="modal modal-open">
+      <div className="modal-box max-w-md">
+        <div className="flex items-center justify-between">
+          <h3 className="font-bold text-lg">
+            {mode === "create" ? (
+              <span className="flex items-center gap-2">
+                <Plus className="size-5" />
+                管理者を追加
+              </span>
+            ) : (
+              "管理者を編集"
+            )}
+          </h3>
+          <button
+            type="button"
+            className="btn btn-circle btn-ghost btn-sm"
+            onClick={onClose}
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="mt-4 flex flex-col gap-4">
+          <label className="form-control w-full">
+            <div className="label">
+              <span className="label-text font-medium">ユーザー名</span>
+            </div>
+            <input
+              type="text"
+              className="input input-bordered w-full rounded-xl lowercase"
+              placeholder="英小文字・数字（例: admin1）"
+              pattern="[a-z0-9_]+"
+              value={username}
+              onChange={(e) => setUsername(e.target.value.toLowerCase())}
+              disabled={loading}
+              autoComplete="off"
+            />
+            <p className="mt-1 text-base-content/40 text-xs">
+              英小文字・数字・アンダースコアのみ使用可能
+            </p>
+          </label>
+
+          <label className="form-control w-full">
+            <div className="label">
+              <span className="label-text font-medium">
+                パスワード
+                {mode === "edit" && (
+                  <span className="ml-1 text-base-content/50 text-xs">
+                    (変更する場合のみ入力)
+                  </span>
+                )}
+              </span>
+            </div>
+            <div className="relative">
+              <input
+                type={showPassword ? "text" : "password"}
+                className="input input-bordered w-full rounded-xl pr-12"
+                placeholder="8文字以上"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                disabled={loading}
+                autoComplete="new-password"
+              />
+              <button
+                type="button"
+                className="btn btn-ghost btn-sm absolute top-1/2 right-2 -translate-y-1/2"
+                onClick={() => setShowPassword(!showPassword)}
+                tabIndex={-1}
+              >
+                {showPassword ? (
+                  <EyeOff className="size-4" />
+                ) : (
+                  <Eye className="size-4" />
+                )}
+              </button>
+            </div>
+          </label>
+
+          {error && (
+            <div className="flex items-center gap-2 rounded-lg bg-error/10 px-4 py-2.5 text-error text-sm">
+              <CircleX className="size-5 shrink-0" />
+              {error}
+            </div>
+          )}
+
+          <div className="mt-2 flex justify-end gap-2">
+            <button
+              type="button"
+              className="btn btn-ghost rounded-xl"
+              onClick={onClose}
+              disabled={loading}
+            >
+              キャンセル
+            </button>
+            <button
+              type="submit"
+              className="btn btn-primary rounded-xl"
+              disabled={loading}
+            >
+              {loading ? (
+                <span className="loading loading-spinner loading-sm" />
+              ) : mode === "create" ? (
+                "作成"
+              ) : (
+                "保存"
+              )}
+            </button>
+          </div>
+        </form>
+      </div>
+      <form method="dialog" className="modal-backdrop">
+        <button type="button" onClick={onClose}>
+          close
+        </button>
+      </form>
+    </dialog>
+  )
+}
+
+type AdminDeleteModalProps = {
+  admins: SelectAdmin[]
+  onClose: () => void
+  onSuccess: (newList: SelectAdmin[]) => void
+}
+
+export function AdminDeleteModal({
+  admins,
+  onClose,
+  onSuccess,
+}: AdminDeleteModalProps) {
+  const [loading, setLoading] = useState(false)
+  const [successMessage, setSuccessMessage] = useState<string | null>(null)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  async function handleDelete() {
+    setLoading(true)
+    setErrorMessage(null)
+
+    try {
+      const response = await fetch("/api/admin", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id: admins.map((a) => a.id) }),
+      })
+
+      const result = await response.json()
+
+      if (response.ok && result.success) {
+        setSuccessMessage("管理者を削除しました。")
+        if (result.newList) {
+          setTimeout(() => onSuccess(result.newList), 1000)
+        }
+      } else {
+        setErrorMessage(result.message || "削除に失敗しました。")
+      }
+    } catch {
+      setErrorMessage("通信エラーが発生しました。")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <dialog className="modal modal-open">
+      <div className="modal-box max-w-sm">
+        <div className="flex flex-col items-center px-2 py-2">
+          {successMessage ? (
+            <div className="flex flex-col items-center gap-3">
+              <CircleCheck className="size-12 text-success" />
+              <p className="text-center font-medium">{successMessage}</p>
+            </div>
+          ) : (
+            <div className="flex flex-col items-center gap-3">
+              <TriangleAlert className="size-12 text-warning" />
+              <p className="text-center font-medium">
+                以下の管理者を削除しますか？
+              </p>
+              <div className="flex flex-col gap-1">
+                {admins.map((a) => (
+                  <span key={a.id} className="badge badge-outline badge-sm">
+                    {a.username}
+                  </span>
+                ))}
+              </div>
+              <p className="text-center text-base-content/60 text-sm">
+                この操作は元に戻せません。関連するセッションやアカウントデータもすべて削除されます。
+              </p>
+            </div>
+          )}
+
+          {errorMessage && (
+            <div className="mt-4 flex w-full items-center gap-2 rounded-lg bg-error/10 px-4 py-2.5 text-error text-sm">
+              <CircleX className="size-5 shrink-0" />
+              {errorMessage}
+            </div>
+          )}
+
+          <div className="mt-6 flex w-full flex-col gap-2">
+            {!successMessage && (
+              <button
+                type="button"
+                className="btn btn-error w-full rounded-xl shadow-error/20 shadow-lg transition-all duration-200 hover:shadow-error/30 hover:shadow-xl"
+                onClick={handleDelete}
+                disabled={loading}
+              >
+                {loading ? (
+                  <>
+                    削除中
+                    <span className="loading loading-spinner loading-sm" />
+                  </>
+                ) : (
+                  "削除する"
+                )}
+              </button>
+            )}
+            <button
+              type="button"
+              className="btn btn-ghost w-full rounded-xl"
+              onClick={onClose}
+              disabled={loading}
+            >
+              {successMessage ? "閉じる" : "キャンセル"}
+            </button>
+          </div>
+        </div>
+      </div>
+      <form method="dialog" className="modal-backdrop">
+        <button type="button" onClick={onClose}>
+          close
+        </button>
+      </form>
+    </dialog>
+  )
+}

--- a/@robopo/web/components/admin/view.tsx
+++ b/@robopo/web/components/admin/view.tsx
@@ -1,0 +1,315 @@
+"use client"
+
+import {
+  ArrowDown01,
+  ArrowDownAZ,
+  ArrowUp01,
+  ArrowUpAZ,
+  Plus,
+  Search,
+  SquarePen,
+  Trash2,
+} from "lucide-react"
+import { useState } from "react"
+import { AdminDeleteModal, AdminFormModal } from "@/components/admin/modals"
+import type { SelectAdmin } from "@/lib/db/schema"
+
+type SortKey = "id" | "username" | "createdAt"
+
+export function AdminView({
+  initialAdminList,
+}: {
+  initialAdminList: SelectAdmin[]
+}) {
+  const [adminList, setAdminList] = useState(initialAdminList)
+  const [selectedIds, setSelectedIds] = useState<string[]>([])
+  const [searchQuery, setSearchQuery] = useState("")
+  const [sortKey, setSortKey] = useState<SortKey>("createdAt")
+  const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc")
+  const [successMessage, setSuccessMessage] = useState<string | null>(null)
+
+  const [createModalOpen, setCreateModalOpen] = useState(false)
+  const [editModalOpen, setEditModalOpen] = useState(false)
+  const [deleteModalOpen, setDeleteModalOpen] = useState(false)
+
+  const selectedAdmin =
+    selectedIds.length === 1
+      ? (adminList.find((a) => a.id === selectedIds[0]) ?? null)
+      : null
+
+  const selectedAdmins = adminList.filter((a) => selectedIds.includes(a.id))
+
+  // Filter by search
+  const filtered = adminList.filter((a) => {
+    if (!searchQuery) {
+      return true
+    }
+    const q = searchQuery.toLowerCase()
+    return (a.username ?? "").toLowerCase().includes(q)
+  })
+
+  // Sort
+  const sorted = [...filtered].sort((a, b) => {
+    let cmp = 0
+    switch (sortKey) {
+      case "id":
+        cmp = a.id.localeCompare(b.id)
+        break
+      case "username":
+        cmp = (a.username ?? "").localeCompare(b.username ?? "")
+        break
+      case "createdAt": {
+        const aTime = a.createdAt ? new Date(a.createdAt).getTime() : 0
+        const bTime = b.createdAt ? new Date(b.createdAt).getTime() : 0
+        cmp = aTime - bTime
+        break
+      }
+    }
+    return sortOrder === "asc" ? cmp : -cmp
+  })
+
+  function handleSort(key: SortKey) {
+    if (sortKey === key) {
+      setSortOrder((o) => (o === "asc" ? "desc" : "asc"))
+    } else {
+      setSortKey(key)
+      setSortOrder("desc")
+    }
+  }
+
+  function handleSelect(id: string) {
+    setSelectedIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
+    )
+  }
+
+  function handleSelectAll() {
+    const allIds = sorted.map((a) => a.id)
+    setSelectedIds((prev) => {
+      const allSelected = allIds.every((id) => prev.includes(id))
+      return allSelected ? [] : allIds
+    })
+  }
+
+  function showSuccess(msg: string) {
+    setSuccessMessage(msg)
+    setTimeout(() => setSuccessMessage(null), 3000)
+  }
+
+  const SortIcon = ({ k }: { k: SortKey }) => {
+    if (sortKey !== k) {
+      return null
+    }
+    if (k === "username") {
+      return sortOrder === "asc" ? (
+        <ArrowUpAZ className="size-3.5" />
+      ) : (
+        <ArrowDownAZ className="size-3.5" />
+      )
+    }
+    return sortOrder === "asc" ? (
+      <ArrowUp01 className="size-3.5" />
+    ) : (
+      <ArrowDown01 className="size-3.5" />
+    )
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      {/* Action bar */}
+      <div className="shrink-0 px-4 pt-4 pb-2">
+        {/* Action buttons */}
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            className="btn btn-primary btn-sm rounded-xl shadow-lg shadow-primary/20 transition-all duration-200 hover:shadow-primary/30 hover:shadow-xl"
+            onClick={() => setCreateModalOpen(true)}
+          >
+            <Plus className="size-4" />
+            新規作成
+          </button>
+          <button
+            type="button"
+            className="btn btn-sm rounded-xl transition-all duration-200"
+            disabled={selectedIds.length !== 1}
+            onClick={() => setEditModalOpen(true)}
+          >
+            <SquarePen className="size-4" />
+            編集
+          </button>
+          <button
+            type="button"
+            className={`btn btn-sm rounded-xl transition-all duration-200 ${
+              selectedIds.length > 0 ? "btn-outline btn-error" : ""
+            }`}
+            disabled={selectedIds.length === 0}
+            onClick={() => setDeleteModalOpen(true)}
+          >
+            <Trash2 className="size-4" />
+            削除
+          </button>
+        </div>
+
+        {/* Success message */}
+        {successMessage && (
+          <div className="mt-2 rounded-lg bg-success/10 px-4 py-2 text-sm text-success">
+            {successMessage}
+          </div>
+        )}
+
+        {/* Search */}
+        <label className="input mt-3 flex items-center gap-2 rounded-xl border-base-300/50 bg-base-200/50 transition-all duration-200 focus-within:border-primary/50 focus-within:ring-2 focus-within:ring-primary/20">
+          <Search className="size-4 text-base-content/40" />
+          <input
+            type="text"
+            className="grow bg-transparent text-sm"
+            placeholder="ユーザー名で検索"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+          />
+        </label>
+
+        {/* Sort */}
+        <div className="mt-2 flex items-center gap-2 text-base-content/60 text-xs">
+          <button
+            type="button"
+            className={`btn btn-ghost btn-xs gap-1 ${sortKey === "username" ? "text-primary" : ""}`}
+            onClick={() => handleSort("username")}
+          >
+            ユーザー名
+            <SortIcon k="username" />
+          </button>
+          <button
+            type="button"
+            className={`btn btn-ghost btn-xs gap-1 ${sortKey === "createdAt" ? "text-primary" : ""}`}
+            onClick={() => handleSort("createdAt")}
+          >
+            作成日時
+            <SortIcon k="createdAt" />
+          </button>
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="m-3 min-h-0 flex-1 overflow-x-auto overflow-y-auto rounded-xl border border-base-300/50">
+        <table className="table-pin-rows table-zebra table">
+          <thead>
+            <tr className="border-base-300/50 border-b bg-base-200/60">
+              <th className="w-12">
+                <label>
+                  <input
+                    type="checkbox"
+                    className="checkbox checkbox-primary size-4"
+                    checked={
+                      sorted.length > 0 &&
+                      sorted.every((a) => selectedIds.includes(a.id))
+                    }
+                    onChange={() => handleSelectAll()}
+                  />
+                </label>
+              </th>
+              <th className="py-3 font-semibold text-base-content/50 text-xs uppercase tracking-wider">
+                ユーザー名
+              </th>
+              <th className="py-3 font-semibold text-base-content/50 text-xs uppercase tracking-wider">
+                最終ログイン
+              </th>
+              <th className="py-3 font-semibold text-base-content/50 text-xs uppercase tracking-wider">
+                作成日時
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.length > 0 ? (
+              sorted.map((admin) => (
+                <tr
+                  key={admin.id}
+                  className="cursor-pointer transition-colors duration-150 hover:bg-primary/5"
+                  onClick={() => handleSelect(admin.id)}
+                >
+                  <th className="w-12">
+                    <label>
+                      <input
+                        type="checkbox"
+                        className="checkbox checkbox-primary size-4"
+                        checked={selectedIds.includes(admin.id)}
+                        onChange={() => handleSelect(admin.id)}
+                      />
+                    </label>
+                  </th>
+                  <td className="py-3 font-medium">{admin.username}</td>
+                  <td
+                    className="whitespace-nowrap py-3 text-base-content/60 text-sm"
+                    suppressHydrationWarning
+                  >
+                    {admin.lastLoginAt ? (
+                      new Date(admin.lastLoginAt).toLocaleString("ja-JP")
+                    ) : (
+                      <span className="text-base-content/30">-</span>
+                    )}
+                  </td>
+                  <td
+                    className="py-3 text-base-content/60 text-sm"
+                    suppressHydrationWarning
+                  >
+                    {admin.createdAt
+                      ? new Date(admin.createdAt).toLocaleString("ja-JP")
+                      : "-"}
+                  </td>
+                </tr>
+              ))
+            ) : (
+              <tr>
+                <td
+                  colSpan={4}
+                  className="py-12 text-center text-base-content/40"
+                >
+                  管理者が登録されていません。
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Modals */}
+      {createModalOpen && (
+        <AdminFormModal
+          mode="create"
+          onClose={() => setCreateModalOpen(false)}
+          onSuccess={(newList) => {
+            setAdminList(newList)
+            setCreateModalOpen(false)
+            setSelectedIds([])
+            showSuccess("管理者を作成しました。")
+          }}
+        />
+      )}
+      {editModalOpen && selectedAdmin && (
+        <AdminFormModal
+          mode="edit"
+          admin={selectedAdmin}
+          onClose={() => setEditModalOpen(false)}
+          onSuccess={(newList) => {
+            setAdminList(newList)
+            setEditModalOpen(false)
+            setSelectedIds([])
+            showSuccess("管理者を更新しました。")
+          }}
+        />
+      )}
+      {deleteModalOpen && selectedAdmins.length > 0 && (
+        <AdminDeleteModal
+          admins={selectedAdmins}
+          onClose={() => setDeleteModalOpen(false)}
+          onSuccess={(newList) => {
+            setAdminList(newList)
+            setDeleteModalOpen(false)
+            setSelectedIds([])
+            showSuccess("管理者を削除しました。")
+          }}
+        />
+      )}
+    </div>
+  )
+}

--- a/@robopo/web/components/common/commonList.tsx
+++ b/@robopo/web/components/common/commonList.tsx
@@ -307,106 +307,99 @@ export function CommonSelectionList({
   }
 
   return (
-    <>
-      {type !== "competition" && type !== "course" && (
-        <h2 className="text-center font-semibold text-xl">
-          {typeLabel(type)}一覧
-        </h2>
-      )}
-      <div className="flex min-h-0 w-full flex-1 flex-col">
-        <div className="m-3 min-h-0 flex-1 overflow-x-auto overflow-y-auto rounded-xl border border-base-300/50">
-          <table className="table-pin-rows table-zebra table">
-            <thead>
-              <tr className="border-base-300/50 border-b bg-base-200/60">
-                <th className="w-12">
-                  {selectionMode === "checkbox" && onSelectAll ? (
-                    <label>
-                      <input
-                        type="checkbox"
-                        className="checkbox checkbox-primary size-4"
-                        checked={
-                          commonDataList.length > 0 &&
-                          Array.isArray(selectedId) &&
-                          commonDataList.every((item) =>
-                            selectedId.includes(item.id),
-                          )
-                        }
-                        onChange={() => onSelectAll()}
-                      />
-                    </label>
-                  ) : (
+    <div className="flex min-h-0 w-full flex-1 flex-col">
+      <div className="m-3 min-h-0 flex-1 overflow-x-auto overflow-y-auto rounded-xl border border-base-300/50">
+        <table className="table-pin-rows table-zebra table">
+          <thead>
+            <tr className="border-base-300/50 border-b bg-base-200/60">
+              <th className="w-12">
+                {selectionMode === "checkbox" && onSelectAll ? (
+                  <label>
+                    <input
+                      type="checkbox"
+                      className="checkbox checkbox-primary size-4"
+                      checked={
+                        commonDataList.length > 0 &&
+                        Array.isArray(selectedId) &&
+                        commonDataList.every((item) =>
+                          selectedId.includes(item.id),
+                        )
+                      }
+                      onChange={() => onSelectAll()}
+                    />
+                  </label>
+                ) : (
+                  <label>
+                    <input
+                      type={selectionMode}
+                      disabled={true}
+                      className="opacity-0"
+                    />
+                  </label>
+                )}
+              </th>
+              {itemNames(type).map((name) => (
+                <th
+                  key={name}
+                  className="py-3 font-semibold text-base-content/50 text-xs uppercase tracking-wider"
+                  hidden={
+                    selectionMode === "radio" &&
+                    type === "player" &&
+                    name === "参加大会"
+                  }
+                >
+                  {name}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {commonDataList.length > 0 ? (
+              commonDataList.map((common) => (
+                <tr
+                  key={common.id}
+                  className="cursor-pointer transition-colors duration-150 hover:bg-primary/5"
+                  onClick={() => onSelect(common.id)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault()
+                      onSelect(common.id)
+                    }
+                  }}
+                >
+                  <th className="w-12">
                     <label>
                       <input
                         type={selectionMode}
-                        disabled={true}
-                        className="opacity-0"
+                        name="selectedCommon"
+                        value={common.id}
+                        checked={isChecked(common.id)}
+                        onChange={() => onSelect(common.id)}
+                        className={`size-4 ${selectionMode === "checkbox" ? "checkbox checkbox-primary" : ""}`}
                       />
                     </label>
-                  )}
-                </th>
-                {itemNames(type).map((name) => (
-                  <th
-                    key={name}
-                    className="py-3 font-semibold text-base-content/50 text-xs uppercase tracking-wider"
-                    hidden={
-                      selectionMode === "radio" &&
-                      type === "player" &&
-                      name === "参加大会"
-                    }
-                  >
-                    {name}
                   </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {commonDataList.length > 0 ? (
-                commonDataList.map((common) => (
-                  <tr
-                    key={common.id}
-                    className="cursor-pointer transition-colors duration-150 hover:bg-primary/5"
-                    onClick={() => onSelect(common.id)}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter" || e.key === " ") {
-                        e.preventDefault()
-                        onSelect(common.id)
-                      }
-                    }}
-                  >
-                    <th className="w-12">
-                      <label>
-                        <input
-                          type={selectionMode}
-                          name="selectedCommon"
-                          value={common.id}
-                          checked={isChecked(common.id)}
-                          onChange={() => onSelect(common.id)}
-                          className={`size-4 ${selectionMode === "checkbox" ? "checkbox checkbox-primary" : ""}`}
-                        />
-                      </label>
-                    </th>
-                    <TableComponent
-                      type={type}
-                      common={common}
-                      onCourseCompetitionClick={onCourseCompetitionClick}
-                    />
-                  </tr>
-                ))
-              ) : (
-                <tr>
-                  <td
-                    colSpan={itemNames(type).length + 1}
-                    className="py-12 text-center text-base-content/40"
-                  >
-                    {emptyLabel(type, selectionMode)}が登録されていません。
-                  </td>
+                  <TableComponent
+                    type={type}
+                    common={common}
+                    onCourseCompetitionClick={onCourseCompetitionClick}
+                  />
                 </tr>
-              )}
-            </tbody>
-          </table>
-        </div>
+              ))
+            ) : (
+              <tr>
+                <td
+                  colSpan={itemNames(type).length + 1}
+                  className="py-12 text-center text-base-content/40"
+                >
+                  {emptyLabel(type, selectionMode)}が登録されていません。
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
       </div>
-    </>
+    </div>
   )
 }
 

--- a/@robopo/web/components/course/modals.tsx
+++ b/@robopo/web/components/course/modals.tsx
@@ -156,7 +156,7 @@ export function CourseFormModal({
             <input
               id="course-name"
               type="text"
-              className="input input-bordered w-full"
+              className="input input-bordered w-full rounded-xl"
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="コース名"
@@ -169,7 +169,7 @@ export function CourseFormModal({
             </label>
             <textarea
               id="course-description"
-              className="textarea textarea-bordered w-full"
+              className="textarea textarea-bordered w-full rounded-xl"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               placeholder="コースの説明（任意）"

--- a/@robopo/web/components/header/navigationDrawer.tsx
+++ b/@robopo/web/components/header/navigationDrawer.tsx
@@ -7,6 +7,7 @@ import { useEffect, useRef, useState } from "react"
 import { createPortal } from "react-dom"
 import type { NavItem } from "@/lib/navigation"
 import {
+  ADMIN_SETTINGS_LIST,
   COMPETITION_MANAGEMENT_LIST,
   NAVIGATION_GENERAL_LIST,
 } from "@/lib/navigation"
@@ -141,8 +142,14 @@ export function NavigationDrawer() {
     return pathname.startsWith(href)
   }
 
-  const allItems = [...NAVIGATION_GENERAL_LIST, ...COMPETITION_MANAGEMENT_LIST]
+  const allItems = [
+    ...NAVIGATION_GENERAL_LIST,
+    ...COMPETITION_MANAGEMENT_LIST,
+    ...ADMIN_SETTINGS_LIST,
+  ]
   const dividerIndex = NAVIGATION_GENERAL_LIST.length
+  const settingsDividerIndex =
+    NAVIGATION_GENERAL_LIST.length + COMPETITION_MANAGEMENT_LIST.length
 
   const drawerOverlay = (
     <div
@@ -210,6 +217,20 @@ export function NavigationDrawer() {
                     style={{ "--drawer-item-index": i } as React.CSSProperties}
                   >
                     大会管理
+                  </span>
+                </>
+              )}
+              {i === settingsDividerIndex && (
+                <>
+                  <div
+                    className={`drawer-divider my-2 border-base-300 border-t ${isOpen ? "drawer-divider-visible" : ""}`}
+                    style={{ "--drawer-item-index": i } as React.CSSProperties}
+                  />
+                  <span
+                    className={`drawer-item mb-1 block px-3 font-semibold text-base-content/40 text-xs uppercase tracking-wider ${isOpen ? "drawer-item-visible" : ""}`}
+                    style={{ "--drawer-item-index": i } as React.CSSProperties}
+                  >
+                    設定
                   </span>
                 </>
               )}

--- a/@robopo/web/components/home/dashboard.tsx
+++ b/@robopo/web/components/home/dashboard.tsx
@@ -1,8 +1,8 @@
 "use client"
 
-import { ClipboardCheck, Settings } from "lucide-react"
+import { ClipboardCheck, Settings, Shield } from "lucide-react"
 import type React from "react"
-import { ChallengeTab, ManageTab } from "@/components/home/tabs"
+import { ChallengeTab, ManageTab, SettingsTab } from "@/components/home/tabs"
 import type {
   SelectCompetition,
   SelectCompetitionCourse,
@@ -92,6 +92,13 @@ export function Dashboard({
             icon={<Settings className="h-5 w-5" />}
           >
             <ManageTab />
+          </DashboardCard>
+        </div>
+
+        {/* Settings card */}
+        <div className="md:col-span-2">
+          <DashboardCard title="設定" icon={<Shield className="h-5 w-5" />}>
+            <SettingsTab />
           </DashboardCard>
         </div>
       </div>

--- a/@robopo/web/components/home/tabs.tsx
+++ b/@robopo/web/components/home/tabs.tsx
@@ -18,7 +18,10 @@ import type {
   SelectJudgeWithUsername,
   SelectPlayer,
 } from "@/lib/db/schema"
-import { COMPETITION_MANAGEMENT_LIST } from "@/lib/navigation"
+import {
+  ADMIN_SETTINGS_LIST,
+  COMPETITION_MANAGEMENT_LIST,
+} from "@/lib/navigation"
 
 function SelectionCard({
   name,
@@ -368,6 +371,23 @@ export const ManageTab = (): React.JSX.Element => {
   return (
     <div className="grid gap-2">
       {COMPETITION_MANAGEMENT_LIST.map((btn) => (
+        <Link
+          key={btn.href}
+          href={btn.href}
+          className="btn btn-ghost justify-start gap-3 border border-base-300"
+        >
+          {btn.icon}
+          {btn.label}
+        </Link>
+      ))}
+    </div>
+  )
+}
+
+export const SettingsTab = (): React.JSX.Element => {
+  return (
+    <div className="grid gap-2">
+      {ADMIN_SETTINGS_LIST.map((btn) => (
         <Link
           key={btn.href}
           href={btn.href}

--- a/@robopo/web/components/judge/modals.tsx
+++ b/@robopo/web/components/judge/modals.tsx
@@ -32,7 +32,7 @@ export function JudgeFormModal({
   onClose,
   onSuccess,
 }: JudgeFormModalProps) {
-  const [username, setUsername] = useState("")
+  const [username, setUsername] = useState(judge?.username ?? "")
   const [password, setPassword] = useState("")
   const [showPassword, setShowPassword] = useState(false)
   const [note, setNote] = useState(judge?.note ?? "")
@@ -66,14 +66,15 @@ export function JudgeFormModal({
       }
     }
 
-    if (
-      mode === "edit" &&
-      password &&
-      password.length > 0 &&
-      password.length < 8
-    ) {
-      setError("パスワードは8文字以上で入力してください。")
-      return
+    if (mode === "edit") {
+      if (username.trim() && !/^[a-z0-9_]+$/.test(username.trim())) {
+        setError("ユーザー名は英小文字・数字・アンダースコアのみ使用できます。")
+        return
+      }
+      if (password && password.length > 0 && password.length < 8) {
+        setError("パスワードは8文字以上で入力してください。")
+        return
+      }
     }
 
     setLoading(true)
@@ -88,8 +89,13 @@ export function JudgeFormModal({
       if (mode === "create") {
         body.username = username.trim()
         body.password = password
-      } else if (password) {
-        body.password = password
+      } else {
+        if (username.trim() && username.trim() !== judge?.username) {
+          body.username = username.trim()
+        }
+        if (password) {
+          body.password = password
+        }
       }
 
       const url = mode === "create" ? "/api/judge" : `/api/judge/${judge?.id}`
@@ -136,7 +142,7 @@ export function JudgeFormModal({
               <input
                 id="judge-username"
                 type="text"
-                className="input input-bordered w-full lowercase"
+                className="input input-bordered w-full rounded-xl lowercase"
                 value={username}
                 onChange={(e) => setUsername(e.target.value.toLowerCase())}
                 placeholder="英小文字・数字（例: judge1）"
@@ -144,21 +150,26 @@ export function JudgeFormModal({
                 required
               />
               <p className="mt-1 text-base-content/40 text-xs">
-                英小文字・数字・アンダースコアのみ使用可能（ログインにも使用）
+                英小文字・数字・アンダースコアのみ使用可能
               </p>
             </div>
           ) : (
             <div>
-              <label className="label" htmlFor="judge-username-display">
+              <label className="label" htmlFor="judge-username-edit">
                 <span className="label-text">ユーザー名</span>
               </label>
               <input
-                id="judge-username-display"
+                id="judge-username-edit"
                 type="text"
-                className="input input-bordered w-full"
-                value={judge?.username ?? ""}
-                disabled
+                className="input input-bordered w-full rounded-xl lowercase"
+                value={username}
+                onChange={(e) => setUsername(e.target.value.toLowerCase())}
+                placeholder="英小文字・数字（例: judge1）"
+                pattern="[a-z0-9_]+"
               />
+              <p className="mt-1 text-base-content/40 text-xs">
+                英小文字・数字・アンダースコアのみ使用可能
+              </p>
             </div>
           )}
 
@@ -173,7 +184,7 @@ export function JudgeFormModal({
               <input
                 id="judge-password"
                 type={showPassword ? "text" : "password"}
-                className="input input-bordered w-full pr-12"
+                className="input input-bordered w-full rounded-xl pr-12"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 placeholder={
@@ -210,7 +221,7 @@ export function JudgeFormModal({
             </label>
             <textarea
               id="judge-note"
-              className="textarea textarea-bordered w-full"
+              className="textarea textarea-bordered w-full rounded-xl"
               value={note}
               onChange={(e) => setNote(e.target.value)}
               placeholder="備考（任意）"

--- a/@robopo/web/components/player/modals.tsx
+++ b/@robopo/web/components/player/modals.tsx
@@ -110,7 +110,7 @@ export function PlayerFormModal({
             <input
               id="player-name"
               type="text"
-              className="input input-bordered w-full"
+              className="input input-bordered w-full rounded-xl"
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="選手名"
@@ -124,7 +124,7 @@ export function PlayerFormModal({
             <input
               id="player-furigana"
               type="text"
-              className="input input-bordered w-full"
+              className="input input-bordered w-full rounded-xl"
               value={furigana}
               onChange={(e) => setFurigana(e.target.value)}
               placeholder="ふりがな（任意）"
@@ -137,7 +137,7 @@ export function PlayerFormModal({
             <input
               id="player-bib"
               type="text"
-              className="input input-bordered w-full"
+              className="input input-bordered w-full rounded-xl"
               value={bibNumber}
               onChange={(e) => setBibNumber(e.target.value)}
               placeholder="ゼッケン番号（任意）"
@@ -149,7 +149,7 @@ export function PlayerFormModal({
             </label>
             <textarea
               id="player-note"
-              className="textarea textarea-bordered w-full"
+              className="textarea textarea-bordered w-full rounded-xl"
               value={note}
               onChange={(e) => setNote(e.target.value)}
               placeholder="備考（任意）"

--- a/@robopo/web/lib/db/schema.ts
+++ b/@robopo/web/lib/db/schema.ts
@@ -227,3 +227,10 @@ export type SelectCompetitionWithCourse = {
   courseIds: number[]
   courseNames: string[]
 }
+
+export type SelectAdmin = {
+  id: string
+  username: string | null
+  lastLoginAt: Date | null
+  createdAt: Date | null
+}

--- a/@robopo/web/lib/navigation.tsx
+++ b/@robopo/web/lib/navigation.tsx
@@ -4,6 +4,7 @@ import {
   LogIn,
   LogOut,
   Route as RouteIcon,
+  Shield,
   Trophy,
   UserCheck,
   Users,
@@ -62,5 +63,13 @@ export const NAVIGATION_GENERAL_LIST: NavItem[] = [
     label: "ホーム",
     href: "/",
     icon: <House className="size-6" />,
+  },
+]
+
+export const ADMIN_SETTINGS_LIST: NavItem[] = [
+  {
+    label: "管理者一覧",
+    href: "/admin" as Route,
+    icon: <Shield className="size-6" />,
   },
 ]

--- a/@robopo/web/proxy.ts
+++ b/@robopo/web/proxy.ts
@@ -16,5 +16,6 @@ export const config = {
     "/player/:path*",
     "/judge/:path*",
     "/summary/:path*",
+    "/admin/:path*",
   ],
 }

--- a/@robopo/web/server/db.ts
+++ b/@robopo/web/server/db.ts
@@ -1,6 +1,6 @@
 "use server"
 
-import { eq } from "drizzle-orm"
+import { eq, isNull, max } from "drizzle-orm"
 import { db } from "@/lib/db/db"
 import {
   getCompetitionWithCourse,
@@ -14,6 +14,7 @@ import {
   course,
   judge,
   player,
+  type SelectAdmin,
   type SelectCompetition,
   type SelectCompetitionCourse,
   type SelectCompetitionJudge,
@@ -21,6 +22,7 @@ import {
   type SelectCourse,
   type SelectJudgeWithUsername,
   type SelectPlayer,
+  session,
   user,
 } from "@/lib/db/schema"
 
@@ -132,4 +134,21 @@ export async function getCompetitionJudgeAssignList(): Promise<{
     .select()
     .from(competitionJudge)
   return { competitionJudgeList }
+}
+
+// Get admin users (users without a judge record)
+export async function getAdminList(): Promise<SelectAdmin[]> {
+  const rows = await db
+    .select({
+      id: user.id,
+      username: user.username,
+      lastLoginAt: max(session.createdAt),
+      createdAt: user.createdAt,
+    })
+    .from(user)
+    .leftJoin(judge, eq(user.id, judge.userId))
+    .leftJoin(session, eq(user.id, session.userId))
+    .where(isNull(judge.id))
+    .groupBy(user.id)
+  return rows
 }

--- a/@robopo/web/test/unit/components/home/dashboard.test.tsx
+++ b/@robopo/web/test/unit/components/home/dashboard.test.tsx
@@ -49,10 +49,10 @@ const defaultProps = {
 }
 
 describe("Dashboard", () => {
-  test("renders two dashboard cards", () => {
+  test("renders three dashboard cards", () => {
     const { container } = renderWithRouter(<Dashboard {...defaultProps} />)
     const cards = container.querySelectorAll(".rounded-box")
-    expect(cards.length).toBe(2)
+    expect(cards.length).toBe(3)
   })
 
   test("renders scoring card with primary variant", () => {
@@ -65,5 +65,6 @@ describe("Dashboard", () => {
     renderWithRouter(<Dashboard {...defaultProps} />)
     expect(screen.getByText("採点")).toBeTruthy()
     expect(screen.getByText("大会管理")).toBeTruthy()
+    expect(screen.getByText("設定")).toBeTruthy()
   })
 })


### PR DESCRIPTION
## Summary by Sourcery

管理者用の管理ページを追加し、CRUD API と UI を実装してナビゲーションやダッシュボード設定に統合し、関連するフォームやジャッジの取り扱いを新しい管理者モデルに合わせました。

New Features:
- 管理者ユーザーの作成・編集・削除用に、検索・ソート・選択ベースのアクションが可能な管理者一覧ページを追加。
- 管理者アカウントの作成・更新・削除を行い、更新後の管理者リストをクライアントへ返す管理者管理 API を公開。
- 設定セクションを追加し、ナビゲーションドロワー、ホームタブ、およびダッシュボードから管理者ページへのリンクを追加。

Bug Fixes:
- ジャッジのユーザー名編集を可能にし、ユーザー名／パスワードの変更が紐づくユーザー／アカウントレコードに反映されるようにしつつ、クライアント・サーバー両方でバリデーションを実施。

Enhancements:
- 角丸の `input` および `textarea` バリアントを適用することで、コンペティション、コース、プレイヤー、ジャッジの各モーダル間でフォームスタイルを統一。
- 編集時にユーザー名を事前入力し、送信前にクライアント側でユーザー名の形式を検証することで、ジャッジフォームのバリデーション UX を改善。
- 共通の選択リストレイアウトについて、周囲のタイトルラッパーを削除し、より一貫したコンポジションになるよう調整。

Tests:
- 新しい設定用ダッシュボードカードを考慮するよう、ダッシュボードコンポーネントのテスト期待値を更新。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an admin management page with CRUD APIs and UI, integrate it into navigation and dashboard settings, and align related forms and judge handling with the new admin model.

New Features:
- Introduce an admin listing page with search, sorting, and selection-based actions for creating, editing, and deleting admin users.
- Expose admin management APIs to create, update, and delete admin accounts and return updated admin lists to the client.
- Add a settings section and links to the admin page in the navigation drawer, home tabs, and dashboard.

Bug Fixes:
- Allow editing of judge usernames and propagate username/password changes to linked user/account records with validation on both client and server.

Enhancements:
- Unify form styling across competition, course, player, and judge modals by applying rounded input and textarea variants.
- Refine judge form validation UX by pre-filling the username on edit and validating username format client-side before submit.
- Adjust the common selection list layout by removing the surrounding title wrapper for more consistent composition.

Tests:
- Update the dashboard component test expectations to account for the new settings dashboard card.

</details>