### PR TITLE
feat: add print all score

### DIFF
--- a/@robopo/web/app/admin/page.tsx
+++ b/@robopo/web/app/admin/page.tsx
@@ -1,5 +1,11 @@
+import type { Metadata } from "next"
 import { AdminView } from "@/components/admin/view"
 import { getAdminList } from "@/server/db"
+
+export const metadata: Metadata = {
+  title: "管理者一覧",
+  description: "管理者の登録・編集・削除を行います",
+}
 
 export default async function Admin() {
   const initialAdminList = await getAdminList()

--- a/@robopo/web/app/challenge/[competitionId]/[courseId]/[playerId]/page.tsx
+++ b/@robopo/web/app/challenge/[competitionId]/[courseId]/[playerId]/page.tsx
@@ -1,7 +1,13 @@
+import type { Metadata } from "next"
 import { redirect } from "next/navigation"
 import { View } from "@/app/challenge/[competitionId]/[courseId]/[playerId]/view"
 import { getCourseById, getPlayerById } from "@/lib/db/queries/queries"
 import type { SelectCourse, SelectPlayer } from "@/lib/db/schema"
+
+export const metadata: Metadata = {
+  title: "採点",
+  description: "チャレンジの採点を行います",
+}
 
 export default async function Challenge({
   params,

--- a/@robopo/web/app/competition/page.tsx
+++ b/@robopo/web/app/competition/page.tsx
@@ -1,5 +1,11 @@
+import type { Metadata } from "next"
 import { CompetitionView } from "@/components/competition/view"
 import { getCompetitionWithCourseList, getCourseList } from "@/server/db"
+
+export const metadata: Metadata = {
+  title: "大会一覧",
+  description: "大会の登録・編集・削除を行います",
+}
 
 export default async function Competition() {
   const [{ competitions }, { courses }] = await Promise.all([

--- a/@robopo/web/app/course/edit/[courseId]/page.tsx
+++ b/@robopo/web/app/course/edit/[courseId]/page.tsx
@@ -1,5 +1,11 @@
+import type { Metadata } from "next"
 import { EditorPage } from "@/app/course/edit/editorPage"
 import { getCourseById } from "@/lib/db/queries/queries"
+
+export const metadata: Metadata = {
+  title: "コース編集",
+  description: "コースを編集します",
+}
 
 export default async function Edit({
   params,

--- a/@robopo/web/app/course/edit/page.tsx
+++ b/@robopo/web/app/course/edit/page.tsx
@@ -1,4 +1,10 @@
+import type { Metadata } from "next"
 import { EditorPage } from "@/app/course/edit/editorPage"
+
+export const metadata: Metadata = {
+  title: "コース作成",
+  description: "新しいコースを作成します",
+}
 
 export default async function NewEdit() {
   return (

--- a/@robopo/web/app/course/page.tsx
+++ b/@robopo/web/app/course/page.tsx
@@ -1,9 +1,15 @@
+import type { Metadata } from "next"
 import { View } from "@/components/course/view"
 import {
   getCourseWithCompetition,
   groupByCourse,
 } from "@/lib/db/queries/queries"
 import { getCompetitionList } from "@/server/db"
+
+export const metadata: Metadata = {
+  title: "コース一覧",
+  description: "コースの登録・編集・削除を行います",
+}
 
 export default async function Course() {
   const [courseRows, { competitions }] = await Promise.all([

--- a/@robopo/web/app/globals.css
+++ b/@robopo/web/app/globals.css
@@ -368,6 +368,11 @@
     break-inside: avoid;
   }
 
+  /* Force page break after element (for bulk printing) */
+  .print\:break-after-page {
+    break-after: page;
+  }
+
   /* Ensure background colors print */
   .bg-base-200,
   .bg-base-200\/50,
@@ -383,8 +388,17 @@
     display: none;
   }
 
+  /* Override fixed width for print - let @page margins handle sizing */
+  .w-\[210mm\] {
+    width: 100%;
+  }
+
+  .min-h-\[297mm\] {
+    min-height: auto;
+  }
+
   @page {
-    margin: 1cm;
+    margin: 10mm;
     size: A4;
   }
 }

--- a/@robopo/web/app/judge/page.tsx
+++ b/@robopo/web/app/judge/page.tsx
@@ -1,6 +1,12 @@
+import type { Metadata } from "next"
 import { JudgeView } from "@/components/judge/view"
 import { getJudgeWithCompetition, groupByJudge } from "@/lib/db/queries/queries"
 import { getCompetitionList } from "@/server/db"
+
+export const metadata: Metadata = {
+  title: "採点者一覧",
+  description: "採点者の登録・編集・削除を行います",
+}
 
 export default async function JudgePage() {
   const [judgeRows, { competitions }] = await Promise.all([

--- a/@robopo/web/app/layout.tsx
+++ b/@robopo/web/app/layout.tsx
@@ -20,7 +20,10 @@ const notoSansJP = Noto_Sans_JP({
 })
 
 export const metadata: Metadata = {
-  title: "ROBOPO",
+  title: {
+    default: "ROBOPO",
+    template: "%s | ROBOPO",
+  },
   description: "ロボサバ大会集計アプリ",
 }
 

--- a/@robopo/web/app/page.tsx
+++ b/@robopo/web/app/page.tsx
@@ -1,4 +1,5 @@
 import { eq } from "drizzle-orm"
+import type { Metadata } from "next"
 import { headers } from "next/headers"
 import { Dashboard } from "@/components/home/dashboard"
 import { ChallengeTab } from "@/components/home/tabs"
@@ -19,6 +20,11 @@ import {
   getCourseList,
   getJudgeList,
 } from "@/server/db"
+
+export const metadata: Metadata = {
+  title: "ホーム",
+  description: "ロボサバ大会のダッシュボード",
+}
 
 export default async function Home() {
   const session = await auth.api.getSession({

--- a/@robopo/web/app/player/page.tsx
+++ b/@robopo/web/app/player/page.tsx
@@ -1,9 +1,15 @@
+import type { Metadata } from "next"
 import { PlayerView } from "@/components/player/view"
 import {
   getPlayersWithCompetition,
   groupByPlayer,
 } from "@/lib/db/queries/queries"
 import { getCompetitionList } from "@/server/db"
+
+export const metadata: Metadata = {
+  title: "選手一覧",
+  description: "選手の登録・編集・削除を行います",
+}
 
 export default async function Player() {
   const [playerRows, { competitions }] = await Promise.all([

--- a/@robopo/web/app/summary/[...ids]/loading.tsx
+++ b/@robopo/web/app/summary/[...ids]/loading.tsx
@@ -1,0 +1,51 @@
+import { Skeleton } from "@/components/common/skeleton"
+
+export default function Loading() {
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-6">
+      {/* Toolbar skeleton */}
+      <div className="mb-6 flex items-center justify-between">
+        <Skeleton className="h-8 w-16 rounded-xl" />
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-8 w-16 rounded-xl" />
+          <Skeleton className="h-8 w-24 rounded-xl" />
+        </div>
+      </div>
+
+      {/* Header card skeleton */}
+      <div className="card mb-6 border border-base-300 bg-base-100 p-5 shadow-sm">
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-7 w-48" />
+          <Skeleton className="h-4 w-20" />
+        </div>
+        <div className="mt-3 flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <Skeleton className="h-6 w-10 rounded" />
+            <Skeleton className="h-6 w-24" />
+          </div>
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-8 w-20 rounded-lg" />
+            <Skeleton className="h-8 w-24 rounded-lg" />
+          </div>
+        </div>
+      </div>
+
+      {/* Course sections skeleton */}
+      {["s1", "s2"].map((id) => (
+        <div key={id} className="mb-6">
+          <div className="mb-3 flex items-center justify-between border-base-300 border-l-4 pl-3">
+            <Skeleton className="h-5 w-32" />
+            <Skeleton className="h-7 w-28 rounded-lg" />
+          </div>
+          <div className="card border border-base-300 bg-base-100 p-4 shadow-sm">
+            <div className="space-y-2">
+              {["r1", "r2", "r3", "r4", "r5"].map((rid) => (
+                <Skeleton key={rid} className="h-8 w-full rounded-lg" />
+              ))}
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/@robopo/web/app/summary/[...ids]/page.tsx
+++ b/@robopo/web/app/summary/[...ids]/page.tsx
@@ -1,6 +1,20 @@
+import type { Metadata } from "next"
 import { PlayerScoreSheet } from "@/components/summary/playerScoreSheet"
 import { getCompetitionById, getPlayerById } from "@/lib/db/queries/queries"
 import { buildCoursesForPlayer } from "@/lib/summary/buildCourseData"
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ ids: number[] }>
+}): Promise<Metadata> {
+  const { ids } = await params
+  const player = await getPlayerById(Number(ids[2]))
+  return {
+    title: player ? `${player.name} 個人成績` : "個人成績",
+    description: "個人成績シート",
+  }
+}
 
 export default async function SummaryPlayer({
   params,

--- a/@robopo/web/app/summary/page.tsx
+++ b/@robopo/web/app/summary/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next"
 import { SummaryView } from "@/components/summary/summaryView"
 import { getCompetitionStatus } from "@/lib/competition"
 import type { SelectCompetition } from "@/lib/db/schema"
@@ -25,6 +26,11 @@ function getDefaultCompetitionId(
   }
 
   return null
+}
+
+export const metadata: Metadata = {
+  title: "集計結果",
+  description: "大会の集計結果を確認します",
 }
 
 export default async function SummaryPage({

--- a/@robopo/web/app/summary/print-all/[competitionId]/loading.tsx
+++ b/@robopo/web/app/summary/print-all/[competitionId]/loading.tsx
@@ -1,0 +1,51 @@
+import { Skeleton } from "@/components/common/skeleton"
+
+export default function Loading() {
+  return (
+    <>
+      {/* Toolbar skeleton */}
+      <div className="fixed top-0 right-0 left-0 z-50 flex items-center justify-between border-base-300 border-b bg-base-100 px-4 py-3 shadow-sm">
+        <Skeleton className="h-8 w-16 rounded-xl" />
+        <div className="flex items-center gap-3">
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="h-8 w-24 rounded-xl" />
+        </div>
+      </div>
+
+      {/* Multiple A4 sheet skeletons */}
+      <div className="mx-auto mt-16 mb-8">
+        {["p1", "p2", "p3"].map((id) => (
+          <div
+            key={id}
+            className="mx-auto mb-8 box-border min-h-[297mm] w-[210mm] bg-white p-6 shadow-lg"
+          >
+            {/* Header */}
+            <div className="mb-3 flex items-baseline justify-between border-gray-200 border-b pb-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-3 w-20" />
+            </div>
+            {/* Player info */}
+            <div className="mb-4 flex items-center justify-between">
+              <Skeleton className="h-5 w-24" />
+              <div className="flex gap-3">
+                <Skeleton className="h-4 w-16" />
+                <Skeleton className="h-5 w-20" />
+              </div>
+            </div>
+            {/* Course tables */}
+            {["c1", "c2", "c3"].map((cid) => (
+              <div key={cid} className="mb-4">
+                <Skeleton className="mb-1 h-3 w-28" />
+                <div className="space-y-1">
+                  {["r1", "r2", "r3", "r4", "r5"].map((rid) => (
+                    <Skeleton key={rid} className="h-4 w-full" />
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    </>
+  )
+}

--- a/@robopo/web/app/summary/print-all/[competitionId]/page.tsx
+++ b/@robopo/web/app/summary/print-all/[competitionId]/page.tsx
@@ -1,0 +1,64 @@
+import type { Metadata } from "next"
+import { PrintBulkSheet } from "@/components/summary/printBulkSheet"
+import { getCompetitionById } from "@/lib/db/queries/queries"
+import { buildCoursesForPlayer } from "@/lib/summary/buildCourseData"
+import { getCompetitionPlayerList } from "@/server/db"
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ competitionId: string }>
+}): Promise<Metadata> {
+  const { competitionId } = await params
+  const competition = await getCompetitionById(Number(competitionId))
+  return {
+    title: competition
+      ? `${competition.name}_個人成績シート一括`
+      : "個人成績シート一括印刷",
+  }
+}
+
+export default async function PrintAllSummary({
+  params,
+}: {
+  params: Promise<{ competitionId: string }>
+}) {
+  const { competitionId: rawId } = await params
+  const competitionId = Number(rawId)
+
+  const [competitionData, { players }] = await Promise.all([
+    getCompetitionById(competitionId),
+    getCompetitionPlayerList(competitionId),
+  ])
+
+  if (!competitionData) {
+    return <div className="p-8 text-center">大会が見つかりません</div>
+  }
+
+  // Build course data for all players in parallel
+  const playerSheets = await Promise.all(
+    players.map(async (player) => {
+      const { courses, totalPoint, totalChallengeCount } =
+        await buildCoursesForPlayer(competitionId, player.id)
+
+      return {
+        player: {
+          id: player.id,
+          name: player.name,
+          furigana: player.furigana,
+          bibNumber: player.bibNumber,
+        },
+        courses,
+        totalPoint,
+        totalChallengeCount,
+      }
+    }),
+  )
+
+  return (
+    <PrintBulkSheet
+      competitionName={competitionData.name}
+      players={playerSheets}
+    />
+  )
+}

--- a/@robopo/web/app/summary/print/[...ids]/loading.tsx
+++ b/@robopo/web/app/summary/print/[...ids]/loading.tsx
@@ -1,0 +1,46 @@
+import { Skeleton } from "@/components/common/skeleton"
+
+export default function Loading() {
+  return (
+    <>
+      {/* Toolbar skeleton */}
+      <div className="fixed top-0 right-0 left-0 z-50 flex items-center justify-between border-base-300 border-b bg-base-100 px-4 py-3 shadow-sm">
+        <Skeleton className="h-8 w-16 rounded-xl" />
+        <div className="flex items-center gap-3">
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-8 w-24 rounded-xl" />
+        </div>
+      </div>
+
+      {/* A4 sheet skeleton */}
+      <div className="mx-auto mt-16 mb-8">
+        <div className="mx-auto box-border min-h-[297mm] w-[210mm] bg-white p-6 shadow-lg">
+          {/* Header */}
+          <div className="mb-3 flex items-baseline justify-between border-gray-200 border-b pb-2">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-3 w-20" />
+          </div>
+          {/* Player info */}
+          <div className="mb-4 flex items-center justify-between">
+            <Skeleton className="h-5 w-24" />
+            <div className="flex gap-3">
+              <Skeleton className="h-4 w-16" />
+              <Skeleton className="h-5 w-20" />
+            </div>
+          </div>
+          {/* Course tables */}
+          {["c1", "c2", "c3"].map((id) => (
+            <div key={id} className="mb-4">
+              <Skeleton className="mb-1 h-3 w-28" />
+              <div className="space-y-1">
+                {["r1", "r2", "r3", "r4", "r5", "r6"].map((rid) => (
+                  <Skeleton key={rid} className="h-4 w-full" />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
+  )
+}

--- a/@robopo/web/app/summary/print/[...ids]/page.tsx
+++ b/@robopo/web/app/summary/print/[...ids]/page.tsx
@@ -1,6 +1,19 @@
+import type { Metadata } from "next"
 import { PrintScoreSheet } from "@/components/summary/printScoreSheet"
 import { getCompetitionById, getPlayerById } from "@/lib/db/queries/queries"
 import { buildCoursesForPlayer } from "@/lib/summary/buildCourseData"
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ ids: number[] }>
+}): Promise<Metadata> {
+  const { ids } = await params
+  const player = await getPlayerById(Number(ids[2]))
+  return {
+    title: player ? `${player.name}_個人成績シート` : "個人成績シート",
+  }
+}
 
 export default async function PrintSummaryPlayer({
   params,

--- a/@robopo/web/components/summary/printBulkSheet.tsx
+++ b/@robopo/web/components/summary/printBulkSheet.tsx
@@ -1,0 +1,121 @@
+"use client"
+
+import { ArrowLeft, Printer } from "lucide-react"
+import { useRouter } from "next/navigation"
+import {
+  type PrintCourseData,
+  PrintCourseTable,
+} from "@/components/summary/printScoreSheet"
+
+type PlayerSheet = {
+  player: {
+    id: number
+    name: string
+    furigana: string | null
+    bibNumber: string | null
+  }
+  courses: PrintCourseData[]
+  totalPoint: number
+  totalChallengeCount: number
+}
+
+type PrintBulkSheetProps = {
+  competitionName: string
+  players: PlayerSheet[]
+}
+
+export function PrintBulkSheet({
+  competitionName,
+  players,
+}: PrintBulkSheetProps) {
+  const router = useRouter()
+
+  return (
+    <>
+      {/* Toolbar - hidden when printing */}
+      <div className="fixed top-0 right-0 left-0 z-50 flex items-center justify-between border-base-300 border-b bg-base-100 px-4 py-3 shadow-sm print:hidden">
+        <button
+          type="button"
+          className="btn btn-ghost btn-sm rounded-xl"
+          onClick={() => router.back()}
+        >
+          <ArrowLeft className="size-4" />
+          戻る
+        </button>
+        <div className="flex items-center gap-3">
+          <span className="text-base-content/50 text-sm">
+            一括印刷プレビュー ({players.length}名)
+          </span>
+          <button
+            type="button"
+            className="btn btn-primary btn-sm rounded-xl"
+            onClick={() => window.print()}
+          >
+            <Printer className="size-4" />
+            印刷する
+          </button>
+        </div>
+      </div>
+
+      {/* Player sheets */}
+      <div className="mx-auto mt-16 mb-8 print:mt-0 print:mb-0">
+        {players.map((playerData, index) => (
+          <div
+            key={playerData.player.id}
+            className={`mx-auto box-border min-h-[297mm] w-[210mm] bg-white p-6 shadow-lg print:p-0 print:shadow-none ${
+              index < players.length - 1
+                ? "mb-8 print:mb-0 print:break-after-page"
+                : ""
+            }`}
+          >
+            {/* Header */}
+            <div className="mb-2 flex items-baseline justify-between border-gray-400 border-b pb-1.5">
+              <div className="flex items-baseline gap-2">
+                <span className="text-[10px] text-gray-500">ゼッケンNo：</span>
+                <span className="font-bold text-sm">
+                  {playerData.player.bibNumber ?? "-"}
+                </span>
+              </div>
+              <span className="text-[10px] text-gray-500">
+                {competitionName}
+              </span>
+            </div>
+
+            {/* Player info + totals */}
+            <div className="mb-3 flex items-center justify-between">
+              <div className="flex items-baseline gap-2">
+                <ruby className="font-bold text-base">
+                  {playerData.player.name}
+                  {playerData.player.furigana && (
+                    <rt className="font-normal text-[8px] text-gray-400">
+                      {playerData.player.furigana}
+                    </rt>
+                  )}
+                </ruby>
+              </div>
+              <div className="flex items-center gap-3 text-[9px]">
+                <div className="flex items-center gap-1">
+                  <span className="text-gray-500">試行回数</span>
+                  <span className="font-bold tabular-nums">
+                    {playerData.totalChallengeCount}
+                  </span>
+                </div>
+                <div className="flex items-center gap-1 border border-gray-800 px-2 py-0.5 font-bold">
+                  <span>総得点</span>
+                  <span className="text-sm tabular-nums">
+                    {playerData.totalPoint}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            {/* Course Tables */}
+            {playerData.courses.map((course) => (
+              <PrintCourseTable key={course.id} course={course} />
+            ))}
+          </div>
+        ))}
+      </div>
+    </>
+  )
+}

--- a/@robopo/web/components/summary/printScoreSheet.tsx
+++ b/@robopo/web/components/summary/printScoreSheet.tsx
@@ -18,7 +18,7 @@ type ChallengeResult = {
   detail: string | null
 }
 
-type PrintCourseData = {
+export type PrintCourseData = {
   id: number
   name: string
   missionPair: MissionValue[][]
@@ -152,7 +152,7 @@ export function PrintScoreSheet({
 }
 
 // Compact course table for A4 print
-function PrintCourseTable({ course }: { course: PrintCourseData }) {
+export function PrintCourseTable({ course }: { course: PrintCourseData }) {
   const columns = flattenAttempts(course.resultArray, course.id)
   const maxCols = 25
   const visibleColumns = columns.slice(0, maxCols)

--- a/@robopo/web/components/summary/summaryView.tsx
+++ b/@robopo/web/components/summary/summaryView.tsx
@@ -1,6 +1,13 @@
 "use client"
 
-import { type LucideIcon, Route as RouteIcon, Scale, Users } from "lucide-react"
+import {
+  type LucideIcon,
+  Printer,
+  Route as RouteIcon,
+  Scale,
+  Users,
+} from "lucide-react"
+import Link from "next/link"
 import { useState } from "react"
 import { CourseSummaryTable } from "@/components/summary/courseSummaryTable"
 import { JudgeSummaryTable } from "@/components/summary/judgeSummaryTable"
@@ -54,7 +61,7 @@ export function SummaryView({ competitions, defaultCompetitionId }: Props) {
           </select>
         </div>
 
-        <div className="mt-2 lg:mt-0">
+        <div className="mt-2 flex items-end gap-3 lg:mt-0">
           <div className="inline-flex rounded-xl bg-base-200/60 p-1">
             {TABS.map(({ key, label, icon: Icon }) => (
               <button
@@ -72,6 +79,16 @@ export function SummaryView({ competitions, defaultCompetitionId }: Props) {
               </button>
             ))}
           </div>
+
+          {competitionId > 0 && (
+            <Link
+              href={`/summary/print-all/${competitionId}`}
+              className="btn btn-primary btn-sm rounded-xl"
+            >
+              <Printer className="size-4" />
+              一括印刷
+            </Link>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary by Sourcery

大会内のすべてのプレイヤー向けの一括印刷用スコアシートを追加し、サマリーページおよび管理ページ全体でページメタデータと印刷時の挙動を改善します。

新機能:
- 大会内のすべてのプレイヤーについて、印刷可能な A4 ページを生成する一括スコアシート印刷ビューを追加。
- サマリービューから、選択した大会の新しい一括印刷画面を開くためのツールバーアクションを公開。

改善点:
- 印刷専用スタイルを調整し、ページ区切りやサイズ上書きなど A4 レイアウトを改善して、印刷出力の品質を向上。
- 新しい一括印刷ビューから再利用できるよう、共有の印刷用コーステーブルの型/コンポーネントをエクスポート。
- 体感パフォーマンス向上のため、個別サマリー、プレイヤーごとの印刷、ならびに一括印刷ページにローディングスケルトン UI を追加。
- コア管理画面、スコアリング、大会、コース、ジャッジ、プレイヤー、サマリー、ホームページ向けにページごとのメタデータ（タイトルとディスクリプション）を定義し、SEO と UX 改善のためにルートレイアウトをタイトルテンプレート対応に更新。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add bulk printable score sheets for all players in a competition and improve page metadata and printing behavior across summary and admin pages.

New Features:
- Add a bulk score-sheet print view that generates printable A4 pages for all players in a competition.
- Expose a toolbar action from the summary view to open the new bulk print screen for the selected competition.

Enhancements:
- Refine print-specific styles for A4 layouts, including page breaks and sizing overrides, to improve printed output.
- Export shared print course table types/components so they can be reused by the new bulk print view.
- Add loading skeleton UIs for individual summary, per-player print, and bulk print pages to improve perceived performance.
- Define per-page metadata (titles and descriptions) for core admin, scoring, competition, course, judge, player, summary, and home pages, and update the root layout to use title templates for better SEO and UX.

</details>