### PR TITLE
feat: polish spectator page

### DIFF
--- a/@robopo/web/app/api/competition/[id]/route.ts
+++ b/@robopo/web/app/api/competition/[id]/route.ts
@@ -1,4 +1,5 @@
 import { eq } from "drizzle-orm"
+import { normalizeMaskMinutesBefore } from "@/lib/competition"
 import { db } from "@/lib/db/db"
 import { updateCompetition } from "@/lib/db/queries/update"
 import { competitionCourse } from "@/lib/db/schema"
@@ -32,7 +33,10 @@ export async function PATCH(
     parsedStart > parsedEnd
   ) {
     return Response.json(
-      { success: false, message: "開催日は終了日より前でなければなりません。" },
+      {
+        success: false,
+        message: "開催日時は終了日時より前でなければなりません。",
+      },
       { status: 400 },
     )
   }
@@ -49,6 +53,14 @@ export async function PATCH(
   }
   if (parsedEnd !== undefined) {
     updateData.endDate = parsedEnd
+  }
+  if (body.maskEnabled !== undefined) {
+    updateData.maskEnabled = !!body.maskEnabled
+  }
+  if (body.maskMinutesBefore !== undefined) {
+    updateData.maskMinutesBefore = normalizeMaskMinutesBefore(
+      body.maskMinutesBefore,
+    )
   }
 
   try {

--- a/@robopo/web/app/api/competition/route.ts
+++ b/@robopo/web/app/api/competition/route.ts
@@ -1,15 +1,27 @@
 import { deleteById } from "@/app/api/delete"
+import { normalizeMaskMinutesBefore } from "@/lib/competition"
 import { db } from "@/lib/db/db"
 import { createCompetition } from "@/lib/db/queries/insert"
 import { competitionCourse } from "@/lib/db/schema"
 import { getCompetitionWithCourseList } from "@/server/db"
 
 export async function POST(req: Request) {
-  const { name, description, startDate, endDate, courseIds } = await req.json()
+  const {
+    name,
+    description,
+    startDate,
+    endDate,
+    courseIds,
+    maskEnabled,
+    maskMinutesBefore,
+  } = await req.json()
 
   if (startDate && endDate && new Date(startDate) > new Date(endDate)) {
     return Response.json(
-      { success: false, message: "開催日は終了日より前でなければなりません。" },
+      {
+        success: false,
+        message: "開催日時は終了日時より前でなければなりません。",
+      },
       { status: 400 },
     )
   }
@@ -19,6 +31,8 @@ export async function POST(req: Request) {
     description: description || null,
     startDate: startDate ? new Date(startDate) : null,
     endDate: endDate ? new Date(endDate) : null,
+    maskEnabled: !!maskEnabled,
+    maskMinutesBefore: normalizeMaskMinutesBefore(maskMinutesBefore),
   }
   try {
     const result = await createCompetition(competitionData)

--- a/@robopo/web/app/api/spectator/[competitionId]/route.ts
+++ b/@robopo/web/app/api/spectator/[competitionId]/route.ts
@@ -1,5 +1,22 @@
+import { getCompetitionById } from "@/lib/db/queries/queries"
 import { maxCoursePoint } from "@/lib/summary/calculations"
 import { getCompetitionCourseList, getCompetitionPlayerList } from "@/server/db"
+
+function shouldMask(competition: {
+  maskEnabled: boolean
+  maskMinutesBefore: number
+  endDate: Date | null
+}): boolean {
+  if (!competition.maskEnabled || !competition.endDate) {
+    return false
+  }
+  const now = new Date()
+  const maskStartTime = new Date(
+    new Date(competition.endDate).getTime() -
+      competition.maskMinutesBefore * 60 * 1000,
+  )
+  return now >= maskStartTime
+}
 
 export async function GET(
   _req: Request,
@@ -12,10 +29,18 @@ export async function GET(
     return Response.json({ error: "Invalid competition ID." }, { status: 400 })
   }
 
-  const [{ competitionCourses }, { players }] = await Promise.all([
-    getCompetitionCourseList(competitionId),
-    getCompetitionPlayerList(competitionId),
-  ])
+  const [competitionData, { competitionCourses }, { players }] =
+    await Promise.all([
+      getCompetitionById(competitionId),
+      getCompetitionCourseList(competitionId),
+      getCompetitionPlayerList(competitionId),
+    ])
+
+  if (!competitionData) {
+    return Response.json({ error: "Competition not found." }, { status: 404 })
+  }
+
+  const masked = shouldMask(competitionData)
 
   // Calculate total points for each player across all courses (parallelized)
   const playerScores = await Promise.all(
@@ -28,8 +53,8 @@ export async function GET(
       const totalPoint = coursePoints.reduce((sum, pt) => sum + pt, 0)
       return {
         playerId: player.id,
-        playerName: player.name,
-        bibNumber: player.bibNumber,
+        playerName: masked ? "???" : player.name,
+        bibNumber: masked ? null : player.bibNumber,
         totalPoint,
       }
     }),
@@ -49,5 +74,5 @@ export async function GET(
     return { ...player, rank: currentRank }
   })
 
-  return Response.json(result)
+  return Response.json({ players: result, masked })
 }

--- a/@robopo/web/app/competition/tabs.tsx
+++ b/@robopo/web/app/competition/tabs.tsx
@@ -6,7 +6,7 @@ import type { SelectCompetitionWithCourse, SelectCourse } from "@/lib/db/schema"
 
 const DEFAULT_COURSE_NAMES = ["THE一本橋", "センサーコース"]
 
-function formatDateForInput(date: Date | null | undefined): string {
+function formatDateTimeForInput(date: Date | null | undefined): string {
   if (!date) {
     return ""
   }
@@ -14,7 +14,9 @@ function formatDateForInput(date: Date | null | undefined): string {
   const year = d.getFullYear()
   const month = String(d.getMonth() + 1).padStart(2, "0")
   const day = String(d.getDate()).padStart(2, "0")
-  return `${year}-${month}-${day}`
+  const hours = String(d.getHours()).padStart(2, "0")
+  const minutes = String(d.getMinutes()).padStart(2, "0")
+  return `${year}-${month}-${day}T${hours}:${minutes}`
 }
 
 type CompetitionFormModalProps = {
@@ -35,10 +37,10 @@ export function CompetitionFormModal({
   const [name, setName] = useState(competition?.name ?? "")
   const [description, setDescription] = useState(competition?.description ?? "")
   const [startDate, setStartDate] = useState(
-    formatDateForInput(competition?.startDate),
+    formatDateTimeForInput(competition?.startDate),
   )
   const [endDate, setEndDate] = useState(
-    formatDateForInput(competition?.endDate),
+    formatDateTimeForInput(competition?.endDate),
   )
   const [selectedCourseIds, setSelectedCourseIds] = useState<number[]>(
     mode === "create"
@@ -46,6 +48,12 @@ export function CompetitionFormModal({
           .filter((c) => DEFAULT_COURSE_NAMES.includes(c.name))
           .map((c) => c.id)
       : (competition?.courseIds ?? []),
+  )
+  const [maskEnabled, setMaskEnabled] = useState(
+    competition?.maskEnabled ?? false,
+  )
+  const [maskMinutesBefore, setMaskMinutesBefore] = useState(
+    competition?.maskMinutesBefore ?? 30,
   )
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -63,7 +71,7 @@ export function CompetitionFormModal({
       return "名前は必須です。"
     }
     if (startDate && endDate && startDate > endDate) {
-      return "開催日は終了日より前でなければなりません。"
+      return "開催日時は終了日時より前でなければなりません。"
     }
     return null
   }
@@ -86,6 +94,8 @@ export function CompetitionFormModal({
         startDate: startDate || null,
         endDate: endDate || null,
         courseIds: selectedCourseIds,
+        maskEnabled,
+        maskMinutesBefore,
       }
 
       const url =
@@ -153,11 +163,11 @@ export function CompetitionFormModal({
           <div className="flex gap-4">
             <div className="flex-1">
               <label className="label" htmlFor="comp-start">
-                <span className="label-text">開催日</span>
+                <span className="label-text">開催日時</span>
               </label>
               <input
                 id="comp-start"
-                type="date"
+                type="datetime-local"
                 className="input input-bordered w-full rounded-xl"
                 value={startDate}
                 onChange={(e) => setStartDate(e.target.value)}
@@ -165,11 +175,11 @@ export function CompetitionFormModal({
             </div>
             <div className="flex-1">
               <label className="label" htmlFor="comp-end">
-                <span className="label-text">終了日</span>
+                <span className="label-text">終了日時</span>
               </label>
               <input
                 id="comp-end"
-                type="date"
+                type="datetime-local"
                 className="input input-bordered w-full rounded-xl"
                 value={endDate}
                 onChange={(e) => setEndDate(e.target.value)}
@@ -178,9 +188,40 @@ export function CompetitionFormModal({
           </div>
           {startDate && endDate && startDate > endDate && (
             <p className="text-error text-sm">
-              開催日は終了日より前でなければなりません。
+              開催日時は終了日時より前でなければなりません。
             </p>
           )}
+
+          {/* Mask settings */}
+          <div className="rounded-xl border border-base-300/50 bg-base-200/30 p-3">
+            <label className="flex cursor-pointer items-center gap-3">
+              <input
+                type="checkbox"
+                className="checkbox checkbox-primary checkbox-sm"
+                checked={maskEnabled}
+                onChange={(e) => setMaskEnabled(e.target.checked)}
+              />
+              <span className="text-sm">終了間際に選手名をマスクする</span>
+            </label>
+            {maskEnabled && (
+              <div className="mt-3 flex items-center gap-2 pl-8">
+                <span className="text-base-content/60 text-sm">終了前</span>
+                <input
+                  type="number"
+                  min={1}
+                  max={999}
+                  className="input input-bordered input-sm w-20 rounded-xl text-center"
+                  value={maskMinutesBefore}
+                  onChange={(e) =>
+                    setMaskMinutesBefore(Number(e.target.value) || 30)
+                  }
+                />
+                <span className="text-base-content/60 text-sm">
+                  分からマスク
+                </span>
+              </div>
+            )}
+          </div>
 
           {/* Course selection */}
           <div>

--- a/@robopo/web/components/common/commonList.tsx
+++ b/@robopo/web/components/common/commonList.tsx
@@ -206,19 +206,51 @@ function TableComponent({
             {(common as SelectCompetitionWithCourse).startDate ? (
               new Date(
                 (common as SelectCompetitionWithCourse).startDate as Date,
-              ).toLocaleDateString("ja-JP")
+              ).toLocaleString("ja-JP", {
+                year: "numeric",
+                month: "2-digit",
+                day: "2-digit",
+                hour: "2-digit",
+                minute: "2-digit",
+              })
             ) : (
               <span className="text-base-content/30">-</span>
             )}
           </td>
           <td
-            className="py-3 text-base-content/60 text-sm"
+            className="whitespace-nowrap py-3 text-base-content/60 text-sm"
             suppressHydrationWarning
           >
             {(common as SelectCompetitionWithCourse).endDate ? (
               new Date(
                 (common as SelectCompetitionWithCourse).endDate as Date,
-              ).toLocaleDateString("ja-JP")
+              ).toLocaleString("ja-JP", {
+                year: "numeric",
+                month: "2-digit",
+                day: "2-digit",
+                hour: "2-digit",
+                minute: "2-digit",
+              })
+            ) : (
+              <span className="text-base-content/30">-</span>
+            )}
+          </td>
+          <td className="py-3 text-center">
+            {(common as SelectCompetitionWithCourse).maskEnabled ? (
+              <span className="badge badge-warning badge-sm">ON</span>
+            ) : (
+              <span className="badge badge-ghost badge-sm">OFF</span>
+            )}
+          </td>
+          <td className="whitespace-nowrap py-3 text-base-content/60 text-sm">
+            {(common as SelectCompetitionWithCourse).maskEnabled ? (
+              <span>
+                終了前
+                <span className="mx-1 font-bold font-mono tabular-nums">
+                  {(common as SelectCompetitionWithCourse).maskMinutesBefore}
+                </span>
+                分
+              </span>
             ) : (
               <span className="text-base-content/30">-</span>
             )}
@@ -254,7 +286,16 @@ function itemNames(type: CommonListProps["type"]): string[] {
   } else if (type === "course") {
     itemNames.push("ID", "コース名", "設定済み", "使用大会", "作成日時", "説明")
   } else if (type === "competition") {
-    itemNames.push("ID", "名前", "コース", "開催日", "終了日", "説明")
+    itemNames.push(
+      "ID",
+      "名前",
+      "コース",
+      "開催日時",
+      "終了日時",
+      "マスク",
+      "マスク時間",
+      "説明",
+    )
   }
   return itemNames
 }

--- a/@robopo/web/components/spectator/leaderboard.tsx
+++ b/@robopo/web/components/spectator/leaderboard.tsx
@@ -66,6 +66,7 @@ export function Leaderboard({
     defaultCompetitionId ?? 0,
   )
   const [players, setPlayers] = useState<SpectatorPlayer[]>([])
+  const [masked, setMasked] = useState(false)
   const [loading, setLoading] = useState(false)
   const [countdown, setCountdown] = useState(REFRESH_INTERVAL)
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
@@ -79,7 +80,8 @@ export function Leaderboard({
       const res = await fetch(`/api/spectator/${competitionId}`)
       if (res.ok) {
         const data = await res.json()
-        setPlayers(data)
+        setPlayers(data.players)
+        setMasked(data.masked)
       }
     } catch {
       // Silently retry on next interval
@@ -165,6 +167,15 @@ export function Leaderboard({
         <p className="mb-6 text-center text-base-content/50 text-sm">
           {competitions[0].name}
         </p>
+      )}
+
+      {/* Mask indicator */}
+      {masked && (
+        <div className="mb-4 rounded-xl border border-amber-200 bg-gradient-to-r from-amber-50 to-orange-50 px-4 py-2.5 text-center">
+          <span className="font-bold text-amber-700 text-sm">
+            選手名は結果発表までシークレットです
+          </span>
+        </div>
       )}
 
       {/* Refresh indicator */}

--- a/@robopo/web/lib/competition.ts
+++ b/@robopo/web/lib/competition.ts
@@ -1,10 +1,11 @@
 export type CompetitionStatus = "before" | "active" | "ended" | "unknown"
 
 /**
- * Determine the current status of a competition based on its date range.
- * - "before": today is before the start date
- * - "active": today is within [startDate, endDate]
- * - "ended": today is after the end date
+ * Determine the current status of a competition based on its datetime range.
+ * Compares at minute precision (includes hours and minutes).
+ * - "before": now is before the start datetime
+ * - "active": now is within [startDate, endDate]
+ * - "ended": now is after the end datetime
  * - "unknown": start or end date is not set
  */
 export function getCompetitionStatus(c: {
@@ -14,27 +15,41 @@ export function getCompetitionStatus(c: {
   if (!c.startDate || !c.endDate) {
     return "unknown"
   }
-  const today = new Date()
-  today.setHours(0, 0, 0, 0)
+  const now = new Date()
   const start = new Date(c.startDate)
-  start.setHours(0, 0, 0, 0)
   const end = new Date(c.endDate)
-  end.setHours(0, 0, 0, 0)
-  if (today < start) {
+  if (now < start) {
     return "before"
   }
-  if (today > end) {
+  if (now > end) {
     return "ended"
   }
   return "active"
 }
 
 /**
- * Check if a competition is currently active (today falls within its date range).
+ * Check if a competition is currently active.
  */
 export function isCompetitionActive(c: {
   startDate: Date | null
   endDate: Date | null
 }): boolean {
   return getCompetitionStatus(c) === "active"
+}
+
+export const MASK_MINUTES_MIN = 1
+export const MASK_MINUTES_MAX = 999
+export const MASK_MINUTES_DEFAULT = 30
+
+/**
+ * Normalize maskMinutesBefore value to a valid range.
+ * - Invalid/missing values fall back to the default
+ * - Out-of-range values are clamped to [MIN, MAX]
+ */
+export function normalizeMaskMinutesBefore(value: unknown): number {
+  const num = Number(value)
+  if (!Number.isFinite(num)) {
+    return MASK_MINUTES_DEFAULT
+  }
+  return Math.min(MASK_MINUTES_MAX, Math.max(MASK_MINUTES_MIN, Math.floor(num)))
 }

--- a/@robopo/web/lib/db/queries/queries.ts
+++ b/@robopo/web/lib/db/queries/queries.ts
@@ -668,6 +668,8 @@ export async function getCompetitionWithCourse() {
       description: competition.description,
       startDate: competition.startDate,
       endDate: competition.endDate,
+      maskEnabled: competition.maskEnabled,
+      maskMinutesBefore: competition.maskMinutesBefore,
       createdAt: competition.createdAt,
       courseId: course.id,
       courseName: course.name,
@@ -689,6 +691,8 @@ export function groupByCompetition(
     description: string | null
     startDate: Date | null
     endDate: Date | null
+    maskEnabled: boolean
+    maskMinutesBefore: number
     createdAt: Date | null
     courseId: number | null
     courseName: string | null
@@ -705,6 +709,8 @@ export function groupByCompetition(
         description: row.description,
         startDate: row.startDate,
         endDate: row.endDate,
+        maskEnabled: row.maskEnabled,
+        maskMinutesBefore: row.maskMinutesBefore,
         createdAt: row.createdAt,
         courseIds: [],
         courseNames: [],

--- a/@robopo/web/lib/db/schema.ts
+++ b/@robopo/web/lib/db/schema.ts
@@ -13,6 +13,8 @@ export const competition = pgTable("competition", {
   description: text("description"),
   startDate: timestamp("start_date"),
   endDate: timestamp("end_date"),
+  maskEnabled: boolean("mask_enabled").notNull().default(false),
+  maskMinutesBefore: integer("mask_minutes_before").notNull().default(30),
   createdAt: timestamp("created_at").defaultNow(),
 })
 
@@ -223,6 +225,8 @@ export type SelectCompetitionWithCourse = {
   description: string | null
   startDate: Date | null
   endDate: Date | null
+  maskEnabled: boolean
+  maskMinutesBefore: number
   createdAt: Date | null
   courseIds: number[]
   courseNames: string[]

--- a/@robopo/web/test/unit/components/common/commonList.test.tsx
+++ b/@robopo/web/test/unit/components/common/commonList.test.tsx
@@ -34,6 +34,8 @@ const competitions = [
     description: null,
     startDate: null,
     endDate: null,
+    maskEnabled: false,
+    maskMinutesBefore: 30,
     createdAt: new Date(),
     courseIds: [],
     courseNames: [],
@@ -44,6 +46,8 @@ const competitions = [
     description: null,
     startDate: null,
     endDate: null,
+    maskEnabled: false,
+    maskMinutesBefore: 30,
     createdAt: new Date(),
     courseIds: [],
     courseNames: [],
@@ -237,8 +241,10 @@ describe("Competition table columns", () => {
     expect(headerTexts).toContain("名前")
     expect(headerTexts).toContain("コース")
     expect(headerTexts).toContain("説明")
-    expect(headerTexts).toContain("開催日")
-    expect(headerTexts).toContain("終了日")
+    expect(headerTexts).toContain("開催日時")
+    expect(headerTexts).toContain("終了日時")
+    expect(headerTexts).toContain("マスク")
+    expect(headerTexts).toContain("マスク時間")
   })
 
   test("renders dash for null description, startDate, and endDate", () => {
@@ -253,8 +259,8 @@ describe("Competition table columns", () => {
     )
     const cells = container.querySelectorAll("tbody tr:first-child td")
     const cellTexts = Array.from(cells).map((c) => c.textContent?.trim())
-    // courses, description, startDate, endDate should all be "-"
-    expect(cellTexts.filter((t) => t === "-")).toHaveLength(4)
+    // courses, startDate, endDate, maskMinutesBefore, description should all be "-"
+    expect(cellTexts.filter((t) => t === "-")).toHaveLength(5)
   })
 
   test("renders formatted dates for non-null startDate and endDate", () => {
@@ -266,6 +272,8 @@ describe("Competition table columns", () => {
         description: "テスト説明",
         startDate: new Date("2026-04-01T00:00:00"),
         endDate: new Date("2026-04-30T00:00:00"),
+        maskEnabled: false,
+        maskMinutesBefore: 30,
         createdAt: new Date(),
         courseIds: [1],
         courseNames: ["テストコース"],
@@ -286,9 +294,9 @@ describe("Competition table columns", () => {
     const cellTexts = Array.from(cells).map((c) => c.textContent?.trim())
     // description should render
     expect(cellTexts).toContain("テスト説明")
-    // dates should not be "-"
+    // Only maskMinutesBefore should be "-" (maskEnabled is false)
     const dashCount = cellTexts.filter((t) => t === "-").length
-    expect(dashCount).toBe(0)
+    expect(dashCount).toBe(1)
     // dates should not contain ISO format "T" separator
     for (const text of cellTexts) {
       expect(text).not.toContain("T00:00:00")


### PR DESCRIPTION
## Summary by Sourcery

大会終了間際に観客向けリーダーボード上の選手情報をマスクするための大会ごとの設定を追加し、大会の開始／終了を日付のみではなくフルの日時範囲で扱うように変更します。

New Features:
- 観客向けリーダーボードにおいて、大会終了前の一定時間に選手名やゼッケン番号をマスクできるようにします。
- 大会の作成・編集画面および一覧ビュー上で、マスク状態とタイミングを制御する設定項目を表示します。

Enhancements:
- 大会の開始／終了フィールドおよびステータスロジックを、日付のみではなく分単位の精度を持つフルの日時で動作するよう変更します。
- 観客向けリーダーボードの API と UI を更新し、マスク状態を提供するとともに、マスク有効時には通知を表示するようにします。

Tests:
- 大会一覧のテストを拡張し、新しい日時カラムとマスク設定の表示をカバーします。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add per-competition settings to mask player information near the end of an event and switch competitions to use full datetime ranges instead of date-only values.

New Features:
- Allow configuring masking of player names and bib numbers shortly before competition end on the spectator leaderboard.
- Expose mask status and timing controls in the competition creation and edit UI and list views.

Enhancements:
- Change competition start/end fields and status logic to operate on full datetimes with minute-level precision.
- Update spectator leaderboard API and UI to surface mask status and display a masking notice when active.

Tests:
- Extend competition list tests to cover new datetime columns and mask configuration display.

</details>