### PR TITLE
fix: show message on summary page

### DIFF
--- a/@robopo/web/app/summary/page.tsx
+++ b/@robopo/web/app/summary/page.tsx
@@ -59,7 +59,7 @@ export default async function SummaryPage({
         <h1 className="font-bold text-2xl text-base-content tracking-tight">
           集計結果
         </h1>
-        <p className="mt-0.5 text-base-content/60 text-sm lg:hidden">
+        <p className="mt-0.5 text-base-content/60 text-sm">
           大会を選択して集計結果を確認します
         </p>
       </div>

--- a/@robopo/web/components/summary/summaryView.tsx
+++ b/@robopo/web/components/summary/summaryView.tsx
@@ -61,14 +61,14 @@ export function SummaryView({ competitions, defaultCompetitionId }: Props) {
           </select>
         </div>
 
-        <div className="mt-2 flex items-end gap-3 lg:mt-0">
-          <div className="inline-flex rounded-xl bg-base-200/60 p-1">
+        <div className="mt-2 flex flex-col gap-2 lg:mt-0 lg:flex-row lg:items-end lg:gap-3">
+          <div className="flex rounded-xl bg-base-200/60 p-1 lg:inline-flex">
             {TABS.map(({ key, label, icon: Icon }) => (
               <button
                 key={key}
                 type="button"
                 onClick={() => setActiveTab(key)}
-                className={`flex items-center gap-1.5 rounded-lg px-4 py-2 font-medium text-sm transition-all duration-200 ${
+                className={`flex flex-1 items-center justify-center gap-1.5 whitespace-nowrap rounded-lg px-3 py-2 font-medium text-sm transition-all duration-200 lg:flex-none lg:px-4 ${
                   activeTab === key
                     ? "bg-primary text-primary-content shadow-sm"
                     : "text-base-content/60 hover:bg-base-300/50 hover:text-base-content"
@@ -83,7 +83,7 @@ export function SummaryView({ competitions, defaultCompetitionId }: Props) {
           {competitionId > 0 && (
             <Link
               href={`/summary/print-all/${competitionId}`}
-              className="btn btn-primary btn-sm rounded-xl"
+              className="btn btn-primary btn-sm self-end rounded-xl lg:self-auto"
             >
               <Printer className="size-4" />
               一括印刷


### PR DESCRIPTION
## Summary by Sourcery

要約ページのレイアウトと、さまざまなビューポートにおける案内テキストの視認性を改善しました。

Bug Fixes:
- フレックスの動作と配置を調整することで、小さい画面と大きい画面の両方でサマリータブと印刷ボタンが正しくレイアウトされるようにしました。

Enhancements:
- サマリーページのヘルパーメッセージがモバイルのみではなく、すべての画面サイズで表示されるようにしました。
- 小さい画面ではレスポンシブな全幅ボタン、大きな画面ではインラインレイアウトをよりよくサポートできるよう、タブバーのスタイリングを調整しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the summary page layout and visibility of instructional text across viewports.

Bug Fixes:
- Ensure the summary tabs and print button layout correctly on small and large screens by adjusting flex behavior and alignment.

Enhancements:
- Make the summary page helper message visible on all screen sizes instead of only on mobile.
- Refine the tab bar styling to better support responsive, full-width buttons on small screens and inline layout on larger screens.

</details>