### PR TITLE
chore: auto upgrade tools

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -23,7 +23,7 @@ run = ["bun update", "bun i --linker=isolated", "mise deps"]
 auto = true
 
 [hooks]
-enter = ["mise i -q", "mise deps -q"]
+enter = ["mise upgrade -q", "mise deps -q"]
 
 [settings]
 experimental = true


### PR DESCRIPTION
## Summary by Sourcery

雑務:
- プロジェクトに入った際に自動的にツールをアップグレードするため、`mise i` の代わりに `mise upgrade` を実行するように、mise の enter フックを変更しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Change mise enter hook to run `mise upgrade` instead of `mise i` for automatic tool upgrades when entering the project

</details>