### PR TITLE
chore: remove deps-state.toml

### DIFF
--- a/.mise/deps-state.toml
+++ b/.mise/deps-state.toml
@@ -1,3 +1,0 @@
-[providers.bun]
-"bun.lock" = "a8cfa599558eed9e9b06038d7d7f0a8db7a128c7f05a70dd6da9014a294fb721"
-"package.json" = "15af1a79a83138580af33700c6f5d5de94a4ca36e15cf14592436ec48a9fa081"


### PR DESCRIPTION
## Summary by Sourcery

雑務:
- 廃止された `.mise/deps-state.toml` ファイルを削除してリポジトリをクリーンアップ。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Clean up repository by deleting the obsolete `.mise/deps-state.toml` file.

</details>