### PR TITLE
ci(playwright): parallelize tests by browser via matrix strategy

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -23,8 +23,28 @@ permissions:
 
 jobs:
   test:
+    name: test (${{ matrix.project }})
     timeout-minutes: 30
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - project: chromium
+            browser: chromium
+            artifact: chromium
+          - project: firefox
+            browser: firefox
+            artifact: firefox
+          - project: webkit
+            browser: webkit
+            artifact: webkit
+          - project: "Mobile Chrome"
+            browser: chromium
+            artifact: mobile-chrome
+          - project: "Mobile Safari"
+            browser: webkit
+            artifact: mobile-safari
     defaults:
       run:
         working-directory: "@robopo/web"
@@ -69,15 +89,15 @@ jobs:
         run: bun run build
 
       - name: 🎭 Install Playwright Browsers
-        run: bun playwright install --with-deps
+        run: bun playwright install --with-deps ${{ matrix.browser }}
 
       - name: 🧪 Run Playwright tests
-        run: bunx playwright test
+        run: bunx playwright test --project="${{ matrix.project }}"
 
       - name: 🆙 Upload Test Report
         uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
-          name: playwright-report
+          name: playwright-report-${{ matrix.artifact }}
           path: "@robopo/web/playwright-report/"
           retention-days: 30


### PR DESCRIPTION
Splits the Playwright CI job into a matrix that runs each Playwright
project (chromium, firefox, webkit, Mobile Chrome, Mobile Safari) on its
own runner. Each job installs only the browser it needs and uploads its
own report artifact. Local execution is unchanged — `bunx playwright
test` still runs every project serially as before.

## Summary by Sourcery

単一のテストジョブをブラウザごとのマトリックス戦略に分割し、それに合わせてセットアップ、実行、およびアーティファクト名を調整することで、Playwright の CI テストを並列化します。

CI:
- マトリックス戦略を使用してブラウザ／プロジェクトごとに Playwright の CI テストを並列実行し、`fail-fast` を無効化してすべてのジョブが独立して完了するようにします。
- すべてのブラウザセットをインストールするのではなく、マトリックスごとのエントリで必要な Playwright ブラウザのみをインストールします。
- Playwright のテスト実行を現在のマトリックスプロジェクトにスコープし、プロジェクトごとにテストレポートアーティファクトを固有の名前でアップロードします。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Parallelize Playwright CI tests by splitting the single test job into a browser-specific matrix strategy and adjusting setup, execution, and artifact naming accordingly.

CI:
- Run Playwright CI tests in parallel per browser/project using a matrix strategy, disabling fail-fast so all jobs complete independently.
- Install only the required Playwright browser per matrix entry instead of the full browser set.
- Scope Playwright test execution to the current matrix project and upload per-project test report artifacts with distinct names.

</details>