### PR TITLE
test: use iphone 15

### DIFF
--- a/@robopo/web/components/spectator/live-spectator.tsx
+++ b/@robopo/web/components/spectator/live-spectator.tsx
@@ -98,7 +98,7 @@ export function LiveSpectator({
   const [competitionId, setCompetitionId] = useState<number | null>(
     defaultCompetitionId,
   )
-  const [now, setNow] = useState(() => Date.now())
+  const [now, setNow] = useState<number | null>(null)
   const [recentEvents, setRecentEvents] = useState<
     { id: string; text: string }[]
   >([])
@@ -147,8 +147,10 @@ export function LiveSpectator({
     window.history.replaceState(null, "", url.toString())
   }, [theme, hydrated])
 
-  // Tick clock for remaining time.
+  // Defer reading Date.now() to after hydration: the SSR clock string would
+  // otherwise mismatch the client's first paint when the second ticks over.
   useEffect(() => {
+    setNow(Date.now())
     const id = setInterval(() => setNow(Date.now()), 1000)
     return () => clearInterval(id)
   }, [])
@@ -182,7 +184,7 @@ export function LiveSpectator({
   const compact = useIsCompact()
 
   const remainingMs = useMemo(() => {
-    if (!snapshot?.competition.endDate) {
+    if (!snapshot?.competition.endDate || now === null) {
       return null
     }
     return new Date(snapshot.competition.endDate).getTime() - now

--- a/@robopo/web/playwright.config.ts
+++ b/@robopo/web/playwright.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
     },
     {
       name: "Mobile Safari",
-      use: { ...devices["iPhone 16"] },
+      use: { ...devices["iPhone 15"] },
     },
   ],
   webServer: {


### PR DESCRIPTION
## Summary by Sourcery

ライブ観戦の時間処理とモバイルテストデバイスの設定を調整。

バグ修正:
- ハイドレーション完了後まで `Date.now()` の呼び出しを遅延させ、初期時間が null の場合にガードを入れることで、ライブ観戦のカウントダウンにおけるサーバー／クライアント間の時計の不整合を防止。

テスト:
- Playwright のモバイル Safari 設定を更新し、iPhone 16 ではなく iPhone 15 のデバイスプロファイルで実行するように変更。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust live spectator time handling and mobile test device configuration.

Bug Fixes:
- Prevent server/client clock mismatches in the live spectator countdown by deferring Date.now() until after hydration and guarding on a null initial time.

Tests:
- Update Playwright mobile Safari configuration to run against the iPhone 15 device profile instead of iPhone 16.

</details>