### PR TITLE
fix: use hoisted linker in bun

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -16,8 +16,8 @@ description = "Setup environment variables for @robopo/web"
 run = "bun run setup-env"
 
 [tasks.update]
-description = "Update bun dependencies and reinstall with isolated linker"
-run = ["bun update", "bun i --linker=isolated", "mise deps"]
+description = "Update bun dependencies and reinstall"
+run = ["bun update", "bun i", "mise deps"]
 
 [deps.bun]
 auto = true


### PR DESCRIPTION
## Summary by Sourcery

Build:
- 分離されたリンカーオプションを削除し、Bun の再インストールコマンドを簡素化するために mise タスク設定を更新。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Update mise task configuration to simplify Bun reinstall command by removing the isolated linker option.

</details>