### PR TITLE
ci: prevent error from cancel

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -16,7 +16,13 @@ permissions:
 jobs:
   comment:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.event == 'pull_request'
+    # The workflows above upload the artifacts only when they conclude with
+    # success or failure. Any other conclusion, such as a run cancelled by
+    # cancel-in-progress, leaves nothing to download.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      (github.event.workflow_run.conclusion == 'success' ||
+      github.event.workflow_run.conclusion == 'failure')
     steps:
       - name: 📥 Download artifact
         uses: actions/download-artifact@v8


### PR DESCRIPTION
## Summary by Sourcery

CI:
- トリガーとなったワークフローがキャンセルされた、または正常に完了しなかった場合には実行をスキップするよう、コメント用ワークフローの条件を更新し、アーティファクトのダウンロードエラーを防止しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Update the comment workflow condition to skip runs where the triggering workflow was cancelled or otherwise did not complete successfully, preventing artifact download errors.

</details>